### PR TITLE
fix: exclude fixtures from the pnpm workspace

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,8 +525,6 @@ importers:
         specifier: catalog:dev
         version: 4.1.10(@types/node@24.1.0)(vite@8.1.4(@types/node@24.1.0)(jiti@2.7.0)(yaml@2.9.0))
 
-  fixtures/input: {}
-
 packages:
 
   '@altano/repository-tools@2.0.3':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,6 @@ trustPolicy: no-downgrade
 trustPolicyIgnoreAfter: 10080
 
 packages:
-  - fixtures/*
   - src/*
 
 overrides:


### PR DESCRIPTION
## Summary

The v6.0.0-beta.7 release job failed after successfully publishing `@isentinel/eslint-config`: the reusable release workflow runs a recursive `pnpm publish`, and the `fixtures/*` entry in `pnpm-workspace.yaml` made `fixtures/input` (added as `@test/fixture-package` by the vitest fixture tests in #551, not `private`) a publishable workspace package — npm rejected it with a 404 on the unknown `@test` scope.

The fixture package.json is lint-test input, not a real package, so this drops the `fixtures/*` workspace glob instead of polluting the fixture (and its three output snapshots) with `"private": true`.

## Verification

- `pnpm -r ls --depth -1` now lists only the root package
- `pnpm publish -r --dry-run --no-git-checks` finds nothing unexpected to publish
- gen / lint / typecheck / tests (77/77) green

Note: `@isentinel/eslint-config@6.0.0-beta.7` itself published fine — only the trailing fixture publish failed, so no release recovery is needed beyond this fix.

https://claude.ai/code/session_01RRos9XCSrCw73GRsLZvKdw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration to exclude fixture directories from package discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->