### PR TITLE
feat: dedicated oxlint typegen for rule hovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ _fixtures
 .history
 
 src/typegen.d.ts
+src/oxlint/typegen.d.ts
 .eslint-config-inspector
 
 # cspell

--- a/hk.pkl
+++ b/hk.pkl
@@ -8,7 +8,7 @@ local sharedGuards = new Mapping<String, Step> {
     ["detect-private-key"] = (Builtins.detect_private_key) { shell = bash }
     ["check-added-large-files"] = (Builtins.check_added_large_files) {
         shell = bash
-        exclude = List("pnpm-lock.yaml", "src/typegen.d.ts")
+        exclude = List("pnpm-lock.yaml", "src/typegen.d.ts", "src/oxlint/typegen.d.ts")
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"build": "nr gen && tsdown --clean --dts && node scripts/check-dist.ts",
 		"build:inspector": "pnpm build && pnpm dlx @eslint/config-inspector build --config eslint-inspector.config.ts --out-dir ./.eslint-config-inspector",
 		"dev": "npx @eslint/config-inspector --config eslint-inspector.config.ts",
-		"gen": "node scripts/typegen.ts && node scripts/versiongen.ts",
+		"gen": "node scripts/typegen.ts && node scripts/typegen-oxlint.ts && node scripts/versiongen.ts",
 		"postgen": "echo 'Generation complete!'",
 		"lint": "oxlint && eslint --cache",
 		"lint:ci": "oxlint && eslint --cache --cache-strategy content",

--- a/scripts/typegen-oxlint.ts
+++ b/scripts/typegen-oxlint.ts
@@ -1,0 +1,247 @@
+/**
+ * Generates `src/oxlint/typegen.d.ts`: typed rule maps for oxlint config
+ * items, keyed by canonical oxlint rule names.
+ *
+ * - Native (Rust) rules come from oxlint's `configuration_schema.json` (option
+ *   types via the `DummyRuleMap` interface oxlint ships) and `oxlint --rules
+ *   --format=json` (oxc.rs doc links, type-aware flags).
+ * - JsPlugin rules whose oxlint prefix differs from the ESLint-side prefix
+ *   (for example `unicorn-js/*`) are re-exported from the ESLint-side
+ *   `RuleOptions` with doc links taken from each plugin's rule metadata.
+ * - JsPlugin rules that keep their ESLint-side prefix (for example
+ *   `perfectionist/*`) reuse `RuleOptions` through a filtering mapped type,
+ *   which preserves the original plugin doc hovers.
+ *
+ * Must run after `scripts/typegen.ts`, which produces the `src/typegen.d.ts`
+ * this script reads.
+ */
+import { pluginsToRulesDTS } from "eslint-typegen/core";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+
+import { oxlintJsPluginPrefixRenames, oxlintJsPlugins } from "../src/rules/oxlint-mapping.ts";
+
+interface OxlintRuleInfo {
+	default: boolean;
+	docs_url: string;
+	scope: string;
+	type_aware: boolean;
+	value: string;
+}
+
+interface RuleMeta {
+	deprecated?: unknown;
+	docs?: { description?: string; url?: string };
+}
+
+const require = createRequire(import.meta.url);
+const oxlintRoot = path.join(path.dirname(require.resolve("oxlint")), "..");
+
+// ----- Native rules -----
+
+const schema = JSON.parse(
+	await fs.readFile(path.join(oxlintRoot, "configuration_schema.json"), "utf8"),
+) as { definitions: { DummyRuleMap: { properties: Record<string, unknown> } } };
+
+const nativeKeys = Object.keys(schema.definitions.DummyRuleMap.properties).sort();
+
+const rulesResult = spawnSync(
+	process.execPath,
+	[path.join(oxlintRoot, "bin/oxlint"), "--rules", "--format=json"],
+	{ encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+);
+if (rulesResult.status !== 0) {
+	throw new Error(`oxlint --rules failed: ${rulesResult.stderr}`);
+}
+
+const ruleInfos = JSON.parse(rulesResult.stdout) as Array<OxlintRuleInfo>;
+const ruleInfoByKey = new Map<string, OxlintRuleInfo>();
+for (const info of ruleInfos) {
+	// `--rules` scopes use underscores (jsx_a11y), config keys use dashes.
+	const prefix = info.scope.replaceAll("_", "-");
+	const key = prefix === "eslint" ? info.value : `${prefix}/${info.value}`;
+	ruleInfoByKey.set(key, info);
+}
+
+const missingInfo = nativeKeys.filter((key) => !ruleInfoByKey.has(key));
+if (missingInfo.length > 0) {
+	throw new Error(
+		`configuration_schema.json rules missing from \`oxlint --rules\`: ${missingInfo.join(", ")}`,
+	);
+}
+
+const nativeEntries = nativeKeys.map((key) => {
+	const info = ruleInfoByKey.get(key);
+	const lines = ["  /**"];
+	if (info?.type_aware === true) {
+		lines.push("   * Requires type information (`oxlint --type-aware`).", "   *");
+	}
+
+	lines.push(`   * @see ${info?.docs_url}`, "   */", `  '${key}'?: DummyRuleMap['${key}']`);
+	return lines.join("\n");
+});
+
+// ----- JsPlugin rules -----
+
+// Keys of the ESLint-side generated RuleOptions, used to type renamed
+// jsPlugin rules by reference instead of re-compiling their schemas.
+const eslintTypegen = await fs.readFile("src/typegen.d.ts", "utf8");
+const eslintRuleKeys = new Set(
+	[...eslintTypegen.matchAll(/^ {2}'([^']+)'\?:/gm)].flatMap((match) => {
+		return match[1] === undefined ? [] : [match[1]];
+	}),
+);
+const eslintRulePrefixes = new Set(
+	Array.from(eslintRuleKeys, (key) => key.slice(0, Math.max(0, key.lastIndexOf("/")))),
+);
+
+async function loadPluginRules(specifier: string): Promise<Record<string, { meta?: RuleMeta }>> {
+	const imported = (await import(specifier)) as Record<string, unknown>;
+	const unwrapped = (imported["default"] ?? imported) as { default?: unknown; rules?: unknown };
+	const plugin = (unwrapped.rules === undefined ? unwrapped.default : unwrapped) as {
+		rules?: Record<string, { meta?: RuleMeta }>;
+	};
+	if (plugin.rules === undefined) {
+		throw new Error(`Cannot resolve rules of jsPlugin package: ${specifier}`);
+	}
+
+	return plugin.rules;
+}
+
+function toJsdoc(meta: RuleMeta | undefined): Array<string> {
+	const lines = ["  /**"];
+	const description = meta?.docs?.description?.replaceAll(/\s+/g, " ").replaceAll("*/", "*\\/");
+	if (description !== undefined && description !== "") {
+		lines.push(`   * ${description}`);
+	}
+
+	if (meta?.docs?.url !== undefined) {
+		lines.push(`   * @see ${meta.docs.url}`);
+	}
+
+	if (meta?.deprecated !== undefined && meta.deprecated !== false) {
+		lines.push("   * @deprecated");
+	}
+
+	lines.push("   */");
+	return lines;
+}
+
+const renamedEntries: Array<string> = [];
+let renamedFallbacks = 0;
+const renamedPrefixPairs = Object.entries(oxlintJsPluginPrefixRenames);
+renamedPrefixPairs.sort(([, a], [, b]) => a.localeCompare(b));
+
+for (const [eslintPrefix, oxlintPrefix] of renamedPrefixPairs) {
+	const specifier = oxlintJsPlugins[oxlintPrefix];
+	if (specifier === undefined) {
+		throw new Error(`No jsPlugin specifier for renamed prefix: ${oxlintPrefix}`);
+	}
+
+	const rules = await loadPluginRules(specifier);
+	for (const ruleName of Object.keys(rules).sort()) {
+		const eslintKey = eslintPrefix === "" ? ruleName : `${eslintPrefix}/${ruleName}`;
+		let typeReference = `RuleOptions['${eslintKey}']`;
+		if (!eslintRuleKeys.has(eslintKey)) {
+			typeReference = "DummyRule";
+			renamedFallbacks += 1;
+		}
+
+		renamedEntries.push(
+			[
+				...toJsdoc(rules[ruleName]?.meta),
+				`  '${oxlintPrefix}/${ruleName}'?: ${typeReference}`,
+			].join("\n"),
+		);
+	}
+}
+
+// JsPlugin prefixes that keep their ESLint-side names. Prefixes present in the
+// ESLint-side RuleOptions are picked up by a mapped type (which preserves the
+// plugin doc hovers); the rest get their types generated from the plugin.
+const renamedOxlintPrefixes = new Set(Object.values(oxlintJsPluginPrefixRenames));
+const keptPrefixes = Object.keys(oxlintJsPlugins)
+	.filter((prefix) => !renamedOxlintPrefixes.has(prefix))
+	.sort();
+const keptMappedPrefixes = keptPrefixes.filter((prefix) => eslintRulePrefixes.has(prefix));
+const keptGeneratedPrefixes = keptPrefixes.filter((prefix) => !eslintRulePrefixes.has(prefix));
+
+const extraPlugins: Record<string, { rules?: unknown }> = {};
+for (const prefix of keptGeneratedPrefixes) {
+	const specifier = oxlintJsPlugins[prefix];
+	if (specifier === undefined) {
+		continue;
+	}
+
+	extraPlugins[prefix] = { rules: await loadPluginRules(specifier) };
+}
+
+let extraDts = await pluginsToRulesDTS(extraPlugins as never, {
+	exportTypeName: "OxlintExtraJsPluginRuleOptions",
+	includeAugmentation: false,
+	includeIgnoreComments: false,
+	includeTypeImports: false,
+});
+extraDts = extraDts.trim();
+
+// ----- Compose -----
+
+const dts = `/* eslint-disable */
+/* prettier-ignore */
+// Generated by scripts/typegen-oxlint.ts — do not edit.
+import type { Linter } from 'eslint'
+import type { DummyRule, DummyRuleMap } from 'oxlint'
+
+import type { RuleOptions } from '../typegen'
+
+/**
+ * Rules implemented natively by oxlint (in Rust), including the tsgolint
+ * type-aware rules.
+ */
+export interface OxlintNativeRuleOptions {
+${nativeEntries.join("\n")}
+}
+
+/**
+ * JsPlugin rules whose oxlint-side prefix differs from the ESLint-side prefix
+ * (native oxlint plugin prefixes are reserved, so those jsPlugins use \`-js\`
+ * aliases).
+ */
+export interface OxlintRenamedJsPluginRuleOptions {
+${renamedEntries.join("\n")}
+}
+
+${extraDts}
+
+/** JsPlugin prefixes whose rules keep their ESLint-side names in oxlint configs. */
+type OxlintKeptJsPluginPrefix = ${keptMappedPrefixes.map((prefix) => `'${prefix}'`).join(" | ")}
+
+/** JsPlugin rules whose oxlint names match the ESLint-side names. */
+type OxlintKeptJsPluginRuleOptions = {
+  [K in keyof RuleOptions as K extends \`\${OxlintKeptJsPluginPrefix}/\${string}\` ? K : never]: RuleOptions[K]
+}
+
+/** All rules known to the oxlint factory, keyed by canonical oxlint rule name. */
+export type OxlintRuleOptions = OxlintKeptJsPluginRuleOptions &
+  OxlintExtraJsPluginRuleOptions &
+  OxlintRenamedJsPluginRuleOptions &
+  OxlintNativeRuleOptions
+
+/**
+ * Rule map for oxlint config items: known rules are fully typed, unknown
+ * rules fall back to \`DummyRule\`.
+ */
+export type OxlintRules = Record<string, DummyRule | undefined> & OxlintRuleOptions
+`;
+
+await fs.writeFile("src/oxlint/typegen.d.ts", dts);
+
+console.log(
+	`typegen-oxlint: ${nativeKeys.length} native rules, ${renamedEntries.length} renamed jsPlugin rules ` +
+		`(${renamedFallbacks} without RuleOptions types), ` +
+		`${keptMappedPrefixes.length} kept prefixes mapped, ` +
+		`${keptGeneratedPrefixes.length} kept prefixes generated (${keptGeneratedPrefixes.join(", ")})`,
+);

--- a/src/oxlint/configs/oxfmt.ts
+++ b/src/oxlint/configs/oxfmt.ts
@@ -78,11 +78,13 @@ export function oxlintOxfmt(
 			{
 				name,
 				files,
+				// The split rules are keyed by translated oxlint names, which
+				// the eslint-side `Rules` typing cannot express.
 				rules: {
 					...nativeRules,
 					"arrow-body-style": "off",
 					"prefer-arrow-callback": "off",
-				},
+				} as TypedOxlintConfigItem["rules"],
 			},
 			{
 				name: `${name}/js-plugin`,
@@ -91,7 +93,7 @@ export function oxlintOxfmt(
 				rules: {
 					...jsPluginRules,
 					"oxfmt/oxfmt": ["error", oxfmtOptions],
-				},
+				} as TypedOxlintConfigItem["rules"],
 			},
 		];
 	}

--- a/src/oxlint/factory.ts
+++ b/src/oxlint/factory.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "oxlint";
 
 import { GLOB_EXCLUDE, GLOB_ROOT, GLOB_SRC } from "../globs.ts";
 import { buildOxfmtOptions } from "../rules/oxfmt.ts";
+import type { Rules } from "../types.ts";
 import {
 	getOverrides,
 	isInAgentSession,
@@ -294,7 +295,7 @@ export function isentinel(
 		}
 
 		const { name: _name, plugins: _plugins, settings: _settings, ...override } = config;
-		overrides.push(override as OxlintOverride);
+		overrides.push(override);
 	}
 
 	const fragments = configs.flat();
@@ -307,7 +308,9 @@ export function isentinel(
 			name: "isentinel/options-rules",
 			files: [GLOB_SRC],
 			keepUnmappedOff: true,
-			rules,
+			// The split accepts eslint-named rules and translates them; the
+			// oxlint-facing `OxlintRules` typing cannot express that input.
+			rules: rules as Rules,
 		});
 		for (const fragment of optionsFragments) {
 			mergeFragment(fragment);

--- a/src/oxlint/types.ts
+++ b/src/oxlint/types.ts
@@ -6,17 +6,13 @@
  * type modules would make `dist/index.d.mts` depend on `oxlint`, breaking
  * ESLint-only consumers who do not install it.
  */
-import type { Linter } from "eslint";
 import type { DummyRuleMap, OxlintConfig, OxlintOverride } from "oxlint";
 
 import type { OptionsConfig } from "../eslint/types.ts";
-import type { Rules } from "../types.ts";
+import type { OxlintRules } from "./typegen";
 
 /** Rule names implemented natively by oxlint. */
 export type OxlintNativeRuleName = keyof DummyRuleMap;
-
-/** A rule map restricted to native oxlint rules. */
-export type OxlintRules = Partial<Record<OxlintNativeRuleName, Linter.RuleEntry>>;
 
 /** Top-level oxlint `settings`. */
 export type OxlintSettings = NonNullable<OxlintConfig["settings"]>;
@@ -40,7 +36,7 @@ export type TypedOxlintConfigItem = Omit<OxlintOverride, "rules"> & {
 	 * An object containing the configured rules, using canonical oxlint rule
 	 * names (native names or jsPlugin-prefixed names).
 	 */
-	rules?: Rules;
+	rules?: OxlintRules;
 
 	/**
 	 * Plugin-specific settings. The factory strips these from fragments and
@@ -89,4 +85,10 @@ export type OxlintFactoryOptions = Omit<TypedOxlintConfigItem, "files"> &
 		options?: OxlintLinterOptions;
 	};
 
+export type {
+	OxlintNativeRuleOptions,
+	OxlintRenamedJsPluginRuleOptions,
+	OxlintRuleOptions,
+	OxlintRules,
+} from "./typegen";
 export type { DummyRuleMap, ExternalPluginEntry, OxlintConfig, OxlintOverride } from "oxlint";

--- a/src/oxlint/utils.ts
+++ b/src/oxlint/utils.ts
@@ -168,7 +168,9 @@ export function createOxlintConfigs({
 			files,
 			...(globals ? { globals } : {}),
 			plugins: nativePlugins,
-			rules: nativeRules,
+			// The split rules are keyed by translated oxlint names, which the
+			// eslint-side `Rules` typing cannot express.
+			rules: nativeRules as TypedOxlintConfigItem["rules"],
 			...(settings ? { settings } : {}),
 		});
 	}
@@ -180,7 +182,7 @@ export function createOxlintConfigs({
 			files,
 			...(globals && fragments.length === 0 ? { globals } : {}),
 			jsPlugins,
-			rules: jsPluginRules,
+			rules: jsPluginRules as TypedOxlintConfigItem["rules"],
 			...(settings && fragments.length === 0 ? { settings } : {}),
 		});
 	}

--- a/src/rules/oxlint-mapping.ts
+++ b/src/rules/oxlint-mapping.ts
@@ -898,7 +898,7 @@ const UNICORN_NATIVE_RENAMES: Readonly<Record<string, string>> = {
  * Prefix translation for rules that run via jsPlugins. Native oxlint plugin
  * prefixes are reserved, so those jsPlugins use `-js` aliases.
  */
-const JS_PLUGIN_PREFIX_RENAMES: Readonly<Record<string, string>> = {
+export const oxlintJsPluginPrefixRenames: Readonly<Record<string, string>> = {
 	"": "eslint-js",
 	"import": "import-js",
 	"jsdoc": "jsdoc-js",
@@ -999,7 +999,7 @@ export function translateRuleToOxlint(rule: string): string {
 
 	// js-plugin (or unmapped rules used by the standalone factory, which keep
 	// their prefix)
-	const renamed = JS_PLUGIN_PREFIX_RENAMES[prefix];
+	const renamed = oxlintJsPluginPrefixRenames[prefix];
 	return renamed === undefined ? rule : `${renamed}/${name}`;
 }
 


### PR DESCRIPTION
> [!NOTE]
> Follow-up to #553. Will be rebased (and can be re-based onto `main`) once #553 merges. Based on `feat/oxlint-support` so the diff shows only this change.

Gives the oxlint side its own typegen so rule hovers in `oxlint.config.ts` show oxlint-appropriate docs instead of the ESLint-side ones (e.g. `max-lines` now links to https://oxc.rs/docs/guide/usage/linter/rules/eslint/max-lines.html rather than eslint.org, and options are checked against what oxlint actually accepts).

## Design

New `scripts/typegen-oxlint.ts` generates `src/oxlint/typegen.d.ts` (gitignored, like `src/typegen.d.ts`), consumed by `TypedOxlintConfigItem.rules`:

- **Native rules (841)**: typed by reference from oxlint's own `DummyRuleMap`, with generated `@see` oxc.rs doc links from `oxlint --rules --format=json`, plus "requires type information" notes for the 59 tsgolint type-aware rules.
- **Renamed jsPlugin prefixes** (`unicorn-js/`, `eslint-js/`, `react-x/`, ...): 903 entries typed by reference from the ESLint-side `RuleOptions`, doc links from each plugin's rule meta (key-remapped mapped types drop JSDoc, so these are generated explicitly).
- **Kept jsPlugin prefixes** (`perfectionist/`, `sonar/`, `ts/`, ...): a filter mapped type over `RuleOptions`, which preserves the original plugin doc hovers with zero duplication. `jest-extended`/`oxlint-comments` (absent from `RuleOptions`) are generated via eslint-typegen's `pluginsToRulesDTS`.

Unknown rules fall back to oxlint's `DummyRule`, so the map stays open like the ESLint side.

## Wiring

- `pnpm gen` now runs `typegen.ts && typegen-oxlint.ts && versiongen.ts` (order matters: the oxlint typegen reads `src/typegen.d.ts`).
- Loud drift detection: generation hard-fails if `configuration_schema.json` rule keys and `oxlint --rules` output diverge, so oxlint bumps can't silently rot the types.
- Generated file is ~346 KB; `dist/oxlint.d.mts` grows to 1.25 MB (`dist/index.d.mts` unchanged).

## Limitations

- Native rule hovers have the doc link + option types but no prose description (oxlint ships none machine-readable).
- Kept-prefix typing is a superset: it offers rules that cannot actually run under the jsPlugin runtime (e.g. type-aware `ts/` rules).

https://claude.ai/code/session_01RRos9XCSrCw73GRsLZvKdw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated generation of typed Oxlint rule definitions, including native and JavaScript plugin rules.
  * Expanded Oxlint configuration typing and exports for improved rule support.
  * Exposed Oxlint plugin prefix mappings for consistent rule translation.

* **Refactor**
  * Updated configuration generation to use the new generated Oxlint types.
  * Improved type handling across Oxlint configuration fragments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->