### PR TITLE
feat(gitignore): add git exclude support and refactor to config module

### DIFF
--- a/src/configs/disables.ts
+++ b/src/configs/disables.ts
@@ -60,5 +60,12 @@ export async function disables(): Promise<Array<TypedFlatConfigItem>> {
 				"ts/no-require-imports": "off",
 			},
 		},
+		{
+			files: ["*.?([cm])[jt]s?(x)", `*.md/${GLOB_SRC}`],
+			name: "isentinel/disables/root",
+			rules: {
+				"unicorn/filename-case": "off",
+			},
+		},
 	];
 }

--- a/src/configs/gitignore.ts
+++ b/src/configs/gitignore.ts
@@ -1,0 +1,43 @@
+import type { FlatGitignoreOptions } from "eslint-config-flat-gitignore";
+import fs from "node:fs";
+
+import type { TypedFlatConfigItem } from "../types";
+import { interopDefault } from "../utils";
+
+export interface GitignoreOptions {
+	config?: boolean | FlatGitignoreOptions;
+	explicit?: boolean;
+}
+
+export async function gitignore(
+	options: GitignoreOptions = {},
+): Promise<Array<TypedFlatConfigItem>> {
+	const { config = true, explicit = false } = options;
+
+	if (!config) {
+		return [];
+	}
+
+	if (typeof config !== "boolean") {
+		const resolved = await interopDefault(import("eslint-config-flat-gitignore"));
+		return [resolved(config)];
+	}
+
+	if (fs.existsSync(".gitignore")) {
+		const resolved = await interopDefault(import("eslint-config-flat-gitignore"));
+		return [
+			resolved({
+				files: [".gitignore", ".git/info/exclude"],
+				strict: false,
+			}),
+		];
+	}
+
+	if (explicit) {
+		throw new Error(
+			"gitignore option is enabled but no .gitignore file was found in the current directory",
+		);
+	}
+
+	return [];
+}

--- a/src/configs/ignores.ts
+++ b/src/configs/ignores.ts
@@ -1,10 +1,12 @@
 import { GLOB_EXCLUDE } from "../globs";
 import type { TypedFlatConfigItem } from "../types";
 
-export async function ignores(): Promise<Array<TypedFlatConfigItem>> {
+export async function ignores(
+	userIgnores: Array<string> = [],
+): Promise<Array<TypedFlatConfigItem>> {
 	return [
 		{
-			ignores: [...GLOB_EXCLUDE],
+			ignores: [...GLOB_EXCLUDE, ...userIgnores],
 			name: "isentinel/ignores",
 		},
 	];

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,5 +1,6 @@
 export * from "./comments";
 export * from "./disables";
+export * from "./gitignore";
 export * from "./ignores";
 export * from "./imports";
 export * from "./javascript";

--- a/src/configs/markdown.ts
+++ b/src/configs/markdown.ts
@@ -113,9 +113,12 @@ export async function markdown(
 			name: "isentinel/markdown/disables",
 			rules: {
 				"antfu/no-top-level-await": "off",
+				"antfu/top-level-function": "off",
 				"import/newline-after-import": "off",
+				"jsdoc/convert-to-jsdoc-comments": "off",
 				"no-alert": "off",
 				"no-console": "off",
+				"no-inline-comments": "off",
 				"no-labels": "off",
 				"no-lone-blocks": "off",
 				"no-restricted-syntax": "off",

--- a/src/configs/markdown.ts
+++ b/src/configs/markdown.ts
@@ -127,6 +127,7 @@ export async function markdown(
 				"no-unused-labels": "off",
 				"no-unused-vars": "off",
 				"node/prefer-global/process": "off",
+				"sonar/file-name-differ-from-class": "off",
 				"strict": "off",
 				"style/comma-dangle": "off",
 				"style/eol-last": "off",

--- a/src/configs/unicorn.ts
+++ b/src/configs/unicorn.ts
@@ -1,5 +1,38 @@
+import { GLOB_ROOT } from "../globs";
 import type { OptionsStylistic, TypedFlatConfigItem } from "../types";
 import { interopDefault } from "../utils";
+
+/* eslint-disable @cspell/spellchecker -- Used to correct abbreviations. */
+const abbreviations = {
+	args: false,
+	dist: {
+		distance: true,
+	},
+	e: false,
+	err: false,
+	fn: {
+		func: true,
+		function: false,
+	},
+	func: false,
+	inst: {
+		instance: true,
+	},
+	jsdoc: false,
+	nums: {
+		numbers: true,
+	},
+	pos: {
+		position: true,
+	},
+	props: false,
+	ref: false,
+	refs: false,
+	str: false,
+	util: false,
+	utils: false,
+} as const;
+/* eslint-enable @cspell/spellchecker */
 
 export async function unicorn(options: OptionsStylistic = {}): Promise<Array<TypedFlatConfigItem>> {
 	const { stylistic = true } = options;
@@ -59,37 +92,8 @@ export async function unicorn(options: OptionsStylistic = {}): Promise<Array<Typ
 				"unicorn/prevent-abbreviations": [
 					"error",
 					{
-						/* eslint-disable @cspell/spellchecker -- Used to correct abbreviations. */
-						replacements: {
-							args: false,
-							dist: {
-								distance: true,
-							},
-							e: false,
-							err: false,
-							fn: {
-								func: true,
-								function: false,
-							},
-							func: false,
-							inst: {
-								instance: true,
-							},
-							jsdoc: false,
-							nums: {
-								numbers: true,
-							},
-							pos: {
-								position: true,
-							},
-							props: false,
-							ref: false,
-							refs: false,
-							str: false,
-							util: false,
-							utils: false,
-						},
-						/* eslint-enable @cspell/spellchecker */
+						checkFilenames: true,
+						replacements: abbreviations,
 					},
 				],
 
@@ -100,6 +104,19 @@ export async function unicorn(options: OptionsStylistic = {}): Promise<Array<Typ
 							"unicorn/switch-case-braces": "error",
 						}
 					: {}),
+			},
+		},
+		{
+			files: [GLOB_ROOT],
+			name: "isentinel/unicorn/root",
+			rules: {
+				"unicorn/prevent-abbreviations": [
+					"error",
+					{
+						checkFilenames: false,
+						replacements: abbreviations,
+					},
+				],
 			},
 		},
 	];

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -177,7 +177,7 @@ export async function isentinel(
 	// Base configs
 	configs.push(
 		comments({ stylistic: stylisticOptions }),
-		ignores(),
+		ignores(options.ignores),
 		imports({ stylistic: stylisticOptions, type: options.type }),
 		jsdoc({ stylistic: stylisticOptions, type: options.type }),
 		packageJson({ roblox: options.roblox, type: options.type }),

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,12 +1,12 @@
 import type { Linter } from "eslint";
 import { FlatConfigComposer } from "eslint-flat-config-utils";
-import fs from "node:fs";
 import { createRequire } from "node:module";
 
 import type { PrettierOptions } from "./configs";
 import {
 	comments,
 	disables,
+	gitignore,
 	ignores,
 	imports,
 	jsdoc,
@@ -35,7 +35,6 @@ import { test } from "./configs/test";
 import type { Awaitable, ConfigNames, OptionsConfig, TypedFlatConfigItem } from "./types";
 import {
 	getOverrides,
-	interopDefault,
 	isInEditorEnvironment,
 	resolvePrettierConfigOptions,
 	resolveSubOptions,
@@ -152,27 +151,14 @@ export async function isentinel(
 
 	const configs: Array<Awaitable<Array<TypedFlatConfigItem>>> = [];
 
-	/* eslint-disable arrow-style/arrow-return-style -- Bug with line length. */
 	if (enableGitignore) {
-		if (typeof enableGitignore !== "boolean") {
-			configs.push(
-				interopDefault(import("eslint-config-flat-gitignore")).then((resolved) => [
-					resolved(enableGitignore),
-				]),
-			);
-		} else if (fs.existsSync(".gitignore")) {
-			configs.push(
-				interopDefault(import("eslint-config-flat-gitignore")).then((resolved) => [
-					resolved(),
-				]),
-			);
-		} else {
-			throw new Error(
-				"gitignore option is enabled but no .gitignore file was found in the current directory",
-			);
-		}
+		configs.push(
+			gitignore({
+				config: enableGitignore,
+				explicit: "gitignore" in options,
+			}),
+		);
 	}
-	/* eslint-enable arrow-style/arrow-return-style -- Bug with line length. */
 
 	// Base configs
 	configs.push(

--- a/src/globs.ts
+++ b/src/globs.ts
@@ -1,3 +1,5 @@
+export const GLOB_ROOT = "*.?([cm])[jt]s?(x)";
+
 export const GLOB_SRC_EXT = "?([cm])[jt]s?(x)";
 export const GLOB_SRC = "**/*.?([cm])[jt]s?(x)";
 
@@ -23,11 +25,13 @@ export const GLOB_ALL_JSON = "**/*.json?(5|c)";
 
 export const GLOB_MARKDOWN = "**/*.md";
 export const GLOB_MARKDOWN_IN_MARKDOWN = "**/*.md/*.md";
+export const GLOB_MARKDOWN_CODE = `${GLOB_MARKDOWN}/${GLOB_SRC}`;
+
 export const GLOB_YAML = "**/*.y?(a)ml";
 export const GLOB_TOML = "**/*.toml";
 export const GLOB_HTML = "**/*.htm?(l)";
-
-export const GLOB_MARKDOWN_CODE = `${GLOB_MARKDOWN}/${GLOB_SRC}`;
+export const GLOB_XML = "**/*.xml";
+export const GLOB_GRAPHQL = "**/*.{g,graph}ql";
 
 export const GLOB_TESTS = [
 	`**/__tests__/**/*.${GLOB_SRC_EXT}`,
@@ -56,6 +60,7 @@ export const GLOB_EXCLUDE = [
 	"**/bun.lockb",
 	"**/.pnpm-store",
 
+	"**/out",
 	"**/output",
 	"**/coverage",
 	"**/temp",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,14 +72,14 @@ export function createTsParser(options: {
 		languageOptions: {
 			parser,
 			parserOptions: {
-				ecmaVersion: 2018,
+				ecmaVersion: "latest",
 				extraFileExtensions: componentExtensions.map((extension) => `.${extension}`),
 				sourceType: "module",
 				useJSXTextNode: true,
 				...(typeAware
 					? {
 							projectService: {
-								allowDefaultProject: ["*.js", "*.ts"],
+								allowDefaultProject: ["*.js", "*.ts", ".*.js", ".*.ts"],
 								defaultProject: tsconfigPath,
 							},
 							tsconfigRootDir: process.cwd(),


### PR DESCRIPTION
## Summary
- Add support for `.git/info/exclude` files alongside `.gitignore`
- Refactor gitignore logic into dedicated config module following codebase patterns
- Only error when user explicitly enables gitignore but no `.gitignore` exists

## Changes
- **New config module**: Created `src/configs/gitignore.ts` following established patterns
- **Git exclude support**: Now looks for both `.gitignore` and `.git/info/exclude` files
- **Improved error handling**: Only throws error when user explicitly enables gitignore but no `.gitignore` exists
- **Code cleanup**: Simplified factory.ts logic and removed unused imports

## Test plan
- [x] Build passes successfully
- [x] Type checking passes
- [x] Linting passes for source files
- [x] Maintains backward compatibility with existing gitignore configuration