### PR TITLE
feat: type-aware split option for two-pass linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,8 +535,8 @@ On large projects the type-aware rules dominate ESLint wall time; an explicit
 numeric `--concurrency` is the biggest single win. The `typeAware` option
 additionally splits the config into two complementary passes: a non-type-aware
 pass (`typeAware: false`) that never builds a TypeScript program and a
-type-aware-only pass (`typeAware: "only"`). Together they cover exactly the
-full config. See [docs/type-aware-split.md](./docs/type-aware-split.md).
+type-aware-only pass (`typeAware: "only"`). Together they cover exactly the full
+config. See [docs/type-aware-split.md](./docs/type-aware-split.md).
 
 #### ESLint Plugin Development
 

--- a/README.md
+++ b/README.md
@@ -529,6 +529,15 @@ pnpm i -D oxlint oxlint-tsgolint
 See [docs/oxlint.md](./docs/oxlint.md) for the per-rule mapping, what stays in
 ESLint and why, and migration notes.
 
+#### Type-Aware Split
+
+On large projects the type-aware rules dominate ESLint wall time. The
+`typeAware` option splits the config into two complementary passes: a
+non-type-aware pass (`typeAware: false`) that never builds a TypeScript program
+and can run with `--cache` and `--concurrency auto`, and a type-aware-only pass
+(`typeAware: "only"`) that runs serially. Together they cover exactly the full
+config. See [docs/type-aware-split.md](./docs/type-aware-split.md).
+
 #### ESLint Plugin Development
 
 If you're developing an ESLint plugin, you can enable specialized rules to help

--- a/README.md
+++ b/README.md
@@ -531,12 +531,12 @@ ESLint and why, and migration notes.
 
 #### Type-Aware Split
 
-On large projects the type-aware rules dominate ESLint wall time. The
-`typeAware` option splits the config into two complementary passes: a
-non-type-aware pass (`typeAware: false`) that never builds a TypeScript program
-and can run with `--cache` and `--concurrency auto`, and a type-aware-only pass
-(`typeAware: "only"`) that runs serially. Together they cover exactly the full
-config. See [docs/type-aware-split.md](./docs/type-aware-split.md).
+On large projects the type-aware rules dominate ESLint wall time; an explicit
+numeric `--concurrency` is the biggest single win. The `typeAware` option
+additionally splits the config into two complementary passes: a non-type-aware
+pass (`typeAware: false`) that never builds a TypeScript program and a
+type-aware-only pass (`typeAware: "only"`). Together they cover exactly the
+full config. See [docs/type-aware-split.md](./docs/type-aware-split.md).
 
 #### ESLint Plugin Development
 

--- a/docs/type-aware-split.md
+++ b/docs/type-aware-split.md
@@ -1,9 +1,15 @@
 # Type-Aware Split
 
 Type-aware rules need a TypeScript program and therefore dominate ESLint wall
-time on large projects. The `typeAware` factory option splits the config into
-two complementary passes so the cheap rules can run cached and parallel while
-only the type-aware remainder runs serially:
+time on large projects. Before reaching for a split, try an explicit numeric
+`--concurrency` on your existing single config — serial type-aware linting
+degrades badly as the run grows, and a fixed worker count (not `auto`, whose
+heuristic under-parallelizes type-aware workloads) routinely cuts a cold run by
+an order of magnitude.
+
+The `typeAware` factory option additionally splits the config into two
+complementary passes, so the non-type-aware majority gives near-instant
+feedback without ever building a TypeScript program:
 
 ```ts
 // eslint.config.ts — the full config; editors and hooks keep using this one.
@@ -30,20 +36,23 @@ export default isentinel({ type: "game", typeAware: "only" });
 // package.json
 {
 	"scripts": {
-		"lint:fast": "eslint --config eslint.fast.config.ts --cache --cache-location .eslintcache-fast --concurrency auto",
-		"lint:slow": "eslint --config eslint.slow.config.ts --cache --cache-location .eslintcache-slow",
+		"lint:fast": "eslint --config eslint.fast.config.ts --cache --cache-location .eslintcache-fast --concurrency 8",
+		"lint:slow": "eslint --config eslint.slow.config.ts --cache --cache-location .eslintcache-slow --concurrency 8",
 	},
 }
 ```
 
 Use a distinct `--cache-location` per pass — the two passes have different
-configs, so sharing one cache file would invalidate it on every run.
+configs, so sharing one cache file would invalidate it on every run. Use a
+fixed `--concurrency` count rather than `auto`: the type-aware pass
+parallelizes well, but every worker builds its own TypeScript program, so pick
+a worker count your memory can afford.
 
 ## What each mode does
 
 - `typeAware: false` drops every rule that requires type information and removes
   the type-aware parser setup (`projectService`), so no TypeScript program is
-  ever built. This is what makes `--cache` and `--concurrency` worthwhile.
+  ever built and the pass stays fast regardless of cache state.
 - `typeAware: "only"` keeps only the type-aware rules plus the parser setup they
   need, and skips the non-JS/TS-language configs (JSON, YAML, TOML, Markdown,
   pnpm, spell checking, formatting) entirely — those files are not linted in

--- a/docs/type-aware-split.md
+++ b/docs/type-aware-split.md
@@ -8,8 +8,8 @@ heuristic under-parallelizes type-aware workloads) routinely cuts a cold run by
 an order of magnitude.
 
 The `typeAware` factory option additionally splits the config into two
-complementary passes, so the non-type-aware majority gives near-instant
-feedback without ever building a TypeScript program:
+complementary passes, so the non-type-aware majority gives near-instant feedback
+without ever building a TypeScript program:
 
 ```ts
 // eslint.config.ts — the full config; editors and hooks keep using this one.
@@ -43,10 +43,10 @@ export default isentinel({ type: "game", typeAware: "only" });
 ```
 
 Use a distinct `--cache-location` per pass — the two passes have different
-configs, so sharing one cache file would invalidate it on every run. Use a
-fixed `--concurrency` count rather than `auto`: the type-aware pass
-parallelizes well, but every worker builds its own TypeScript program, so pick
-a worker count your memory can afford.
+configs, so sharing one cache file would invalidate it on every run. Use a fixed
+`--concurrency` count rather than `auto`: the type-aware pass parallelizes well,
+but every worker builds its own TypeScript program, so pick a worker count your
+memory can afford.
 
 ## What each mode does
 

--- a/docs/type-aware-split.md
+++ b/docs/type-aware-split.md
@@ -1,0 +1,92 @@
+# Type-Aware Split
+
+Type-aware rules need a TypeScript program and therefore dominate ESLint wall
+time on large projects. The `typeAware` factory option splits the config into
+two complementary passes so the cheap rules can run cached and parallel while
+only the type-aware remainder runs serially:
+
+```ts
+// eslint.config.ts — the full config; editors and hooks keep using this one.
+import isentinel from "@isentinel/eslint-config";
+
+export default isentinel({ type: "game" });
+```
+
+```ts
+// eslint.fast.config.ts — everything that does not need type information.
+import isentinel from "@isentinel/eslint-config";
+
+export default isentinel({ type: "game", typeAware: false });
+```
+
+```ts
+// eslint.slow.config.ts — only the type-aware rules.
+import isentinel from "@isentinel/eslint-config";
+
+export default isentinel({ type: "game", typeAware: "only" });
+```
+
+```jsonc
+// package.json
+{
+	"scripts": {
+		"lint:fast": "eslint --config eslint.fast.config.ts --cache --cache-location .eslintcache-fast --concurrency auto",
+		"lint:slow": "eslint --config eslint.slow.config.ts --cache --cache-location .eslintcache-slow",
+	},
+}
+```
+
+Use a distinct `--cache-location` per pass — the two passes have different
+configs, so sharing one cache file would invalidate it on every run.
+
+## What each mode does
+
+- `typeAware: false` drops every rule that requires type information and removes
+  the type-aware parser setup (`projectService`), so no TypeScript program is
+  ever built. This is what makes `--cache` and `--concurrency` worthwhile.
+- `typeAware: "only"` keeps only the type-aware rules plus the parser setup they
+  need, and skips the non-JS/TS-language configs (JSON, YAML, TOML, Markdown,
+  pnpm, spell checking, formatting) entirely — those files are not linted in
+  this pass at all.
+
+For every file, the effective rules of the two passes together equal the full
+config exactly (a test enforces this partition). Both modes work for ESLint-only
+and hybrid (`oxlint: true`) consumers; in hybrid mode the split applies to the
+rules that stay in ESLint after the oxlint hand-off.
+
+## How rules are classified
+
+A rule is type-aware when any of these hold:
+
+- its `meta.docs.requiresTypeChecking` is `true`;
+- it is in the preset's manual list of functionally type-aware rules that do not
+  declare the flag (the type-aware React rules,
+  `vitest/require-mock-type-parameters`,
+  `cease-nonsense/prefer-read-only-props`, ...);
+- it is enabled in a config item whose name contains `type-aware` (this covers
+  `overridesTypeAware` and the preset's type-aware config blocks).
+
+Classification is per rule, not per config item: every entry of a rule follows
+its classification, so the paired base-rule disables inside the type-aware
+blocks (for example `dot-notation: "off"` next to `ts/dot-notation`) stay with
+the fast pass and effective severities are preserved exactly.
+
+## Caveats
+
+- **Custom type-aware rules** must either declare
+  `meta.docs.requiresTypeChecking` or be enabled in a config whose name contains
+  `type-aware` (for example via `overridesTypeAware`). Otherwise they are sorted
+  into the fast pass, where no type information exists, and will crash or
+  silently no-op.
+- **Unused disable directives** are only reported by the full config. A
+  directive for a rule that runs in the other pass would be a false "unused"
+  report, so both split modes set
+  `linterOptions.reportUnusedDisableDirectives: "off"`.
+- **Inline config comments** (`/* eslint some/type-aware-rule: "error" */`) that
+  enable a type-aware rule fail in the fast pass — the split only partitions
+  config-file rules.
+- **Markdown fences**: the handful of syntax-only rules that live inside the
+  type-aware config blocks (for example `ts/no-empty-object-type`) follow the
+  type-aware pass and therefore no longer apply to fenced Markdown code blocks
+  (which only the fast pass lints). Type-aware rules never had real fence
+  coverage — fences have no type information.

--- a/docs/type-aware-split.md
+++ b/docs/type-aware-split.md
@@ -73,11 +73,11 @@ the fast pass and effective severities are preserved exactly.
 
 ## Caveats
 
-- **Custom type-aware rules** must either declare
-  `meta.docs.requiresTypeChecking` or be enabled in a config whose name contains
-  `type-aware` (for example via `overridesTypeAware`). Otherwise they are sorted
-  into the fast pass, where no type information exists, and will crash or
-  silently no-op.
+- **Custom type-aware rules** must declare `meta.docs.requiresTypeChecking`, be
+  enabled in a config whose name contains `type-aware` (for example via
+  `overridesTypeAware`), or be listed in the factory's `typeAwareRules` option.
+  Otherwise they are sorted into the fast pass, where no type information
+  exists, and will crash or silently no-op.
 - **Unused disable directives** are only reported by the full config. A
   directive for a rule that runs in the other pass would be a false "unused"
   report, so both split modes set

--- a/src/eslint/factory.ts
+++ b/src/eslint/factory.ts
@@ -507,7 +507,7 @@ export async function isentinel(
 
 	if (typeAwareMode !== undefined) {
 		composer = composer.onResolved((resolved) => {
-			applyTypeAwareSplit(resolved, typeAwareMode);
+			applyTypeAwareSplit(resolved, typeAwareMode, options.typeAwareRules);
 		});
 	}
 

--- a/src/eslint/factory.ts
+++ b/src/eslint/factory.ts
@@ -57,6 +57,8 @@ import { packageJson } from "./configs/package-json.ts";
 import { spelling } from "./configs/spelling.ts";
 import { dropOxlintCoveredRules, warnDeadMappedRules, warnMissingTsgolint } from "./oxlint-drop.ts";
 import { defaultPluginRenaming } from "./plugin-renaming.ts";
+import { applyTypeAwareSplit } from "./type-aware-split.ts";
+import type { TypeAwareSplitMode } from "./type-aware-split.ts";
 import type {
 	Awaitable,
 	ConfigNames,
@@ -134,6 +136,20 @@ export async function isentinel(
 
 	const rootGlobs = mergeGlobs(GLOB_ROOT, customRootGlobs);
 	const enableRoblox = options.roblox !== false;
+
+	const typeAwareMode: TypeAwareSplitMode | undefined =
+		options.typeAware === false || options.typeAware === "only" ? options.typeAware : undefined;
+	const typeAwareOnly = typeAwareMode === "only";
+	const typescriptOptions = resolveSubOptions(options, "typescript");
+	if (
+		typeAwareOnly &&
+		"typeAware" in typescriptOptions &&
+		typescriptOptions.typeAware === false
+	) {
+		throw new Error(
+			'[@isentinel/eslint-config] `typeAware: "only"` requires type-aware linting; do not combine it with `typescript.typeAware: false`.',
+		);
+	}
 
 	const inAgentSession = options.isAgent ?? isInAgentSession();
 	let { defaultSeverity, isInEditor } = options;
@@ -285,7 +301,7 @@ export async function isentinel(
 	}
 
 	if (enableRoblox) {
-		const shouldFormatLua = shouldEnableFeature(formatters, "lua");
+		const shouldFormatLua = shouldEnableFeature(formatters, "lua") && !typeAwareOnly;
 		configs.push(
 			roblox(
 				{
@@ -328,7 +344,7 @@ export async function isentinel(
 		);
 	}
 
-	if (options.jsonc !== false) {
+	if (options.jsonc !== false && !typeAwareOnly) {
 		configs.push(
 			jsonc({
 				...getOverrides(options, "jsonc"),
@@ -345,7 +361,7 @@ export async function isentinel(
 		}
 	}
 
-	if (options.yaml !== false) {
+	if (options.yaml !== false && !typeAwareOnly) {
 		configs.push(
 			yaml({
 				...getOverrides(options, "yaml"),
@@ -358,7 +374,7 @@ export async function isentinel(
 		}
 	}
 
-	if (enableCatalogs !== false) {
+	if (enableCatalogs !== false && !typeAwareOnly) {
 		configs.push(
 			pnpm({
 				isInEditor,
@@ -371,7 +387,7 @@ export async function isentinel(
 		}
 	}
 
-	if (options.toml !== false) {
+	if (options.toml !== false && !typeAwareOnly) {
 		configs.push(
 			toml({
 				...getOverrides(options, "toml"),
@@ -384,7 +400,7 @@ export async function isentinel(
 		}
 	}
 
-	if (options.markdown !== false) {
+	if (options.markdown !== false && !typeAwareOnly) {
 		configs.push(
 			markdown({
 				...getOverrides(options, "markdown"),
@@ -394,7 +410,7 @@ export async function isentinel(
 		);
 	}
 
-	if (enableSpellCheck !== false) {
+	if (enableSpellCheck !== false && !typeAwareOnly) {
 		configs.push(
 			spelling({
 				...resolveSubOptions(options, "spellCheck"),
@@ -410,7 +426,7 @@ export async function isentinel(
 
 	configs.push(disables({ root: rootGlobs }));
 
-	if (stylisticOptions !== false) {
+	if (stylisticOptions !== false && !typeAwareOnly) {
 		// Oxfmt must be the last config
 		configs.push(
 			oxfmt({
@@ -486,6 +502,12 @@ export async function isentinel(
 			}
 
 			dropOxlintCoveredRules(resolved, tsgolintAvailable);
+		});
+	}
+
+	if (typeAwareMode !== undefined) {
+		composer = composer.onResolved((resolved) => {
+			applyTypeAwareSplit(resolved, typeAwareMode);
 		});
 	}
 

--- a/src/eslint/type-aware-split.ts
+++ b/src/eslint/type-aware-split.ts
@@ -1,0 +1,192 @@
+import { typeAwareJsPluginRules } from "../rules/oxlint-mapping.ts";
+import type { TypedFlatConfigItem } from "./types.ts";
+
+/**
+ * Rules that need type information but do not declare
+ * `meta.docs.requiresTypeChecking` and are configured outside the type-aware
+ * config blocks, so neither classification signal catches them.
+ */
+const FUNCTIONALLY_TYPE_AWARE_RULES: ReadonlySet<string> = new Set([
+	...typeAwareJsPluginRules,
+	"cease-nonsense/prefer-read-only-props",
+]);
+
+/** The type-aware split mode; see the factory's `typeAware` option. */
+export type TypeAwareSplitMode = "only" | false;
+
+interface PluginRuleMeta {
+	meta?: { docs?: { requiresTypeChecking?: boolean } };
+}
+
+interface PluginLike {
+	rules?: Record<string, PluginRuleMeta>;
+}
+
+/**
+ * Collect the names of every type-aware rule referenced by the resolved
+ * configs.
+ *
+ * @param configs - The resolved flat config items.
+ * @returns The type-aware rule names.
+ */
+export function collectTypeAwareRules(configs: Array<TypedFlatConfigItem>): Set<string> {
+	const registry = collectRuleRegistry(configs);
+	const typeAware = new Set<string>();
+
+	for (const config of configs) {
+		collectFromConfig(config, registry, typeAware);
+	}
+
+	return typeAware;
+}
+
+/**
+ * Partition the resolved configs by type-awareness for multi-pass linting.
+ *
+ * Classification is per RULE, not per config item: a rule is type-aware when
+ * its `meta.docs.requiresTypeChecking` is `true`, when it is in the manual
+ * functionally-type-aware list, or when it is enabled in a config item whose
+ * name contains `type-aware` (which covers `overridesTypeAware` and custom
+ * type-aware rules without the meta flag). Every entry of a rule (enabled and
+ * `"off"`) follows its classification, so paired base-rule disables inside the
+ * type-aware blocks (for example `dot-notation: "off"` next to
+ * `ts/dot-notation`) stay with the non-type-aware pass and effective
+ * severities are preserved exactly.
+ *
+ * In `false` mode the type-aware parser configs (the ones enabling
+ * `projectService`) are removed as well, so no TypeScript program is ever
+ * built. Both modes disable `reportUnusedDisableDirectives`: a directive for a
+ * rule that runs in the other pass would otherwise be reported as unused. Only
+ * the full config reports unused directives.
+ *
+ * @param configs - The resolved flat config items (mutated in place).
+ * @param mode - `false` drops every type-aware rule; `"only"` keeps only
+ *   type-aware rules.
+ */
+export function applyTypeAwareSplit(
+	configs: Array<TypedFlatConfigItem>,
+	mode: TypeAwareSplitMode,
+): void {
+	const typeAwareRules = collectTypeAwareRules(configs);
+
+	for (let index = configs.length - 1; index >= 0; index -= 1) {
+		const config = configs[index];
+		if (config === undefined) {
+			continue;
+		}
+
+		if (mode === false && isTypeAwareParserConfig(config)) {
+			configs.splice(index, 1);
+			continue;
+		}
+
+		filterConfigRules(config, typeAwareRules, mode);
+	}
+
+	configs.push({
+		name: "isentinel/type-aware-split/disables",
+		linterOptions: {
+			reportUnusedDisableDirectives: "off",
+		},
+	});
+}
+
+/**
+ * Record the type-aware rules of a single config item.
+ *
+ * @param config - The flat config item to scan.
+ * @param registry - Rule id to rule definition.
+ * @param typeAware - The type-aware rule names (mutated).
+ */
+function collectFromConfig(
+	config: TypedFlatConfigItem,
+	registry: Map<string, PluginRuleMeta>,
+	typeAware: Set<string>,
+): void {
+	const inTypeAwareConfig = config.name?.includes("type-aware") ?? false;
+	const entries = Object.entries(config.rules ?? {});
+	for (const [rule, value] of entries) {
+		if (value === undefined) {
+			continue;
+		}
+
+		if (
+			FUNCTIONALLY_TYPE_AWARE_RULES.has(rule) ||
+			registry.get(rule)?.meta?.docs?.requiresTypeChecking === true
+		) {
+			typeAware.add(rule);
+			continue;
+		}
+
+		const severity = Array.isArray(value) ? value[0] : value;
+		if (inTypeAwareConfig && severity !== "off" && severity !== 0) {
+			typeAware.add(rule);
+		}
+	}
+}
+
+/**
+ * Build a registry of rule definitions from the plugins registered on the
+ * resolved configs, keyed by the (renamed) `prefix/name` rule id.
+ *
+ * @param configs - The resolved flat config items.
+ * @returns Rule id to rule definition.
+ */
+function collectRuleRegistry(configs: Array<TypedFlatConfigItem>): Map<string, PluginRuleMeta> {
+	const registry = new Map<string, PluginRuleMeta>();
+
+	for (const config of configs) {
+		const plugins = Object.entries(config.plugins ?? {});
+		for (const [prefix, plugin] of plugins) {
+			const ruleEntries = Object.entries((plugin as PluginLike).rules ?? {});
+			for (const [name, rule] of ruleEntries) {
+				registry.set(`${prefix}/${name}`, rule);
+			}
+		}
+	}
+
+	return registry;
+}
+
+/**
+ * Delete the rule entries of a config item that belong to the other pass.
+ *
+ * @param config - The flat config item (mutated).
+ * @param typeAwareRules - The type-aware rule names.
+ * @param mode - The split mode being applied.
+ */
+function filterConfigRules(
+	{ rules }: TypedFlatConfigItem,
+	typeAwareRules: Set<string>,
+	mode: TypeAwareSplitMode,
+): void {
+	if (rules === undefined) {
+		return;
+	}
+
+	for (const rule of Object.keys(rules)) {
+		const isTypeAware = typeAwareRules.has(rule);
+		if (mode === false ? isTypeAware : !isTypeAware) {
+			delete rules[rule];
+		}
+	}
+}
+
+/**
+ * Whether a config item is a preset type-aware parser config (the one that
+ * enables `projectService`, which builds a TypeScript program).
+ *
+ * @param config - The flat config item.
+ * @returns Whether the config is a type-aware parser config.
+ */
+function isTypeAwareParserConfig(config: TypedFlatConfigItem): boolean {
+	if (config.name === undefined || !config.name.includes("type-aware")) {
+		return false;
+	}
+
+	const parserOptions = config.languageOptions?.["parserOptions"] as
+		| Record<string, unknown>
+		| undefined;
+	const projectService = parserOptions?.["projectService"];
+	return projectService !== undefined && projectService !== false;
+}

--- a/src/eslint/type-aware-split.ts
+++ b/src/eslint/type-aware-split.ts
@@ -62,12 +62,18 @@ export function collectTypeAwareRules(configs: Array<TypedFlatConfigItem>): Set<
  * @param configs - The resolved flat config items (mutated in place).
  * @param mode - `false` drops every type-aware rule; `"only"` keeps only
  *   type-aware rules.
+ * @param extraTypeAwareRules - Additional rules to classify as type-aware (the
+ *   factory's `typeAwareRules` option).
  */
 export function applyTypeAwareSplit(
 	configs: Array<TypedFlatConfigItem>,
 	mode: TypeAwareSplitMode,
+	extraTypeAwareRules: Array<string> = [],
 ): void {
 	const typeAwareRules = collectTypeAwareRules(configs);
+	for (const rule of extraTypeAwareRules) {
+		typeAwareRules.add(rule);
+	}
 
 	for (let index = configs.length - 1; index >= 0; index -= 1) {
 		const config = configs[index];

--- a/src/eslint/type-aware-split.ts
+++ b/src/eslint/type-aware-split.ts
@@ -1,3 +1,4 @@
+import { GLOB_ALL_JSON, GLOB_LUA, GLOB_MARKDOWN, GLOB_TOML, GLOB_YAML } from "../globs.ts";
 import { typeAwareJsPluginRules } from "../rules/oxlint-mapping.ts";
 import type { TypedFlatConfigItem } from "./types.ts";
 
@@ -87,6 +88,18 @@ export function applyTypeAwareSplit(
 		}
 
 		filterConfigRules(config, typeAwareRules, mode);
+	}
+
+	if (mode === "only") {
+		// The non-JS/TS-language config modules are not composed in "only"
+		// mode, but a rules config (for example a user block scoping rules
+		// "off" for JSON or YAML files) can still pull those files into the
+		// run, where the default JS parser fails on them. Ignore them
+		// globally; the non-type-aware pass lints them.
+		configs.push({
+			name: "isentinel/type-aware-split/ignores",
+			ignores: [GLOB_ALL_JSON, GLOB_LUA, GLOB_MARKDOWN, GLOB_TOML, GLOB_YAML],
+		});
 	}
 
 	configs.push({

--- a/src/eslint/types.ts
+++ b/src/eslint/types.ts
@@ -445,6 +445,28 @@ export interface OptionsConfig extends OptionsComponentExtensions, OptionsProjec
 	toml?: boolean | OptionsOverrides;
 
 	/**
+	 * Split the config by type-aware linting so a large project can lint in two
+	 * ESLint passes.
+	 *
+	 * - `false` — drop every rule that requires type information and the
+	 *   type-aware parser setup, so no TypeScript program is built. Pairs well
+	 *   with `--cache` and `--concurrency auto`.
+	 * - `"only"` — keep only the type-aware rules (plus the parser setup they
+	 *   need) and drop the non-JS/TS-language configs (JSON, YAML, TOML,
+	 *   Markdown, pnpm, spell checking, formatting) entirely. Run serially.
+	 *
+	 * For every file, the effective rules of the two passes together equal the
+	 * full config exactly. Both modes disable unused-disable-directive
+	 * reporting; only the full config reports those. Custom type-aware rules
+	 * must either declare `meta.docs.requiresTypeChecking` or be enabled in a
+	 * config whose name contains `type-aware` (for example via
+	 * `overridesTypeAware`) to be sorted into the `"only"` pass.
+	 *
+	 * @default undefined - single full config
+	 */
+	typeAware?: "only" | boolean;
+
+	/**
 	 * Enable TypeScript support.
 	 *
 	 * Passing an object to enable TypeScript Language Server support.

--- a/src/eslint/types.ts
+++ b/src/eslint/types.ts
@@ -449,11 +449,15 @@ export interface OptionsConfig extends OptionsComponentExtensions, OptionsProjec
 	 * ESLint passes.
 	 *
 	 * - `false` — drop every rule that requires type information and the
-	 *   type-aware parser setup, so no TypeScript program is built. Pairs well
-	 *   with `--cache` and `--concurrency auto`.
+	 *   type-aware parser setup, so no TypeScript program is built.
 	 * - `"only"` — keep only the type-aware rules (plus the parser setup they
 	 *   need) and drop the non-JS/TS-language configs (JSON, YAML, TOML,
-	 *   Markdown, pnpm, spell checking, formatting) entirely. Run serially.
+	 *   Markdown, pnpm, spell checking, formatting) entirely.
+	 *
+	 * Both passes benefit from `--cache` (use a distinct `--cache-location`
+	 * per pass) and an explicit numeric `--concurrency`: type-aware linting
+	 * parallelizes well, but each worker builds its own TypeScript program, so
+	 * prefer a fixed worker count over `auto` and mind memory.
 	 *
 	 * For every file, the effective rules of the two passes together equal the
 	 * full config exactly. Both modes disable unused-disable-directive

--- a/src/eslint/types.ts
+++ b/src/eslint/types.ts
@@ -467,6 +467,15 @@ export interface OptionsConfig extends OptionsComponentExtensions, OptionsProjec
 	typeAware?: "only" | boolean;
 
 	/**
+	 * Additional rules to classify as type-aware for the `typeAware` split.
+	 *
+	 * Use this for custom or third-party rules that need type information but
+	 * neither declare `meta.docs.requiresTypeChecking` nor are enabled in a
+	 * config whose name contains `type-aware`.
+	 */
+	typeAwareRules?: Array<string>;
+
+	/**
 	 * Enable TypeScript support.
 	 *
 	 * Passing an object to enable TypeScript Language Server support.

--- a/test/type-aware-split.spec.ts
+++ b/test/type-aware-split.spec.ts
@@ -246,6 +246,16 @@ describe("type-aware split", () => {
 			);
 
 			expect(withOtherLanguages).toStrictEqual([]);
+
+			// Non-JS/TS files must be globally ignored: surviving rule configs
+			// (for example user blocks scoping rules off for JSON files) would
+			// otherwise pull them into the run without a matching parser.
+			const globalIgnores = slow.find(
+				(config) => config.name === "isentinel/type-aware-split/ignores",
+			);
+
+			expect(globalIgnores?.ignores).toContain("**/*.json{,5,c}");
+			expect(globalIgnores?.ignores).toContain("**/*.y{,a}ml");
 		});
 
 		it("should silence unused disable directives in both passes", async ({ expect }) => {

--- a/test/type-aware-split.spec.ts
+++ b/test/type-aware-split.spec.ts
@@ -263,6 +263,22 @@ describe("type-aware split", () => {
 		});
 	});
 
+	it("should classify rules listed in typeAwareRules as type-aware", async ({ expect }) => {
+		expect.hasAssertions();
+
+		const options = { ...baseOptions, typeAwareRules: ["no-console"] };
+		const [fast, slow] = await Promise.all([
+			isentinel({ name: "test/split-extra-fast", ...options, typeAware: false }),
+			isentinel({ name: "test/split-extra-slow", ...options, typeAware: "only" }),
+		]);
+
+		const fastEffective = effectiveEslintRules([...fast], "src/services/service.ts");
+		const slowEffective = effectiveEslintRules([...slow], "src/services/service.ts");
+
+		expect(fastEffective.has("no-console")).toBe(false);
+		expect(slowEffective.has("no-console")).toBe(true);
+	});
+
 	it("should reject typeAware 'only' without type-aware linting", async ({ expect }) => {
 		expect.hasAssertions();
 

--- a/test/type-aware-split.spec.ts
+++ b/test/type-aware-split.spec.ts
@@ -1,0 +1,278 @@
+import { describe, it } from "vitest";
+
+import { isentinel } from "../src";
+import type { TypedFlatConfigItem } from "../src";
+import type { Severity } from "./oxlint-helpers";
+import { effectiveEslintRules } from "./oxlint-helpers";
+
+interface PluginRuleMeta {
+	meta?: { docs?: Record<string, unknown> };
+}
+
+interface SplitVariant {
+	name: string;
+	files: Array<string>;
+	options: Record<string, unknown>;
+}
+
+const baseOptions = {
+	gitignore: false,
+	isAgent: false,
+	isInEditor: false,
+	pnpm: false,
+} as const;
+
+const variants: Array<SplitVariant> = [
+	{
+		name: "roblox-game",
+		files: [
+			"src/services/service.ts",
+			"src/components/component.tsx",
+			"src/util.js",
+			"src/types/env.d.ts",
+			"scripts/build.ts",
+			".github/workflows/ci.yaml",
+			"package.json",
+		],
+		options: { ...baseOptions },
+	},
+	{
+		name: "package",
+		files: ["src/index.ts", "src/utilities/helper.ts", "src/index.spec.ts", "build.config.ts"],
+		options: {
+			...baseOptions,
+			eslintPlugin: true,
+			naming: true,
+			roblox: false,
+			test: { vitest: true },
+			type: "package",
+		},
+	},
+	{
+		name: "react-jest",
+		files: ["src/components/component.tsx", "src/services/service.spec.ts"],
+		options: { ...baseOptions, react: true, test: { jest: true } },
+	},
+	{
+		name: "hybrid",
+		files: ["src/services/service.ts", "src/components/component.tsx", "src/util.js"],
+		options: { ...baseOptions, oxlint: true },
+	},
+];
+
+/**
+ * Build the full, non-type-aware and type-aware-only configs for a variant.
+ *
+ * @param options - Factory options shared by the three configs.
+ * @returns The three resolved config arrays.
+ */
+async function buildSplitConfigs(options: Record<string, unknown>): Promise<{
+	fast: Array<TypedFlatConfigItem>;
+	full: Array<TypedFlatConfigItem>;
+	slow: Array<TypedFlatConfigItem>;
+}> {
+	const [full, fast, slow] = await Promise.all([
+		isentinel({ name: "test/split-full", ...options }),
+		isentinel({ name: "test/split-fast", ...options, typeAware: false }),
+		isentinel({ name: "test/split-slow", ...options, typeAware: "only" }),
+	]);
+	return { fast: [...fast], full: [...full], slow: [...slow] };
+}
+
+/**
+ * Compare the merged effective severities of both split passes against the
+ * full config for one file.
+ *
+ * @param filePath - The file path under comparison.
+ * @param full - Effective severities of the full config.
+ * @param fast - Effective severities of the non-type-aware pass.
+ * @param slow - Effective severities of the type-aware-only pass.
+ * @returns Human-readable problems.
+ */
+function findPartitionProblems(
+	filePath: string,
+	full: Map<string, Severity>,
+	fast: Map<string, Severity>,
+	slow: Map<string, Severity>,
+): Array<string> {
+	const problems: Array<string> = [];
+
+	for (const rule of fast.keys()) {
+		if (slow.has(rule)) {
+			problems.push(`${filePath}: ${rule} appears in both passes`);
+		}
+	}
+
+	const merged = new Map([...fast, ...slow]);
+	for (const [rule, severity] of full) {
+		if (merged.get(rule) !== severity) {
+			problems.push(
+				`${filePath}: ${rule} full=${severity} merged=${merged.get(rule) ?? "absent"}`,
+			);
+		}
+	}
+
+	for (const rule of merged.keys()) {
+		if (!full.has(rule)) {
+			problems.push(`${filePath}: ${rule} not present in the full config`);
+		}
+	}
+
+	return problems;
+}
+
+/**
+ * Collect the rule definitions registered on the given configs, keyed by the
+ * renamed `prefix/name` rule id.
+ *
+ * @param configs - The resolved flat config items.
+ * @returns Rule id to rule definition.
+ */
+function collectRuleRegistry(configs: Array<TypedFlatConfigItem>): Map<string, PluginRuleMeta> {
+	const registry = new Map<string, PluginRuleMeta>();
+	for (const config of configs) {
+		const plugins = Object.entries(config.plugins ?? {});
+		for (const [prefix, plugin] of plugins) {
+			const ruleEntries = Object.entries(
+				(plugin as { rules?: Record<string, PluginRuleMeta> }).rules ?? {},
+			);
+			for (const [name, rule] of ruleEntries) {
+				registry.set(`${prefix}/${name}`, rule);
+			}
+		}
+	}
+
+	return registry;
+}
+
+/**
+ * Find the enabled rules of a config item whose metadata says they require
+ * type checking.
+ *
+ * @param config - The flat config item to scan.
+ * @param registry - Rule id to rule definition.
+ * @returns Human-readable problems.
+ */
+function findTypeCheckedRules(
+	config: TypedFlatConfigItem,
+	registry: Map<string, PluginRuleMeta>,
+): Array<string> {
+	const problems: Array<string> = [];
+	const entries = Object.entries(config.rules ?? {});
+	for (const [rule, value] of entries) {
+		const severity = Array.isArray(value) ? value[0] : value;
+		if (value === undefined || severity === "off" || severity === 0) {
+			continue;
+		}
+
+		if (registry.get(rule)?.meta?.docs?.["requiresTypeChecking"] === true) {
+			problems.push(`${rule} in ${config.name ?? "unnamed config"}`);
+		}
+	}
+
+	return problems;
+}
+
+/**
+ * Whether a config item enables `projectService` (builds a TS program).
+ *
+ * @param config - The flat config item.
+ * @returns Whether the config enables the project service.
+ */
+function enablesProjectService(config: TypedFlatConfigItem): boolean {
+	const parserOptions = config.languageOptions?.["parserOptions"] as
+		| Record<string, unknown>
+		| undefined;
+	const projectService = parserOptions?.["projectService"];
+	return projectService !== undefined && projectService !== false;
+}
+
+describe("type-aware split", () => {
+	describe.for(variants)("$name", (variant: SplitVariant) => {
+		it("should partition effective severities exactly", async ({ expect }) => {
+			expect.hasAssertions();
+
+			const { fast, full, slow } = await buildSplitConfigs(variant.options);
+
+			const problems: Array<string> = [];
+			for (const filePath of variant.files) {
+				problems.push(
+					...findPartitionProblems(
+						filePath,
+						effectiveEslintRules(full, filePath),
+						effectiveEslintRules(fast, filePath),
+						effectiveEslintRules(slow, filePath),
+					),
+				);
+			}
+
+			expect(problems).toStrictEqual([]);
+		});
+
+		it("should never build a TS program in the non-type-aware pass", async ({ expect }) => {
+			expect.hasAssertions();
+
+			const { fast, slow } = await buildSplitConfigs(variant.options);
+
+			expect(fast.filter(enablesProjectService)).toStrictEqual([]);
+			expect(slow.some(enablesProjectService)).toBe(true);
+		});
+
+		it("should keep rules that require type checking out of the fast pass", async ({
+			expect,
+		}) => {
+			expect.hasAssertions();
+
+			const { fast } = await buildSplitConfigs(variant.options);
+			const registry = collectRuleRegistry(fast);
+
+			const problems: Array<string> = [];
+			for (const config of fast) {
+				problems.push(...findTypeCheckedRules(config, registry));
+			}
+
+			expect(problems).toStrictEqual([]);
+		});
+
+		it("should drop non-JS/TS-language configs in the type-aware-only pass", async ({
+			expect,
+		}) => {
+			expect.hasAssertions();
+
+			const { slow } = await buildSplitConfigs(variant.options);
+
+			const withOtherLanguages = slow.filter(
+				(config) => config.processor !== undefined || "language" in config,
+			);
+
+			expect(withOtherLanguages).toStrictEqual([]);
+		});
+
+		it("should silence unused disable directives in both passes", async ({ expect }) => {
+			expect.hasAssertions();
+
+			const { fast, full, slow } = await buildSplitConfigs(variant.options);
+
+			expect(fast.at(-1)?.linterOptions?.reportUnusedDisableDirectives).toBe("off");
+			expect(slow.at(-1)?.linterOptions?.reportUnusedDisableDirectives).toBe("off");
+			expect(
+				full.some(
+					(config) => config.linterOptions?.reportUnusedDisableDirectives === "off",
+				),
+			).toBe(false);
+		});
+	});
+
+	it("should reject typeAware 'only' without type-aware linting", async ({ expect }) => {
+		expect.hasAssertions();
+
+		await expect(
+			isentinel({
+				name: "test/split-guard",
+				...baseOptions,
+				typeAware: "only",
+				typescript: { typeAware: false },
+			}),
+		).rejects.toThrow('typeAware: "only"');
+	});
+});


### PR DESCRIPTION
## Summary

Adds a `typeAware` factory option that splits the ESLint config into two complementary passes for large projects:

- **`typeAware: false`** — drops every rule that requires type information and removes the type-aware parser setup (`projectService`), so no TypeScript program is ever built. A fast, stable feedback loop (~7s warm / ~20s cold on a 3000-file project) immune to cache invalidation.
- **`typeAware: "only"`** — keeps only the type-aware rules (plus the parser setup they need) and skips the non-JS/TS-language configs (JSON/YAML/TOML/Markdown/pnpm/spelling/formatting) entirely; those files are globally ignored in this pass.
- **`typeAwareRules: [...]`** — escape hatch for custom rules that need types but neither declare `meta.docs.requiresTypeChecking` nor live in a `*type-aware*` config block.

## How it works

Partitioning is per **rule**, not per config item, applied in an `onResolved` hook (after the hybrid oxlint drop). A rule is type-aware when:

1. its `meta.docs.requiresTypeChecking` is `true` (looked up from the resolved plugins), or
2. it is in the manual functionally-type-aware list (`typeAwareJsPluginRules` + `cease-nonsense/prefer-read-only-props`), or
3. it is enabled in a config whose name contains `type-aware` (covers `overridesTypeAware`), or
4. it is listed in `typeAwareRules`.

Every entry of a rule (enabled and `"off"`) follows its classification, so the paired base-rule disables inside the type-aware blocks (e.g. `dot-notation: "off"` next to `ts/dot-notation`) stay with the fast pass and effective severities are preserved exactly. A parity test enforces that, for every file, merge(fast, slow) deep-equals the full config and the passes are disjoint — across roblox-game, package, react+jest and hybrid (`oxlint: true`) variants.

Both modes disable `reportUnusedDisableDirectives` (a directive for a rule running in the other pass would be a false "unused" report); only the full config reports those. Verified end-to-end on a real project.

## Benchmarks (3000-file roblox-ts project, hybrid config, 32 cores)

| Run | Wall time |
| --- | --- |
| full hybrid, serial, cold | ~713s |
| full hybrid, `--concurrency 8`, cold | **44.6s** |
| fast pass (`typeAware: false`), cold / warm | 20s / 7.4s |
| slow pass (`typeAware: "only"`), `--concurrency 8` | 39.9s |
| oxlint (incl. tsgolint) reference | 52s |

Profiling showed rules are only ~13% of the type-aware pass; the rest is typescript-eslint per-file type-checking, which degrades badly serially but parallelizes well — so the docs lead with "use an explicit numeric `--concurrency` first" (ESLint's `auto` under-parallelizes this workload), and position the split as tiered-feedback DX rather than a total-time win.

## Docs

`docs/type-aware-split.md` + README section, including the custom-rule classification contract and caveats (inline config comments, Markdown fences).

https://claude.ai/code/session_01RRos9XCSrCw73GRsLZvKdw