### PR TITLE
fix(test): use vitestOptions for jest-extended toggle in vitest branch

### DIFF
--- a/src/configs/test.ts
+++ b/src/configs/test.ts
@@ -184,7 +184,7 @@ export async function test(
 		await ensurePackages(["@vitest/eslint-plugin"]);
 		const vitestPlugin = await interopDefault(import("@vitest/eslint-plugin"));
 
-		const useJestExtended = jestOptions.extended === true;
+		const useJestExtended = vitestOptions.extended === true;
 
 		const jestExtendedPlugin = await (async () => {
 			if (!useJestExtended) {


### PR DESCRIPTION
## Summary

- The Vitest branch of `src/configs/test.ts` was reading `jestOptions.extended` to decide whether to enable the `eslint-plugin-jest-extended` ruleset. That meant a user enabling Vitest with `{ extended: true }` was ignored unless they also passed jest options.
- Switch the read to `vitestOptions.extended` so the flag matches the framework the block is configuring. `OptionsVitest` already declares this field (types.ts:181).

## Test plan

- [x] `tsc --noEmit` (via pre-commit hook)
- [x] ESLint (via pre-commit hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Vitest configuration to use the correct settings source for test rule plugins, ensuring consistent behavior across test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->