### PR TITLE
fix: exclude git hooks/lint-staged from agent session detection

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -252,6 +252,10 @@ export function isInGitHooksOrLintStaged(): boolean {
 }
 
 export function isInAgentSession(): boolean {
+	if (isInGitHooksOrLintStaged()) {
+		return false;
+	}
+
 	return [
 		process.env["CLAUDECODE"],
 		process.env["CLAUDE_CODE_ENTRYPOINT"],


### PR DESCRIPTION
## Description

When an AI agent (Claude Code, Cursor, Codex, etc.) commits work, the agent's marker env vars (`CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CURSOR_AGENT`, `CODEX_THREAD_ID`, `GEMINI_CLI`, `OPENCODE`) propagate into the subprocesses git spawns for the `pre-commit` hook → `lint-staged` → `eslint --fix`.

`isInAgentSession()` only checked those env vars, so it returned `true` during the commit. That caused `factory.ts` to push `ts/consistent-type-imports` into `disableAutofixRules` — so `eslint --fix` in lint-staged silently **never applied that autofix** when an agent committed.

The fix adds the existing `isInGitHooksOrLintStaged()` guard to `isInAgentSession()`, mirroring how the sibling `isInEditorEnvironment()` already excludes hook contexts. A pre-commit hook is a non-interactive validate/fix context, not an interactive agent session, so agent-session relaxations should not apply there. Both factory consumers read through the helper, so no `factory.ts` changes were needed.

Side effect: `defaultSeverity` is also no longer force-set to `"error"` during a commit hook — correct, since the hook should behave like a normal non-interactive lint.

## Linked Issues

fixes #525

## Additional context

- `pnpm typecheck` → exit 0
- `pnpm lint` → exit 0
- No new tests (repo has no test suite).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where agent session detection could incorrectly trigger during git hooks and lint-staged operations, ensuring these tools function properly in all contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->