### PR TITLE
feat: enable eslint-plugin-n for Node.js packages only

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"eslint-plugin-import-lite": "catalog:prod",
 		"eslint-plugin-jsdoc": "catalog:prod",
 		"eslint-plugin-jsonc": "catalog:prod",
+		"eslint-plugin-n": "catalog:peer",
 		"eslint-plugin-no-only-tests": "catalog:prod",
 		"eslint-plugin-package-json": "catalog:prod",
 		"eslint-plugin-perfectionist": "catalog:prod",
@@ -123,6 +124,7 @@
 		"@eslint-react/eslint-plugin": "^1.45.0",
 		"eslint": "^9.10.0",
 		"eslint-plugin-jest": "^28.9.0 || ^29.0.0",
+		"eslint-plugin-n": "^17.0.0",
 		"eslint-plugin-react-roblox-hooks": "^5.1.0-rbx.1"
 	},
 	"peerDependenciesMeta": {
@@ -130,6 +132,9 @@
 			"optional": true
 		},
 		"eslint-plugin-jest": {
+			"optional": true
+		},
+		"eslint-plugin-n": {
 			"optional": true
 		},
 		"eslint-plugin-react-roblox-hooks": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ catalogs:
     eslint-plugin-jest:
       specifier: 29.0.1
       version: 29.0.1
+    eslint-plugin-n:
+      specifier: 17.21.3
+      version: 17.21.3
     eslint-plugin-react-roblox-hooks:
       specifier: 5.1.0-rbx.1
       version: 5.1.0-rbx.1
@@ -313,6 +316,9 @@ importers:
       eslint-plugin-jsonc:
         specifier: catalog:prod
         version: 2.20.1(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-n:
+        specifier: catalog:peer
+        version: 17.21.3(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
       eslint-plugin-no-only-tests:
         specifier: catalog:prod
         version: 3.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,7 @@ catalogs:
     "@eslint-react/eslint-plugin": 1.52.3
     eslint: 9.32.0
     eslint-plugin-jest: 29.0.1
+    eslint-plugin-n: 17.21.3
     eslint-plugin-react-roblox-hooks: 5.1.0-rbx.1
   prod:
     "@antfu/install-pkg": 1.1.0

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -6,6 +6,7 @@ export * from "./javascript";
 export * from "./jsdoc";
 export * from "./jsonc";
 export * from "./markdown";
+export * from "./node";
 export * from "./package-json";
 export * from "./perfectionist";
 export * from "./pnpm";

--- a/src/configs/node.ts
+++ b/src/configs/node.ts
@@ -1,0 +1,26 @@
+import type { TypedFlatConfigItem } from "../types";
+import { interopDefault } from "../utils";
+
+export async function node(): Promise<Array<TypedFlatConfigItem>> {
+	const pluginNode = await interopDefault(import("eslint-plugin-n"));
+
+	return [
+		{
+			name: "isentinel/node/rules",
+			plugins: {
+				node: pluginNode,
+			},
+			rules: {
+				"node/handle-callback-err": ["error", "^(err|error)$"],
+				"node/no-deprecated-api": "error",
+				"node/no-exports-assign": "error",
+				"node/no-new-require": "error",
+				"node/no-path-concat": "error",
+				"node/prefer-global/buffer": ["error", "never"],
+				"node/prefer-global/process": ["error", "never"],
+				"node/prefer-node-protocol": "error",
+				"node/process-exit-as-throw": "error",
+			},
+		},
+	];
+}

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -12,6 +12,7 @@ import {
 	jsdoc,
 	jsonc,
 	markdown,
+	node,
 	perfectionist,
 	pnpm,
 	prettier,
@@ -62,6 +63,7 @@ export const defaultPluginRenaming = {
 	"@eslint-react/naming-convention": "react-naming-convention",
 	"@stylistic": "style",
 	"@typescript-eslint": "ts",
+	"n": "node",
 	"yml": "yaml",
 };
 
@@ -191,6 +193,11 @@ export async function isentinel(
 		}),
 		unicorn({ stylistic: stylisticOptions }),
 	);
+
+	// Enable Node.js rules for non-Roblox packages
+	if (options.type === "package" && options.roblox === false) {
+		configs.push(node());
+	}
 
 	if (enableJsx) {
 		configs.push(jsx());


### PR DESCRIPTION
Move eslint-plugin-n to optional peer dependency and conditionally enable for non-Roblox packages (type: "package", roblox: false). This ensures Node.js packages get proper Node.js linting while Roblox projects avoid unnecessary peer dependency warnings.