### PR TITLE
fix: re-export FlatConfigComposer for monorepo support

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,5 +1,5 @@
 import type { Linter } from "eslint";
-import { FlatConfigComposer } from "eslint-flat-config-utils";
+import { FlatConfigComposer as FlatConfigComposerClass } from "eslint-flat-config-utils";
 
 import type { PrettierOptions } from "./configs";
 import {
@@ -36,7 +36,13 @@ import { jsx } from "./configs/jsx";
 import { packageJson } from "./configs/package-json";
 import { spelling } from "./configs/spelling";
 import { test } from "./configs/test";
-import type { Awaitable, ConfigNames, OptionsConfig, TypedFlatConfigItem } from "./types";
+import type {
+	Awaitable,
+	ConfigNames,
+	FlatConfigComposer,
+	OptionsConfig,
+	TypedFlatConfigItem,
+} from "./types";
 import {
 	getOverrides,
 	isInEditorEnvironment,
@@ -376,7 +382,7 @@ export async function isentinel(
 		configs.push([fusedConfig]);
 	}
 
-	let composer = new FlatConfigComposer<TypedFlatConfigItem, ConfigNames>();
+	let composer = new FlatConfigComposerClass<TypedFlatConfigItem, ConfigNames>();
 
 	composer = composer.append(...configs, ...(userConfigs as Array<TypedFlatConfigItem>));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -461,3 +461,4 @@ export type TypedFlatConfigItem = Omit<Linter.Config<Linter.RulesRecord & Rules>
 };
 
 export { type ConfigNames } from "./typegen";
+export { type FlatConfigComposer } from "eslint-flat-config-utils";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal type imports and exports to improve API structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->