### PR TITLE
fix(deps): update eslint-plugin-arrow-return-style-x to version 1.2.6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ catalogs:
       specifier: 3.1.1
       version: 3.1.1
     eslint-plugin-arrow-return-style-x:
-      specifier: 1.2.5
-      version: 1.2.5
+      specifier: 1.2.6
+      version: 1.2.6
     eslint-plugin-better-max-params:
       specifier: 0.0.1
       version: 0.0.1
@@ -306,7 +306,7 @@ importers:
         version: 3.1.1(eslint@9.33.0(jiti@2.5.1))
       eslint-plugin-arrow-return-style-x:
         specifier: catalog:prod
-        version: 1.2.5(eslint@9.33.0(jiti@2.5.1))(prettier@3.6.2)(typescript@5.8.3)
+        version: 1.2.6(eslint@9.33.0(jiti@2.5.1))(prettier@3.6.2)(typescript@5.8.3)
       eslint-plugin-better-max-params:
         specifier: catalog:prod
         version: 0.0.1(eslint@9.33.0(jiti@2.5.1))
@@ -2418,8 +2418,8 @@ packages:
     peerDependencies:
       eslint: '*'
 
-  eslint-plugin-arrow-return-style-x@1.2.5:
-    resolution: {integrity: sha512-q2Ge+2JcWWA/dEpvUvwXjA6LsG8uT29Ksz/iDY1QUwrAF2lj9SrQXyZvju4BZIJCXErlWd2AkuUL6SyGRImTvw==}
+  eslint-plugin-arrow-return-style-x@1.2.6:
+    resolution: {integrity: sha512-51AC65OTVkLHO824l4+5qCVHdbDbs5hQMAuCZTIZVeEOdqHA6N8a9srNkZlcWCcHflNFWSm8ljhMYbsFOQ9I3A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       eslint: '>=9.15.0'
@@ -5363,8 +5363,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.39.0(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.8.3)
-      '@typescript-eslint/types': 8.39.0
+      '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.43.0
       debug: 4.4.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -6420,7 +6420,7 @@ snapshots:
     dependencies:
       eslint: 9.33.0(jiti@2.5.1)
 
-  eslint-plugin-arrow-return-style-x@1.2.5(eslint@9.33.0(jiti@2.5.1))(prettier@3.6.2)(typescript@5.8.3):
+  eslint-plugin-arrow-return-style-x@1.2.6(eslint@9.33.0(jiti@2.5.1))(prettier@3.6.2)(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/utils': 8.39.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.8.3)
       detect-indent: 7.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,7 +52,7 @@ catalogs:
     eslint-import-resolver-node: 0.3.9
     eslint-merge-processors: 2.0.0
     eslint-plugin-antfu: 3.1.1
-    eslint-plugin-arrow-return-style-x: 1.2.5
+    eslint-plugin-arrow-return-style-x: 1.2.6
     eslint-plugin-better-max-params: 0.0.1
     eslint-plugin-comment-length: 2.2.2
     eslint-plugin-de-morgan: 1.3.1

--- a/src/typegen.d.ts
+++ b/src/typegen.d.ts
@@ -109,12 +109,12 @@ export interface RuleOptions {
   'arrow-spacing'?: Linter.RuleEntry<ArrowSpacing>
   /**
    * Enforce consistent arrow function return style based on length, multiline expressions, JSX usage, and export context
-   * @see https://github.com/christopher-buss/eslint-plugin-arrow-return-style-x/blob/v1.2.5/src/rules/arrow-return-style/documentation.md
+   * @see https://github.com/christopher-buss/eslint-plugin-arrow-return-style-x/blob/v1.2.6/src/rules/arrow-return-style/documentation.md
    */
   'arrow-style/arrow-return-style'?: Linter.RuleEntry<ArrowStyleArrowReturnStyle>
   /**
    * Disallow anonymous arrow functions as export default declarations
-   * @see https://github.com/christopher-buss/eslint-plugin-arrow-return-style-x/blob/v1.2.5/src/rules/no-export-default-arrow/documentation.md
+   * @see https://github.com/christopher-buss/eslint-plugin-arrow-return-style-x/blob/v1.2.6/src/rules/no-export-default-arrow/documentation.md
    */
   'arrow-style/no-export-default-arrow'?: Linter.RuleEntry<[]>
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Improved linting configuration to apply file-type-specific rules with smarter line-length handling and tighter formatter integration for more consistent code style across TS, JS, and Markdown.

- Chores
  - Bumped a linting plugin to the latest patch version for stability and compatibility.

- Documentation
  - Updated documentation references to the latest plugin version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->