### PR TITLE
feat: ship isentinel-lint hybrid lint CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,16 +91,19 @@ export default isentinel(
 
 ### Add script for package.json
 
-For example:
+The package ships an `isentinel-lint` bin that runs oxlint and ESLint together.
+The starter wizard adds these for you; to wire them up manually:
 
 ```json
 {
 	"scripts": {
-		"lint": "eslint",
-		"lint:fix": "eslint --fix"
+		"lint": "isentinel-lint",
+		"lint:fix": "isentinel-lint --fix"
 	}
 }
 ```
+
+See [`isentinel-lint`](#isentinel-lint) for what it does and every flag.
 
 ## Recommended Settings
 
@@ -193,6 +196,98 @@ Add the following settings to your `.vscode/settings.json`:
 	]
 }
 ```
+
+## isentinel-lint
+
+The package ships a second bin, `isentinel-lint`, a hybrid runner that drives
+[oxlint](https://oxc.rs/docs/guide/usage/linter/) and ESLint together. Point
+your `lint` script at it and forget the wiring (the starter wizard does this for
+you):
+
+```json
+{
+	"scripts": {
+		"lint": "isentinel-lint",
+		"lint:fix": "isentinel-lint --fix"
+	}
+}
+```
+
+It resolves the `eslint` and `oxlint` binaries from your project's
+`node_modules`, so both must be installed locally.
+
+### What it does
+
+- Runs `oxlint` and `eslint` in parallel via
+  [`concurrently`](https://www.npmjs.com/package/concurrently), grouping their
+  output and killing both on the first failure.
+- Sizes ESLint's `--concurrency` from how many files actually need re-linting
+  (the dirty count from the cache), rather than eagerly spinning up a worker per
+  CPU. Type-aware rules dominate wall time, so fewer, fuller workers win.
+- Keeps a separate ESLint cache per mode so the fast and type-aware passes never
+  invalidate one another: `.eslintcache` (default), `.eslintcache-fast`
+  (`--type-aware=off`), and `.eslintcache-typeaware` (`--type-aware=only`). A
+  change to an ESLint/oxlint/Prettier/tsconfig file or a lockfile clears all
+  three.
+- Runs `--fix` sequentially (`oxlint --fix`, then `eslint --fix`) so two writers
+  never race on the same files.
+
+Any trailing positional arguments are treated as paths to lint (default `.`).
+
+### Flags
+
+| Flag                     | Description                                                              |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `--eslint`               | Run only ESLint.                                                         |
+| `--oxlint`               | Run only oxlint.                                                         |
+| `--fix`                  | Apply fixes: `oxlint --fix` then `eslint --fix` (sequential).            |
+| `--agents`               | Emit agent-friendly output from both linters.                            |
+| `--type-aware=off\|only` | ESLint type-aware mode. `off` is the fast pass; cannot mix with `--fix`. |
+| `--no-oxlint-type-aware` | Skip oxlint's type-aware rules (no `oxlint-tsgolint` needed).            |
+| `--no-cache`             | Disable ESLint's on-disk cache.                                          |
+| `--concurrency <n\|off>` | Override the concurrency heuristic with a fixed worker count.            |
+| `--eslint-args "<args>"` | Extra arguments forwarded verbatim to ESLint.                            |
+| `--oxlint-args "<args>"` | Extra arguments forwarded verbatim to oxlint.                            |
+| `--print`                | Print the composed commands without running them.                        |
+| `-- <args>`              | Forward args to the single selected tool (needs `--eslint`/`--oxlint`).  |
+| `-h`, `--help`           | Show help.                                                               |
+| `-v`, `--version`        | Show the version.                                                        |
+
+### Environment
+
+| Variable            | Effect                                                                                                               |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `FILES_PER_WORKER`  | Target files a single ESLint worker handles before adding another (default `350`).                                   |
+| `LINT_MAX_WORKERS`  | Upper bound on ESLint workers (default a quarter of available CPUs).                                                 |
+| `ESLINT_TYPE_AWARE` | `off` or `only`; the type-aware mode `--type-aware` sets for the ESLint child (`false` is a legacy alias for `off`). |
+| `CI`                | When set, ESLint uses `--cache-strategy content` (see below).                                                        |
+
+### Type-aware oxlint and tsgolint
+
+By default the runner passes `--type-aware` to oxlint, which needs
+[`oxlint-tsgolint`](https://www.npmjs.com/package/oxlint-tsgolint). If it is not
+installed the runner errors out rather than silently skipping type-aware rules.
+Install it, or pass `--no-oxlint-type-aware` to run oxlint without them:
+
+```bash
+pnpm i -D oxlint oxlint-tsgolint
+```
+
+`--type-aware=off` also drops oxlint's type-aware pass, since the fast mode
+skips type-aware linting entirely.
+
+### CI
+
+When a `CI` environment variable is set, ESLint switches to
+`--cache-strategy content` so caches key on file contents rather than
+timestamps, which are unreliable across fresh checkouts.
+
+### Agent output
+
+`--agents` emits machine-readable output for AI agents: oxlint runs with
+`--format agent`, and ESLint uses the formatter shipped at
+`@isentinel/eslint-config/formatter-agents`, which the runner resolves and
+passes to `eslint --format` for you.
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -218,49 +218,80 @@ It resolves the `eslint` and `oxlint` binaries from your project's
 
 ### What it does
 
-- Runs `oxlint` and `eslint` in parallel via
-  [`concurrently`](https://www.npmjs.com/package/concurrently), grouping their
-  output and killing both on the first failure.
-- Sizes ESLint's `--concurrency` from how many files actually need re-linting
-  (the dirty count from the cache), rather than eagerly spinning up a worker per
-  CPU. Type-aware rules dominate wall time, so fewer, fuller workers win.
-- Keeps a separate ESLint cache per mode so the fast and type-aware passes never
-  invalidate one another: `.eslintcache` (default), `.eslintcache-fast`
-  (`--type-aware=off`), and `.eslintcache-typeaware` (`--type-aware=only`). A
-  change to an ESLint/oxlint/Prettier/tsconfig file or a lockfile clears all
-  three.
+By default (a local run, no `--type-aware`, no `--fix`) it runs **three**
+children concurrently via
+[`concurrently`](https://www.npmjs.com/package/concurrently), grouping their
+output:
+
+- **oxlint** — the full oxlint pass (including its type-aware rules).
+- **fast pass** — ESLint with only the syntactic (non-type-aware) rules, over
+  every lintable file (TS/JS, JSON, YAML, TOML, Markdown, Lua). This is where
+  non-TS files are linted.
+- **type-aware pass** — ESLint with only the type-aware rules, over the TS/JS
+  family. The preset's config splits exactly in two, so `fast ∪ type-aware`
+  reproduces the full config rule-for-rule.
+
+The type-aware pass is the expensive one (it builds a TypeScript program), so
+the runner **skips it entirely when nothing type-relevant changed** since the
+last run — it uses the TypeScript builder to find the files whose type-aware
+results could have changed, and if that set is empty it prints a short note to
+stderr and does not start the pass. The fast pass and oxlint always run.
+
+Other behaviours:
+
+- Sizes each ESLint pass's `--concurrency` from how many files it will actually
+  re-lint (its own dirty count), rather than eagerly spinning up a worker per
+  CPU. The fast pass is cheap per file, so it packs far more files per worker
+  (see `FAST_FILES_PER_WORKER`) than the type-aware pass.
+- Keeps a separate ESLint cache per pass so they never invalidate one another:
+  `.eslintcache-fast` (fast pass), `.eslintcache-typeaware` (type-aware pass),
+  and `.eslintcache` (the full single-pass config used by `--fix`, CI and
+  `--type-aware=full`). A change to an ESLint/oxlint/Prettier/tsconfig file or a
+  lockfile clears all three; a change to the root `package.json` resolution
+  surface (`exports`, `imports`, `main`, `module`, `types`, `typesVersions`,
+  `dependencies`, `devDependencies`, `peerDependencies`) clears only the
+  type-aware caches (a syntactic lint cannot be affected by resolution).
 - Runs `--fix` sequentially (`oxlint --fix`, then `eslint --fix`) so two writers
   never race on the same files.
+- Lets every child run to completion and returns non-zero if any failed — an
+  ordinary lint error in one tool no longer kills the others mid-run.
+
+> **Unused eslint-disable directives.** The default two-pass mode does **not**
+> report unused `eslint-disable` directives: a directive naming a rule that
+> lives in the _other_ pass would look unused to the pass that runs it and
+> produce a false positive. `--fix`, CI and `--type-aware=full` runs use the
+> single full config and still report unused directives.
 
 Any trailing positional arguments are treated as paths to lint (default `.`).
 
 ### Flags
 
-| Flag                     | Description                                                              |
-| ------------------------ | ------------------------------------------------------------------------ |
-| `--eslint`               | Run only ESLint.                                                         |
-| `--oxlint`               | Run only oxlint.                                                         |
-| `--fix`                  | Apply fixes: `oxlint --fix` then `eslint --fix` (sequential).            |
-| `--agents`               | Emit agent-friendly output from both linters.                            |
-| `--type-aware=off\|only` | ESLint type-aware mode. `off` is the fast pass; cannot mix with `--fix`. |
-| `--no-oxlint-type-aware` | Skip oxlint's type-aware rules (no `oxlint-tsgolint` needed).            |
-| `--no-cache`             | Disable ESLint's on-disk cache.                                          |
-| `--concurrency <n\|off>` | Override the concurrency heuristic with a fixed worker count.            |
-| `--eslint-args "<args>"` | Extra arguments forwarded verbatim to ESLint.                            |
-| `--oxlint-args "<args>"` | Extra arguments forwarded verbatim to oxlint.                            |
-| `--print`                | Print the composed commands without running them.                        |
-| `-- <args>`              | Forward args to the single selected tool (needs `--eslint`/`--oxlint`).  |
-| `-h`, `--help`           | Show help.                                                               |
-| `-v`, `--version`        | Show the version.                                                        |
+| Flag                           | Description                                                                                                                        |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `--eslint`                     | Run only ESLint.                                                                                                                   |
+| `--oxlint`                     | Run only oxlint.                                                                                                                   |
+| `--fix`                        | Apply fixes: `oxlint --fix` then `eslint --fix` (sequential).                                                                      |
+| `--agents`                     | Emit agent-friendly output from both linters.                                                                                      |
+| `--type-aware=off\|only\|full` | Force a single ESLint pass: `off` fast-only, `only` type-aware-only, `full` the whole config in one pass. Cannot mix with `--fix`. |
+| `--no-oxlint-type-aware`       | Skip oxlint's type-aware rules (no `oxlint-tsgolint` needed).                                                                      |
+| `--no-cache`                   | Disable ESLint's on-disk cache.                                                                                                    |
+| `--concurrency <n\|off>`       | Override the concurrency heuristic with a fixed worker count.                                                                      |
+| `--eslint-args "<args>"`       | Extra arguments forwarded verbatim to ESLint.                                                                                      |
+| `--oxlint-args "<args>"`       | Extra arguments forwarded verbatim to oxlint.                                                                                      |
+| `--print`                      | Print the composed commands without running them.                                                                                  |
+| `-- <args>`                    | Forward args to the single selected tool (needs `--eslint`/`--oxlint`).                                                            |
+| `-h`, `--help`                 | Show help.                                                                                                                         |
+| `-v`, `--version`              | Show the version.                                                                                                                  |
 
 ### Environment
 
-| Variable            | Effect                                                                                                               |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `FILES_PER_WORKER`  | Target files a single ESLint worker handles before adding another (default `350`).                                   |
-| `LINT_MAX_WORKERS`  | Upper bound on ESLint workers (default a quarter of available CPUs).                                                 |
-| `ESLINT_TYPE_AWARE` | `off` or `only`; the type-aware mode `--type-aware` sets for the ESLint child (`false` is a legacy alias for `off`). |
-| `CI`                | When set, ESLint uses `--cache-strategy content` (see below).                                                        |
+| Variable                | Effect                                                                                                               |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `FILES_PER_WORKER`      | Target files a single type-aware ESLint worker handles before adding another (default `350`).                        |
+| `FAST_FILES_PER_WORKER` | Same, for the fast (syntactic) pass, which packs far more files per worker (default `800`).                          |
+| `LINT_MAX_WORKERS`      | Upper bound on ESLint workers (default a quarter of available CPUs).                                                 |
+| `ESLINT_TYPE_AWARE`     | `off` or `only`; the type-aware mode `--type-aware` sets for the ESLint child (`false` is a legacy alias for `off`). |
+| `CI`                    | When set, the runner uses the single full pass with `--cache-strategy content` (see below).                          |
 
 ### Type-aware oxlint and tsgolint
 
@@ -278,9 +309,12 @@ skips type-aware linting entirely.
 
 ### CI
 
-When a `CI` environment variable is set, ESLint switches to
-`--cache-strategy content` so caches key on file contents rather than
-timestamps, which are unreliable across fresh checkouts.
+When a `CI` environment variable is set the runner skips the two-pass split and
+runs a single full-config ESLint pass (alongside oxlint). CI cores are few, so
+the two-pass parallelism does not pay off, and the full config is the only one
+that reports unused `eslint-disable` directives — which you want enforced in CI.
+The pass also switches to `--cache-strategy content` so caches key on file
+contents rather than timestamps, which are unreliable across fresh checkouts.
 
 ### Agent output
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,23 @@ Other behaviours:
 > produce a false positive. `--fix`, CI and `--type-aware=full` runs use the
 > single full config and still report unused directives.
 
+### Hybrid detection
+
+Running both engines only makes sense when the ESLint config is in **hybrid
+mode** (`oxlint: true`), which drops every oxlint-covered rule from the ESLint
+side so the two engines never overlap. A config that omits `oxlint: true` runs
+every mapped rule in _both_ engines — duplicate diagnostics, and under `--fix` a
+tug-of-war as each rewrites toward its own option resolution. So whenever both
+engines would run (default mode or `--fix`), the runner checks whether the
+resolved config is hybrid; if it is not, it **runs ESLint only, skips oxlint,
+and prints one stderr warning** (enable hybrid mode, or pass `--oxlint` to run
+oxlint explicitly). The check is cheap: the factory records the hybrid status in
+`node_modules/.cache/isentinel-lint/` on every config evaluation, and the runner
+trusts that cache unless your ESLint config is newer, in which case it probes
+`eslint --print-config` once and caches the result. If the status cannot be
+determined it fails open and runs both engines as before. Explicit `--eslint` /
+`--oxlint` runs skip the check entirely.
+
 Any trailing positional arguments are treated as paths to lint (default `.`).
 
 ### Flags

--- a/README.md
+++ b/README.md
@@ -340,6 +340,36 @@ contents rather than timestamps, which are unreliable across fresh checkouts.
 `@isentinel/eslint-config/formatter-agents`, which the runner resolves and
 passes to `eslint --format` for you.
 
+### Known limitations
+
+The incremental machinery favours speed, and a few edges are deliberately left
+to self-heal or need a one-off nudge:
+
+- **Config changes reached through an imported module are invisible to a
+  _skipped_ typed pass.** The runner busts caches on the mtime of your
+  `eslint.config.*`, tsconfigs and lockfiles, but not on files those configs
+  `import`. ESLint's own per-entry config hash would still catch such a change
+  once the pass runs — but if the typed pass was auto-skipped (nothing
+  type-relevant looked dirty), it never runs to notice. Touch your
+  `eslint.config.*` (or run once with `--no-cache`) after editing a module it
+  imports.
+- **mtime granularity.** Cache freshness is compared by modification time, so
+  the usual coarse-filesystem-timestamp race that affects ESLint's own cache
+  applies here too (edits within the same clock tick as the last run can be
+  missed). CI uses `--cache-strategy content` to sidestep it; locally, a second
+  run settles it.
+- **Solution-style / project-reference tsconfigs.** The TypeScript builder used
+  to find type-affected files does not follow project references, so in a
+  solution-style setup builder invalidation silently becomes a no-op and the
+  runner falls back to plain mtime dirtiness. Type-aware results stay correct
+  (ESLint still lints the dirty files); only the cross-file "an imported type
+  changed" invalidation is skipped.
+- **Hybrid status tracks `eslint.config.*` mtimes only.** If you toggle hybrid
+  mode (`oxlint: true`) from a module the config _imports_ rather than the
+  config file itself, the runner trusts its cached hybrid decision for one more
+  run before the factory's passive write corrects it — it self-heals on the next
+  invocation.
+
 ## Customization
 
 Normally you only need to import the `isentinel` preset:

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-import "../dist/cli.js";
+import "../dist/cli.mjs";

--- a/bin/lint.js
+++ b/bin/lint.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import "../dist/lint-cli.mjs";

--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
 	"main": "./dist/index.mjs",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.mts",
-	"bin": "./bin/index.js",
+	"bin": {
+		"eslint-config": "./bin/index.js",
+		"isentinel-lint": "./bin/lint.js"
+	},
 	"files": [
 		"bin",
 		"dist"
@@ -77,6 +80,7 @@
 		"@typescript-eslint/eslint-plugin": "catalog:prod",
 		"@typescript-eslint/parser": "catalog:prod",
 		"ansis": "catalog:prod",
+		"concurrently": "catalog:prod",
 		"eslint-config-flat-gitignore": "catalog:prod",
 		"eslint-config-prettier": "catalog:prod",
 		"eslint-flat-config-utils": "catalog:prod",
@@ -102,6 +106,7 @@
 		"eslint-plugin-unicorn": "catalog:prod",
 		"eslint-plugin-unused-imports": "catalog:prod",
 		"eslint-plugin-yml": "catalog:prod",
+		"file-entry-cache": "catalog:prod",
 		"find-up-simple": "catalog:prod",
 		"globals": "catalog:prod",
 		"jsonc-eslint-parser": "catalog:prod",
@@ -128,7 +133,6 @@
 		"@types/yargs": "catalog:dev",
 		"@vitest/eslint-plugin": "catalog:peer",
 		"bumpp": "catalog:dev",
-		"concurrently": "catalog:dev",
 		"eslint": "catalog:peer",
 		"eslint-plugin-erasable-syntax-only": "catalog:peer",
 		"eslint-plugin-eslint-plugin": "catalog:peer",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	"exports": {
 		".": "./dist/index.mjs",
 		"./cli": "./dist/cli.mjs",
+		"./formatter-agents": "./dist/formatter-agents.mjs",
 		"./oxlint": {
 			"types": "./dist/oxlint.d.mts",
 			"default": "./dist/oxlint.mjs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ catalogs:
     bumpp:
       specifier: 11.1.0
       version: 11.1.0
-    concurrently:
-      specifier: 10.0.3
-      version: 10.0.3
     eslint-typegen:
       specifier: 2.3.1
       version: 2.3.1
@@ -155,6 +152,9 @@ catalogs:
     ansis:
       specifier: 4.3.1
       version: 4.3.1
+    concurrently:
+      specifier: 10.0.3
+      version: 10.0.3
     eslint-config-flat-gitignore:
       specifier: 2.3.0
       version: 2.3.0
@@ -230,6 +230,9 @@ catalogs:
     eslint-plugin-yml:
       specifier: 3.5.0
       version: 3.5.0
+    file-entry-cache:
+      specifier: 8.0.0
+      version: 8.0.0
     find-up-simple:
       specifier: 1.0.1
       version: 1.0.1
@@ -322,6 +325,9 @@ importers:
       ansis:
         specifier: catalog:prod
         version: 4.3.1
+      concurrently:
+        specifier: catalog:prod
+        version: 10.0.3
       eslint-config-flat-gitignore:
         specifier: catalog:prod
         version: 2.3.0(patch_hash=c0af6384f070a0837fdab77e0920cd119c0824908f00c07ca1f27736ff81189b)(eslint@10.7.0(jiti@2.7.0))
@@ -397,6 +403,9 @@ importers:
       eslint-plugin-yml:
         specifier: catalog:prod
         version: 3.5.0(patch_hash=a0c23f5bc2638aedacbb693b99b4bc77d33a7f52fd066d636cf2f8e212b72db7)(eslint@10.7.0(jiti@2.7.0))
+      file-entry-cache:
+        specifier: catalog:prod
+        version: 8.0.0
       find-up-simple:
         specifier: catalog:prod
         version: 1.0.1
@@ -470,9 +479,6 @@ importers:
       bumpp:
         specifier: catalog:dev
         version: 11.1.0
-      concurrently:
-        specifier: catalog:dev
-        version: 10.0.3
       eslint:
         specifier: catalog:peer
         version: 10.7.0(jiti@2.7.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,6 @@ catalogs:
     "@types/semver": 7.7.1
     "@types/yargs": 17.0.35
     bumpp: 11.1.0
-    concurrently: 10.0.3
     eslint-typegen: 2.3.1
     jiti: 2.7.0
     parse-gitignore-ts: 1.0.0
@@ -83,6 +82,7 @@ catalogs:
     "@typescript-eslint/eslint-plugin": 8.64.0
     "@typescript-eslint/parser": 8.64.0
     ansis: 4.3.1
+    concurrently: 10.0.3
     eslint-config-flat-gitignore: 2.3.0
     eslint-config-prettier: 10.1.8
     eslint-flat-config-utils: 3.2.0
@@ -108,6 +108,7 @@ catalogs:
     eslint-plugin-unicorn: 72.0.0
     eslint-plugin-unused-imports: 4.4.1
     eslint-plugin-yml: 3.5.0
+    file-entry-cache: 8.0.0
     find-up-simple: 1.0.1
     globals: 17.7.0
     jsonc-eslint-parser: 3.1.0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,1 +1,0 @@
-export * from "./cli/index.ts";

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -104,12 +104,12 @@ export async function run(options: CliRunOptions = {}): Promise<undefined> {
 		}
 	}
 
-	await updatePackageJson(result);
+	await updatePackageJson(result, argumentSkipPrompt === true);
 	await updateEslintFiles(result);
 	await updateVscodeSettings(result);
 
 	log.success(ansis.green("Setup completed"));
 	outro(
-		`Now you can update the dependencies by running ${ansis.blue("pnpm install")} and run ${ansis.blue("eslint --fix")}\n`,
+		`Now you can update the dependencies by running ${ansis.blue("pnpm install")} and lint by running ${ansis.blue("pnpm lint")} (or ${ansis.blue("pnpm lint:fix")})\n`,
 	);
 }

--- a/src/cli/stages/update-package-json.ts
+++ b/src/cli/stages/update-package-json.ts
@@ -1,4 +1,4 @@
-import { log, note } from "@clack/prompts";
+import { confirm, log, note } from "@clack/prompts";
 
 import ansis from "ansis";
 import fsp from "node:fs/promises";
@@ -11,7 +11,67 @@ import { versionsMap } from "../constants-generated.ts";
 import { dependenciesMap } from "../constants.ts";
 import type { PromptResult } from "../types.ts";
 
-export async function updatePackageJson(result: PromptResult): Promise<void> {
+/** Scripts the wizard wires up so `pnpm lint` drives the hybrid runner. */
+export const LINT_SCRIPTS: Record<string, string> = {
+	"lint": "isentinel-lint",
+	"lint:fix": "isentinel-lint --fix",
+};
+
+/** Whether an existing script should be overwritten by the new value. */
+export type ConfirmOverwrite = (
+	name: string,
+	existing: string,
+	desired: string,
+) => Promise<boolean>;
+
+/** Outcome of merging {@link LINT_SCRIPTS} into a scripts block. */
+export interface ScriptMergeResult {
+	/** Names of scripts newly added because none existed. */
+	added: Array<string>;
+	/** Names of scripts overwritten after the user confirmed. */
+	overwritten: Array<string>;
+}
+
+/**
+ * Merge the lint scripts into a `scripts` block in place. Missing scripts are
+ * always added. An existing script with identical content is left untouched. An
+ * existing script with different content is preserved in skip-prompt mode, and
+ * otherwise only overwritten when {@link ConfirmOverwrite} resolves true.
+ *
+ * @param scripts - The consumer's `scripts` block, mutated in place.
+ * @param options - Skip-prompt flag and the overwrite confirmation callback.
+ * @returns Which scripts were added and which were overwritten.
+ */
+export async function mergeLintScripts(
+	scripts: Record<string, string>,
+	options: { confirmOverwrite?: ConfirmOverwrite; skipPrompt: boolean },
+): Promise<ScriptMergeResult> {
+	const added: Array<string> = [];
+	const overwritten: Array<string> = [];
+
+	for (const [name, desired] of Object.entries(LINT_SCRIPTS)) {
+		const existing = scripts[name];
+		if (existing === undefined) {
+			scripts[name] = desired;
+			added.push(name);
+			continue;
+		}
+
+		if (existing === desired || options.skipPrompt) {
+			continue;
+		}
+
+		const shouldOverwrite = await options.confirmOverwrite?.(name, existing, desired);
+		if (shouldOverwrite === true) {
+			scripts[name] = desired;
+			overwritten.push(name);
+		}
+	}
+
+	return { added, overwritten };
+}
+
+export async function updatePackageJson(result: PromptResult, skipPrompt = false): Promise<void> {
 	const cwd = process.cwd();
 
 	const pathPackageJSON = path.join(cwd, "package.json");
@@ -42,6 +102,27 @@ export async function updatePackageJson(result: PromptResult): Promise<void> {
 
 	if (addedPackages.length) {
 		note(ansis.dim(addedPackages.join(", ")), "Added packages");
+	}
+
+	parsedPackage.scripts ??= {};
+	const scripts = parsedPackage.scripts as Record<string, string>;
+	const { added, overwritten } = await mergeLintScripts(scripts, {
+		confirmOverwrite: async (name, existing, desired) => {
+			const answer = await confirm({
+				initialValue: false,
+				message: `A "${name}" script already exists ("${existing}"). Overwrite it with "${desired}"?`,
+			});
+			return answer === true;
+		},
+		skipPrompt,
+	});
+
+	const touched = [...added, ...overwritten];
+	if (touched.length) {
+		note(
+			ansis.dim(touched.map((name) => `${name}: ${scripts[name]}`).join("\n")),
+			"Lint scripts",
+		);
 	}
 
 	await fsp.writeFile(pathPackageJSON, JSON.stringify(parsedPackage, null, 2));

--- a/src/eslint/factory.ts
+++ b/src/eslint/factory.ts
@@ -3,6 +3,7 @@ import { findUpSync } from "find-up-simple";
 import { isPackageExists } from "local-pkg";
 
 import { GLOB_MARKDOWN, GLOB_ROOT } from "../globs.ts";
+import { writeHybridStatusForCwd } from "../lint-cli/hybrid-status.ts";
 import type { RuleOptions } from "../typegen.d.ts";
 import {
 	getOverrides,
@@ -568,6 +569,22 @@ export async function isentinel(
 		if (stylisticOptions !== false && enableYaml !== false) {
 			configs.push(sortCspell());
 		}
+	}
+
+	// Passively record the hybrid status so `isentinel-lint` can tell, without
+	// re-running the config, whether oxlint would double-lint every mapped rule.
+	// Best-effort and swallowed; config evaluation must never throw for this.
+	writeHybridStatusForCwd(enableOxlint);
+
+	// Stamp a marker observable from outside via `eslint --print-config`: the CLI
+	// probes for `settings["isentinel/oxlint"]` when the cached status is stale.
+	if (enableOxlint) {
+		configs.push([
+			{
+				name: "isentinel/oxlint-marker",
+				settings: { "isentinel/oxlint": true },
+			},
+		]);
 	}
 
 	configs.push(disables({ root: rootGlobs }));

--- a/src/eslint/factory.ts
+++ b/src/eslint/factory.ts
@@ -15,6 +15,7 @@ import {
 	resolvePrettierConfigOptions,
 	resolveSubOptions,
 	shouldEnableFeature,
+	typeAwareSplitFromEnvironment,
 } from "../utils.ts";
 import type { PrettierOptions } from "./configs/index.ts";
 import {
@@ -266,8 +267,16 @@ export async function isentinel(
 	const hasComplement = !enableRoblox || robloxScopedFiles !== undefined;
 	const needsComplementOverlay = enableRoblox && robloxScopedFiles !== undefined;
 
-	const typeAwareMode: TypeAwareSplitMode | undefined =
-		options.typeAware === false || options.typeAware === "only" ? options.typeAware : undefined;
+	// An explicit `typeAware` option always wins; the `ESLINT_TYPE_AWARE` env var
+	// only applies when the option is left undefined (any non-split value such as
+	// `true` still counts as explicit and disables the split).
+	let typeAwareMode: TypeAwareSplitMode | undefined;
+	if (options.typeAware === false || options.typeAware === "only") {
+		typeAwareMode = options.typeAware;
+	} else if (options.typeAware === undefined) {
+		typeAwareMode = typeAwareSplitFromEnvironment();
+	}
+
 	const typeAwareOnly = typeAwareMode === "only";
 	const typescriptOptions = resolveSubOptions(options, "typescript");
 	if (

--- a/src/eslint/types.ts
+++ b/src/eslint/types.ts
@@ -490,6 +490,12 @@ export interface OptionsConfig extends OptionsComponentExtensions, OptionsProjec
 	 * config whose name contains `type-aware` (for example via
 	 * `overridesTypeAware`) to be sorted into the `"only"` pass.
 	 *
+	 * When left `undefined`, the factory reads the `ESLINT_TYPE_AWARE`
+	 * environment variable so a wrapper CLI can drive the split: `off` behaves
+	 * as `false`, `only` behaves as `"only"`, and any other value has no effect
+	 * (`false` is a legacy alias for `off`). An explicitly passed option always
+	 * takes precedence over the environment variable.
+	 *
 	 * @default undefined - single full config
 	 */
 	typeAware?: "only" | boolean;

--- a/src/formatter-agents.ts
+++ b/src/formatter-agents.ts
@@ -1,0 +1,121 @@
+import type { ESLint } from "eslint";
+import path from "node:path";
+import process from "node:process";
+
+type AgentSeverity = "error" | "warning";
+
+interface AgentMessage {
+	readonly column: number | undefined;
+	readonly filePath: string;
+	readonly line: number | undefined;
+	readonly message: string;
+	readonly ruleId: string;
+	readonly severity: AgentSeverity;
+}
+
+function getSeverity(message: ESLint.LintResult["messages"][number]): AgentSeverity {
+	return message.fatal === true || message.severity === 2 ? "error" : "warning";
+}
+
+function getRuleId(message: ESLint.LintResult["messages"][number]): string {
+	return message.ruleId ?? "eslint";
+}
+
+function getRelativeFilePath(
+	filePath: string,
+	lintResultData: ESLint.LintResultData | undefined,
+): string {
+	const currentWorkingDirectory = lintResultData?.cwd ?? process.cwd();
+	const relativeFilePath = path.relative(currentWorkingDirectory, filePath);
+
+	return relativeFilePath.length === 0 ? filePath : relativeFilePath;
+}
+
+function compareNumbers(first = 0, second = 0): number {
+	return first - second;
+}
+
+function compareMessages(first: AgentMessage, second: AgentMessage): number {
+	const fileComparison = first.filePath.localeCompare(second.filePath);
+	if (fileComparison !== 0) {
+		return fileComparison;
+	}
+
+	const lineComparison = compareNumbers(first.line, second.line);
+	if (lineComparison !== 0) {
+		return lineComparison;
+	}
+
+	const columnComparison = compareNumbers(first.column, second.column);
+	if (columnComparison !== 0) {
+		return columnComparison;
+	}
+
+	if (first.severity !== second.severity) {
+		return first.severity === "error" ? -1 : 1;
+	}
+
+	return first.ruleId.localeCompare(second.ruleId);
+}
+
+const WHITESPACE_REGEXP = /\s+/gu;
+/**
+ * ESLint custom formatter that prints one lint message per line in a stable,
+ * agent-friendly shape.
+ *
+ * Each line reads `path:line:column: severity ruleId: message`, with message
+ * whitespace collapsed to single spaces so a diagnostic never wraps across
+ * lines. Output is sorted deterministically (file, line, column, severity,
+ * ruleId) so identical lint runs produce byte-identical output, and returns an
+ * empty string when there are no messages.
+ *
+ * @param lintResults - The per-file lint results ESLint passes to the
+ *   formatter.
+ * @param lintResultData - Optional run metadata; `cwd` is used to relativize
+ *   file paths, falling back to `process.cwd()`.
+ * @returns The formatted report, terminated by a trailing newline, or an empty
+ *   string when nothing was reported.
+ */
+export default function eslintFormatterAgents(
+	lintResults: ReadonlyArray<ESLint.LintResult>,
+	lintResultData?: ESLint.LintResultData,
+): string {
+	const messages = new Array<AgentMessage>();
+
+	for (const lintResult of lintResults) {
+		const filePath = getRelativeFilePath(lintResult.filePath, lintResultData);
+
+		for (const message of lintResult.messages) {
+			messages.push({
+				column: message.column,
+				filePath,
+				line: message.line,
+				message: normalizeMessage(message.message),
+				ruleId: getRuleId(message),
+				severity: getSeverity(message),
+			});
+		}
+	}
+
+	if (messages.length === 0) {
+		return "";
+	}
+
+	return `${messages.toSorted(compareMessages).map(formatMessage).join("\n")}\n`;
+}
+
+function normalizeMessage(message: string): string {
+	return message.replaceAll(WHITESPACE_REGEXP, " ").trim();
+}
+
+function formatMessage({
+	column,
+	filePath,
+	line,
+	message,
+	ruleId,
+	severity,
+}: AgentMessage): string {
+	const location = line === undefined ? filePath : `${filePath}:${line}:${column ?? 0}`;
+	return `${location}: ${severity} ${ruleId}: ${message}`;
+}

--- a/src/globs.ts
+++ b/src/globs.ts
@@ -1,3 +1,4 @@
+// cspell:words cjsx lintable
 export const GLOB_ROOT = [
 	"*",
 	"packages/*/*",
@@ -19,6 +20,34 @@ export const GLOB_ROOT_SRC = [
 
 export const GLOB_SRC_EXT = "{,c,m}[jt]s{,x}";
 export const GLOB_SRC = "**/*.{,c,m}[jt]s{,x}";
+
+/**
+ * The real TS/JS-family file extensions {@link GLOB_SRC_EXT} encodes (the glob
+ * additionally matches non-existent combinations such as `cjsx`). Kept next to
+ * the glob so the two are maintained together; consumed by the lint CLI to size
+ * its type-aware pass.
+ */
+export const GLOB_SRC_EXTENSIONS = ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"] as const;
+
+/**
+ * Every file extension the preset lints by default: the TS/JS family
+ * ({@link GLOB_SRC_EXTENSIONS} / {@link GLOB_SRC}) plus the other languages the
+ * config enables — JSONC ({@link GLOB_ALL_JSON}), YAML ({@link GLOB_YAML}),
+ * TOML ({@link GLOB_TOML}), Markdown ({@link GLOB_MARKDOWN}) and Lua
+ * ({@link GLOB_LUA}). Each group is bound to its glob so the list stays in step
+ * with the patterns.
+ */
+export const GLOB_LINTABLE_EXTENSIONS = [
+	...GLOB_SRC_EXTENSIONS,
+	"json",
+	"jsonc",
+	"json5",
+	"yaml",
+	"yml",
+	"toml",
+	"md",
+	"lua",
+] as const;
 
 export const GLOB_LUA = "**/*.lua{,u}";
 

--- a/src/lint-cli/affected.ts
+++ b/src/lint-cli/affected.ts
@@ -1,0 +1,233 @@
+// cspell:words tsbuildinfo typeaware buildinfo normalised stabilise
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+import type * as TypeScript from "typescript";
+
+import type { TypeAwareMode } from "./types.ts";
+
+/** Result of a builder pass over the consumer's program. */
+export interface AffectedResult {
+	/**
+	 * Absolute (OS-normalised) paths the TS builder flagged as affected,
+	 * restricted to in-project files (node_modules and lib.*.d.ts excluded).
+	 */
+	affected: Set<string>;
+	/**
+	 * True when this run established the initial builder state (no prior
+	 * buildinfo). A first run reports every file as affected, which is
+	 * meaningless for invalidation — callers persist state but skip busting.
+	 */
+	firstRun: boolean;
+}
+
+let warned = false;
+
+/**
+ * Resolve the builder incremental-state (`.tsbuildinfo`) file for a mode.
+ * Stored under `node_modules/.cache/isentinel-lint/` so it never pollutes the
+ * consumer's source tree and is cleaned with `node_modules`.
+ *
+ * @param cwd - The consumer project root.
+ * @param mode - The active ESLint type-aware mode (never `"off"` here).
+ * @returns The absolute path to the mode's buildinfo file.
+ */
+export function builderStatePath(cwd: string, mode: TypeAwareMode | undefined): string {
+	const suffix = mode === "only" ? "typeaware" : "full";
+	return path.join(cwd, "node_modules", ".cache", "isentinel-lint", `tsbuildinfo-${suffix}`);
+}
+
+/**
+ * Compute the set of files whose type-aware lint results may have changed since
+ * the previous run, using TypeScript's builder API. The builder does a native
+ * shape-hash BFS: it recomputes each dependent's emitted-`.d.ts` shape hash and
+ * stops propagating where shapes stabilise, so an implementation-only edit
+ * invalidates nothing downstream while an exported-type change invalidates its
+ * transitive importers. Files that `affectsGlobalScope` invalidate everything.
+ *
+ * Returns `undefined` when the builder path is skipped or fails (no tsconfig,
+ * `typescript` unresolvable, parse/build error) — callers then lint without
+ * invalidation. Never throws.
+ *
+ * @param cwd - The consumer project root.
+ * @param mode - The active ESLint type-aware mode.
+ * @returns The affected result, or `undefined` when skipped.
+ */
+export function computeAffectedFiles(
+	cwd: string,
+	mode: TypeAwareMode | undefined,
+): AffectedResult | undefined {
+	const ts = loadTypescript(cwd);
+	if (ts === undefined) {
+		warnOnce("typescript is not resolvable; skipping type-aware cache invalidation");
+		return undefined;
+	}
+
+	const configPath = ts.findConfigFile(cwd, (file) => ts.sys.fileExists(file), "tsconfig.json");
+	if (configPath === undefined) {
+		warnOnce("no tsconfig.json found; skipping type-aware cache invalidation");
+		return undefined;
+	}
+
+	try {
+		return runBuilder(ts, cwd, configPath, mode);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		warnOnce(`type-aware cache invalidation failed: ${message}`);
+		return undefined;
+	}
+}
+
+/**
+ * Resolve the consumer's `typescript` and load it lazily. Anchored at `cwd` so
+ * resolution walks the consumer's `node_modules` (typescript is a peer of
+ * typescript-eslint, never a dependency of this package). Using `createRequire`
+ * rather than a static import keeps typescript out of the bundle and off the
+ * load path unless the builder actually runs.
+ *
+ * @param cwd - The consumer project root to resolve from.
+ * @returns The TypeScript module, or `undefined` when it cannot be resolved.
+ */
+function loadTypescript(cwd: string): typeof TypeScript | undefined {
+	try {
+		const require = createRequire(path.join(cwd, "__isentinel-lint__.js"));
+		return require("typescript") as typeof TypeScript;
+	} catch {
+		return undefined;
+	}
+}
+
+function warnOnce(message: string): void {
+	if (warned) {
+		return;
+	}
+
+	warned = true;
+	process.stderr.write(`isentinel-lint: ${message}\n`);
+}
+
+/**
+ * Add a file to the affected set when it is an in-project file. Library
+ * declarations and dependencies live under `node_modules` and are never in the
+ * ESLint cache, so removing them would be a no-op and they would only inflate
+ * the escape-valve threshold.
+ *
+ * @param fileName - The TypeScript file name (forward-slash absolute).
+ * @param into - The accumulating affected set.
+ */
+function addProjectFile(fileName: string, into: Set<string>): void {
+	const normalized = path.normalize(fileName);
+	if (normalized.includes(`${path.sep}node_modules${path.sep}`)) {
+		return;
+	}
+
+	into.add(normalized);
+}
+
+/**
+ * Fold one affected target into the set. The builder yields a `SourceFile`
+ * for a normal affected file, or the whole `Program` when a change affects
+ * global scope (ambient/augmentation) — in which case every source file is
+ * affected.
+ *
+ * @param target - The affected `Program` or `SourceFile`.
+ * @param into - The accumulating affected set.
+ */
+function collectAffected(
+	target: TypeScript.Program | TypeScript.SourceFile,
+	into: Set<string>,
+): void {
+	if ("getSourceFiles" in target) {
+		for (const sourceFile of target.getSourceFiles()) {
+			addProjectFile(sourceFile.fileName, into);
+		}
+
+		return;
+	}
+
+	addProjectFile(target.fileName, into);
+}
+
+/**
+ * Drive the incremental builder: read prior state, drain the affected set
+ * without reporting diagnostics, then persist updated state.
+ *
+ * @param ts - The resolved TypeScript module.
+ * @param cwd - The consumer project root.
+ * @param configPath - The resolved tsconfig path.
+ * @param mode - The active ESLint type-aware mode.
+ * @returns The affected result.
+ */
+function runBuilder(
+	ts: typeof TypeScript,
+	cwd: string,
+	configPath: string,
+	mode: TypeAwareMode | undefined,
+): AffectedResult | undefined {
+	const configFile = ts.readConfigFile(configPath, (file) => ts.sys.readFile(file));
+	if (configFile.error !== undefined) {
+		warnOnce("tsconfig.json could not be read; skipping type-aware cache invalidation");
+		return undefined;
+	}
+
+	const basePath = path.dirname(configPath);
+	const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, basePath);
+	if (parsed.fileNames.length === 0) {
+		return { affected: new Set(), firstRun: false };
+	}
+
+	const buildInfoPath = builderStatePath(cwd, mode);
+	fs.mkdirSync(path.dirname(buildInfoPath), { recursive: true });
+	const firstRun = !fs.existsSync(buildInfoPath);
+
+	// Force the settings the shape-hash BFS depends on:
+	// - `declaration: true` makes the builder derive each file's shape hash from
+	//   its emitted `.d.ts` rather than raw source text, so a body-only edit
+	//   (unchanged public surface) does NOT propagate to importers. Without it,
+	//   the hash is the full-text hash and every dependent is invalidated.
+	// - `incremental: true` + `tsBuildInfoFile` persist state in OUR cache dir.
+	// - `composite`/`declarationMap` off, `noEmit` false: we DO emit so real
+	//   `.d.ts` signatures are computed, but the emit `writeFile` (below)
+	//   discards everything except the buildinfo, so nothing lands in the tree.
+	const options: TypeScript.CompilerOptions = {
+		...parsed.options,
+		composite: false,
+		declaration: true,
+		declarationMap: false,
+		emitDeclarationOnly: false,
+		incremental: true,
+		noEmit: false,
+		tsBuildInfoFile: buildInfoPath,
+	};
+
+	const host = ts.createIncrementalCompilerHost(options, ts.sys);
+	const oldProgram = ts.readBuilderProgram(options, host);
+	const builder = ts.createEmitAndSemanticDiagnosticsBuilderProgram(
+		parsed.fileNames,
+		options,
+		host,
+		oldProgram,
+	);
+
+	const affected = new Set<string>();
+	let next = builder.getSemanticDiagnosticsOfNextAffectedFile();
+	while (next !== undefined) {
+		// We deliberately discard `next.result` (the diagnostics); only the
+		// affected set matters here.
+		collectAffected(next.affected, affected);
+		next = builder.getSemanticDiagnosticsOfNextAffectedFile();
+	}
+
+	// Persist builder state by emitting ONLY the buildinfo. `program.emit` walks
+	// remaining affected files and writes the `.tsbuildinfo`; the writeFile
+	// callback swallows every other output so no JS/`.d.ts` reaches disk.
+	const normalizedBuildInfo = path.normalize(buildInfoPath);
+	builder.emit(undefined, (fileName, data) => {
+		if (path.normalize(fileName) === normalizedBuildInfo) {
+			fs.writeFileSync(fileName, data);
+		}
+	});
+
+	return { affected, firstRun };
+}

--- a/src/lint-cli/affected.ts
+++ b/src/lint-cli/affected.ts
@@ -172,6 +172,11 @@ function runBuilder(
 	}
 
 	const basePath = path.dirname(configPath);
+	// Known limitation: `parseJsonConfigFileContent` does not follow project
+	// references, so a solution-style/project-reference tsconfig yields an empty
+	// `fileNames`. Builder invalidation then becomes a silent no-op and the
+	// runner falls back to plain mtime dirtiness — lint results stay correct,
+	// only cross-file type invalidation is skipped.
 	const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, basePath);
 	if (parsed.fileNames.length === 0) {
 		return { affected: new Set(), firstRun: false };

--- a/src/lint-cli/cache.ts
+++ b/src/lint-cli/cache.ts
@@ -6,6 +6,73 @@ import { ALL_CACHE_FILES } from "./constants.ts";
 import { toPosix } from "./paths.ts";
 
 /**
+ * A loaded ESLint cache, reused for both the dirty query and surgical removal.
+ */
+export interface DirtyCache {
+	/**
+	 * The candidate files that changed or are absent from the cache. Reads
+	 * non-destructively — it never reconciles or writes the cache back.
+	 *
+	 * @param files - Absolute paths of the candidate files.
+	 * @returns The files that need re-linting.
+	 */
+	getUpdatedFiles: (files: Array<string>) => Array<string>;
+	/**
+	 * Surgically drop the given files so they are re-linted next run, leaving
+	 * every other entry intact, and persist the result.
+	 *
+	 * @param files - Absolute paths whose cache entries should be removed.
+	 * @returns The number of entries actually removed.
+	 */
+	removeEntries: (files: Iterable<string>) => number;
+}
+
+/**
+ * Compute the newest modification time across the given files. Callers hash the
+ * cache-bust set once per run and compare each pass's cache mtime against the
+ * result, rather than re-reading every bust file's mtime per pass.
+ *
+ * @param files - Absolute paths to stat.
+ * @returns The newest mtime in milliseconds, or `undefined` when none exist.
+ */
+export function maxMtimeMs(files: Iterable<string>): number | undefined {
+	let newest: number | undefined;
+	for (const file of files) {
+		const mtime = safeMtimeMs(file);
+		if (mtime !== undefined && (newest === undefined || mtime > newest)) {
+			newest = mtime;
+		}
+	}
+
+	return newest;
+}
+
+/**
+ * Whether the cache file is older than the newest cache-bust modification. A
+ * missing cache file (or no bust files) returns false: the caller already
+ * treats an absent cache as "everything is dirty".
+ *
+ * @param cacheFilePath - The ESLint cache file to compare against.
+ * @param newestBustMtimeMs - The newest bust-file mtime (see {@link maxMtimeMs}).
+ * @returns Whether the cache is stale.
+ */
+export function isCacheStale(
+	cacheFilePath: string,
+	newestBustMtimeMs: number | undefined,
+): boolean {
+	if (newestBustMtimeMs === undefined) {
+		return false;
+	}
+
+	const cacheMtime = safeMtimeMs(cacheFilePath);
+	if (cacheMtime === undefined) {
+		return false;
+	}
+
+	return newestBustMtimeMs > cacheMtime;
+}
+
+/**
  * Return true when any cache-bust file has been modified more recently than
  * the given cache file. A missing cache file returns false: the caller already
  * treats an absent cache as "everything is dirty".
@@ -15,15 +82,7 @@ import { toPosix } from "./paths.ts";
  * @returns Whether the cache is stale.
  */
 export function isCacheBusted(cacheFilePath: string, bustFiles: Array<string>): boolean {
-	const cacheMtime = safeMtimeMs(cacheFilePath);
-	if (cacheMtime === undefined) {
-		return false;
-	}
-
-	return bustFiles.some((file) => {
-		const mtime = safeMtimeMs(file);
-		return mtime !== undefined && mtime > cacheMtime;
-	});
+	return isCacheStale(cacheFilePath, maxMtimeMs(bustFiles));
 }
 
 /**
@@ -42,9 +101,43 @@ export function clearAllCaches(cwd: string): void {
 }
 
 /**
+ * Normalize a path for cache-key comparison: absolute, forward-slash and
+ * lower-cased. TypeScript emits forward-slash paths while ESLint keys the cache
+ * with OS-native ones, and Windows paths are case-insensitive — this collapses
+ * all of those into a single comparable form.
+ *
+ * @param filePath - The path to normalize.
+ * @returns The canonical key.
+ */
+export function normalizePath(filePath: string): string {
+	return toPosix(path.resolve(filePath)).toLowerCase();
+}
+
+/**
+ * Open an ESLint cache for reuse, or `undefined` when the file is missing (the
+ * caller then treats every target file as dirty). The returned handle backs
+ * both {@link DirtyCache.getUpdatedFiles} and {@link DirtyCache.removeEntries}
+ * so a pass parses the cache once instead of twice.
+ *
+ * @param cacheFilePath - The ESLint cache file to open.
+ * @param useChecksum - Compare by content checksum instead of metadata.
+ * @returns The loaded cache, or `undefined` when the file does not exist.
+ */
+export function openCache(cacheFilePath: string, useChecksum: boolean): DirtyCache | undefined {
+	if (!fs.existsSync(cacheFilePath)) {
+		return undefined;
+	}
+
+	const cache = fileEntryCache.createFromFile(cacheFilePath, useChecksum);
+	return {
+		getUpdatedFiles: (files) => cache.getUpdatedFiles(files),
+		removeEntries: (files) => removeEntriesFrom(cache, files),
+	};
+}
+
+/**
  * List the files ESLint will actually re-lint: those changed or absent from
- * the cache. Reads the cache non-destructively — it never reconciles or writes
- * it back. When the cache file is missing, every target file is dirty.
+ * the cache. When the cache file is missing, every target file is dirty.
  *
  * @param cacheFilePath - The ESLint cache file to read.
  * @param files - Absolute paths of the candidate files.
@@ -56,25 +149,7 @@ export function listDirtyFiles(
 	files: Array<string>,
 	useChecksum: boolean,
 ): Array<string> {
-	if (!fs.existsSync(cacheFilePath)) {
-		return [...files];
-	}
-
-	const cache = fileEntryCache.createFromFile(cacheFilePath, useChecksum);
-	return cache.getUpdatedFiles(files);
-}
-
-/**
- * Normalize a path for cache-key comparison: absolute, forward-slash and
- * lower-cased. TypeScript emits forward-slash paths while ESLint keys the cache
- * with OS-native ones, and Windows paths are case-insensitive — this collapses
- * all of those into a single comparable form.
- *
- * @param filePath - The path to normalize.
- * @returns The canonical key.
- */
-export function normalizePath(filePath: string): string {
-	return toPosix(path.resolve(filePath)).toLowerCase();
+	return openCache(cacheFilePath, useChecksum)?.getUpdatedFiles(files) ?? [...files];
 }
 
 /**
@@ -93,11 +168,21 @@ export function normalizePath(filePath: string): string {
  * @returns The number of entries actually removed.
  */
 export function removeCacheEntries(cacheFilePath: string, files: Iterable<string>): number {
-	if (!fs.existsSync(cacheFilePath)) {
-		return 0;
-	}
+	return openCache(cacheFilePath, false)?.removeEntries(files) ?? 0;
+}
 
-	const cache = fileEntryCache.createFromFile(cacheFilePath, false);
+function safeMtimeMs(filePath: string): number | undefined {
+	try {
+		return fs.statSync(filePath).mtimeMs;
+	} catch {
+		return undefined;
+	}
+}
+
+function removeEntriesFrom(
+	cache: ReturnType<typeof fileEntryCache.createFromFile>,
+	files: Iterable<string>,
+): number {
 	const keyByNormalized = new Map<string, string>();
 	for (const key of cache.cache.keys()) {
 		keyByNormalized.set(normalizePath(key), key);
@@ -114,16 +199,11 @@ export function removeCacheEntries(cacheFilePath: string, files: Iterable<string
 
 	if (removed > 0) {
 		// noPrune: keep every entry we did not explicitly remove.
+		// `getUpdatedFiles` only reads the flat cache (never `setKey`), so
+		// reusing a handle that already ran the dirty query persists the same
+		// keys.
 		cache.cache.save(true);
 	}
 
 	return removed;
-}
-
-function safeMtimeMs(filePath: string): number | undefined {
-	try {
-		return fs.statSync(filePath).mtimeMs;
-	} catch {
-		return undefined;
-	}
 }

--- a/src/lint-cli/cache.ts
+++ b/src/lint-cli/cache.ts
@@ -41,9 +41,31 @@ export function clearAllCaches(cwd: string): void {
 }
 
 /**
- * Count the files ESLint will actually re-lint: those changed or absent from
+ * List the files ESLint will actually re-lint: those changed or absent from
  * the cache. Reads the cache non-destructively — it never reconciles or writes
  * it back. When the cache file is missing, every target file is dirty.
+ *
+ * @param cacheFilePath - The ESLint cache file to read.
+ * @param files - Absolute paths of the candidate files.
+ * @param useChecksum - Compare by content checksum instead of metadata.
+ * @returns The candidate files that need re-linting.
+ */
+export function listDirtyFiles(
+	cacheFilePath: string,
+	files: Array<string>,
+	useChecksum: boolean,
+): Array<string> {
+	if (!fs.existsSync(cacheFilePath)) {
+		return [...files];
+	}
+
+	const cache = fileEntryCache.createFromFile(cacheFilePath, useChecksum);
+	return cache.getUpdatedFiles(files);
+}
+
+/**
+ * Count the files ESLint will actually re-lint. Thin wrapper over
+ * {@link listDirtyFiles}; see it for cache-read semantics.
  *
  * @param cacheFilePath - The ESLint cache file to read.
  * @param files - Absolute paths of the candidate files.
@@ -55,12 +77,63 @@ export function countDirtyFiles(
 	files: Array<string>,
 	useChecksum: boolean,
 ): number {
+	return listDirtyFiles(cacheFilePath, files, useChecksum).length;
+}
+
+/**
+ * Normalize a path for cache-key comparison: absolute, forward-slash and
+ * lower-cased. TypeScript emits forward-slash paths while ESLint keys the cache
+ * with OS-native ones, and Windows paths are case-insensitive — this collapses
+ * all of those into a single comparable form.
+ *
+ * @param filePath - The path to normalize.
+ * @returns The canonical key.
+ */
+export function normalizePath(filePath: string): string {
+	return path.resolve(filePath).split(path.sep).join("/").toLowerCase();
+}
+
+/**
+ * Surgically drop the given files from an ESLint cache so they are re-linted on
+ * the next run, leaving every other entry intact. This is the only write path
+ * to the ESLint cache besides the whole-cache bust; used to invalidate files
+ * whose type-aware results may have changed because a file they import changed.
+ *
+ * Matching is path-normalized (case-insensitive, separator-agnostic) because
+ * TypeScript reports forward-slash paths while ESLint keys the cache with the
+ * OS-native paths it linted. Persists via the underlying flat-cache with
+ * pruning disabled, so untouched (unvisited) entries survive.
+ *
+ * @param cacheFilePath - The ESLint cache file to rewrite.
+ * @param files - Absolute paths whose cache entries should be removed.
+ * @returns The number of entries actually removed.
+ */
+export function removeCacheEntries(cacheFilePath: string, files: Iterable<string>): number {
 	if (!fs.existsSync(cacheFilePath)) {
-		return files.length;
+		return 0;
 	}
 
-	const cache = fileEntryCache.createFromFile(cacheFilePath, useChecksum);
-	return cache.getUpdatedFiles(files).length;
+	const cache = fileEntryCache.createFromFile(cacheFilePath, false);
+	const keyByNormalized = new Map<string, string>();
+	for (const key of cache.cache.keys()) {
+		keyByNormalized.set(normalizePath(key), key);
+	}
+
+	let removed = 0;
+	for (const file of files) {
+		const key = keyByNormalized.get(normalizePath(file));
+		if (key !== undefined) {
+			cache.removeEntry(key);
+			removed += 1;
+		}
+	}
+
+	if (removed > 0) {
+		// noPrune: keep every entry we did not explicitly remove.
+		cache.cache.save(true);
+	}
+
+	return removed;
 }
 
 function safeMtimeMs(filePath: string): number | undefined {

--- a/src/lint-cli/cache.ts
+++ b/src/lint-cli/cache.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { ALL_CACHE_FILES } from "./constants.ts";
+import { toPosix } from "./paths.ts";
 
 /**
  * Return true when any cache-bust file has been modified more recently than
@@ -64,23 +65,6 @@ export function listDirtyFiles(
 }
 
 /**
- * Count the files ESLint will actually re-lint. Thin wrapper over
- * {@link listDirtyFiles}; see it for cache-read semantics.
- *
- * @param cacheFilePath - The ESLint cache file to read.
- * @param files - Absolute paths of the candidate files.
- * @param useChecksum - Compare by content checksum instead of metadata.
- * @returns The number of files that need re-linting.
- */
-export function countDirtyFiles(
-	cacheFilePath: string,
-	files: Array<string>,
-	useChecksum: boolean,
-): number {
-	return listDirtyFiles(cacheFilePath, files, useChecksum).length;
-}
-
-/**
  * Normalize a path for cache-key comparison: absolute, forward-slash and
  * lower-cased. TypeScript emits forward-slash paths while ESLint keys the cache
  * with OS-native ones, and Windows paths are case-insensitive — this collapses
@@ -90,7 +74,7 @@ export function countDirtyFiles(
  * @returns The canonical key.
  */
 export function normalizePath(filePath: string): string {
-	return path.resolve(filePath).split(path.sep).join("/").toLowerCase();
+	return toPosix(path.resolve(filePath)).toLowerCase();
 }
 
 /**

--- a/src/lint-cli/cache.ts
+++ b/src/lint-cli/cache.ts
@@ -128,6 +128,10 @@ export function openCache(cacheFilePath: string, useChecksum: boolean): DirtyCac
 		return undefined;
 	}
 
+	// Reusing one handle for both getUpdatedFiles and removeEntries is safe:
+	// verified against file-entry-cache@8 that getUpdatedFiles compares existing
+	// entries without mutating the persisted store (nothing calls setKey), and
+	// removeEntries' save(true) writes that store minus the removed keys.
 	const cache = fileEntryCache.createFromFile(cacheFilePath, useChecksum);
 	return {
 		getUpdatedFiles: (files) => cache.getUpdatedFiles(files),

--- a/src/lint-cli/cache.ts
+++ b/src/lint-cli/cache.ts
@@ -1,0 +1,72 @@
+import fileEntryCache from "file-entry-cache";
+import fs from "node:fs";
+import path from "node:path";
+
+import { ALL_CACHE_FILES } from "./constants.ts";
+
+/**
+ * Return true when any cache-bust file has been modified more recently than
+ * the given cache file. A missing cache file returns false: the caller already
+ * treats an absent cache as "everything is dirty".
+ *
+ * @param cacheFilePath - The ESLint cache file to compare against.
+ * @param bustFiles - Files whose modification invalidates the cache.
+ * @returns Whether the cache is stale.
+ */
+export function isCacheBusted(cacheFilePath: string, bustFiles: Array<string>): boolean {
+	const cacheMtime = safeMtimeMs(cacheFilePath);
+	if (cacheMtime === undefined) {
+		return false;
+	}
+
+	return bustFiles.some((file) => {
+		const mtime = safeMtimeMs(file);
+		return mtime !== undefined && mtime > cacheMtime;
+	});
+}
+
+/**
+ * Delete every ESLint cache file the runner manages.
+ *
+ * @param cwd - The working directory containing the cache files.
+ */
+export function clearAllCaches(cwd: string): void {
+	for (const name of ALL_CACHE_FILES) {
+		try {
+			fs.rmSync(path.resolve(cwd, name), { force: true });
+		} catch {
+			// Best effort; ESLint will rebuild the cache regardless.
+		}
+	}
+}
+
+/**
+ * Count the files ESLint will actually re-lint: those changed or absent from
+ * the cache. Reads the cache non-destructively — it never reconciles or writes
+ * it back. When the cache file is missing, every target file is dirty.
+ *
+ * @param cacheFilePath - The ESLint cache file to read.
+ * @param files - Absolute paths of the candidate files.
+ * @param useChecksum - Compare by content checksum instead of metadata.
+ * @returns The number of files that need re-linting.
+ */
+export function countDirtyFiles(
+	cacheFilePath: string,
+	files: Array<string>,
+	useChecksum: boolean,
+): number {
+	if (!fs.existsSync(cacheFilePath)) {
+		return files.length;
+	}
+
+	const cache = fileEntryCache.createFromFile(cacheFilePath, useChecksum);
+	return cache.getUpdatedFiles(files).length;
+}
+
+function safeMtimeMs(filePath: string): number | undefined {
+	try {
+		return fs.statSync(filePath).mtimeMs;
+	} catch {
+		return undefined;
+	}
+}

--- a/src/lint-cli/command.ts
+++ b/src/lint-cli/command.ts
@@ -4,8 +4,12 @@ import type {
 	LintCliOptions,
 	OxlintComposeContext,
 } from "./types.ts";
+import { CliError } from "./types.ts";
 
-const SAFE_TOKEN = /^[\w@%+=:,./-]+$/;
+// `%` is deliberately excluded: cmd.exe expands `%VAR%` even inside double
+// quotes, so a `%` token cannot be made safe by quoting on the Windows shell
+// path (see `buildShellCommand`).
+const SAFE_TOKEN = /^[\w@+=:,./-]+$/;
 
 /**
  * Split a raw argument string into tokens, honouring single and double quotes
@@ -118,8 +122,14 @@ export function composeEslintCommand(
 
 	args.push(...options.eslintArgs, ...context.paths);
 
-	const environment: Record<string, string> =
-		context.typeAwareEnv !== undefined ? { ESLINT_TYPE_AWARE: context.typeAwareEnv } : {};
+	// Always control ESLINT_TYPE_AWARE explicitly: set it for the fast/typed
+	// passes, and set it to `undefined` for the full pass so an inherited value
+	// (a user-exported ESLINT_TYPE_AWARE) is REMOVED rather than leaked — a leak
+	// would make the factory split the full config (e.g. --fix applying only
+	// type-aware fixes).
+	const environment: Record<string, string | undefined> = {
+		ESLINT_TYPE_AWARE: context.typeAwareEnv,
+	};
 
 	return { args, bin: "eslint", env: environment, label: context.eslintLabel };
 }
@@ -133,8 +143,10 @@ export function composeEslintCommand(
  * @returns The shell-equivalent command line.
  */
 export function formatCommandLine(command: ChildCommand): string {
+	// `undefined` values mean "unset this variable" (see ChildCommand.env); they
+	// carry no shell-prefix representation, so they are omitted from the line.
 	const environmentPrefix = Object.entries(command.env)
-		.map(([key, value]) => `${key}=${quotePosix(value)}`)
+		.flatMap(([key, value]) => (value === undefined ? [] : [`${key}=${quotePosix(value)}`]))
 		.join(" ");
 	const body = [command.bin, ...command.args].map(quotePosix).join(" ");
 	return environmentPrefix.length > 0 ? `${environmentPrefix} ${body}` : body;
@@ -156,8 +168,22 @@ export function buildShellCommand(
 	args: Array<string>,
 	platform: NodeJS.Platform,
 ): string {
+	const tokens = [nodePath, binJsPath, ...args];
+	if (platform === "win32") {
+		// concurrently shells through cmd.exe, which expands `%VAR%` even inside
+		// double quotes — no quoting can escape it, so refuse rather than
+		// silently corrupt the argument.
+		const offending = tokens.find((token) => token.includes("%"));
+		if (offending !== undefined) {
+			throw new CliError(
+				`Cannot safely pass "${offending}" to cmd.exe: "%" triggers environment-` +
+					"variable expansion even inside quotes. Remove it, or run the tool directly.",
+			);
+		}
+	}
+
 	const quote = platform === "win32" ? quoteWindows : quotePosix;
-	return [nodePath, binJsPath, ...args].map(quote).join(" ");
+	return tokens.map(quote).join(" ");
 }
 
 function quotePosix(token: string): string {

--- a/src/lint-cli/command.ts
+++ b/src/lint-cli/command.ts
@@ -1,4 +1,9 @@
-import type { ChildCommand, ComposeContext, LintCliOptions } from "./types.ts";
+import type {
+	ChildCommand,
+	ComposeContext,
+	LintCliOptions,
+	OxlintComposeContext,
+} from "./types.ts";
 
 const SAFE_TOKEN = /^[\w@%+=:,./-]+$/;
 
@@ -62,7 +67,7 @@ export function splitArgs(input: string): Array<string> {
  */
 export function composeOxlintCommand(
 	options: LintCliOptions,
-	context: ComposeContext,
+	context: OxlintComposeContext,
 ): ChildCommand {
 	const args: Array<string> = [];
 	if (options.agents) {

--- a/src/lint-cli/command.ts
+++ b/src/lint-cli/command.ts
@@ -114,9 +114,9 @@ export function composeEslintCommand(
 	args.push(...options.eslintArgs, ...context.paths);
 
 	const environment: Record<string, string> =
-		options.typeAware !== undefined ? { ESLINT_TYPE_AWARE: options.typeAware } : {};
+		context.typeAwareEnv !== undefined ? { ESLINT_TYPE_AWARE: context.typeAwareEnv } : {};
 
-	return { args, bin: "eslint", env: environment, label: "eslint" };
+	return { args, bin: "eslint", env: environment, label: context.eslintLabel };
 }
 
 /**

--- a/src/lint-cli/command.ts
+++ b/src/lint-cli/command.ts
@@ -1,0 +1,172 @@
+import type { ChildCommand, ComposeContext, LintCliOptions } from "./types.ts";
+
+const SAFE_TOKEN = /^[\w@%+=:,./-]+$/;
+
+/**
+ * Split a raw argument string into tokens, honouring single and double quotes
+ * so values such as `--rule "no-console: error"` survive as one argument.
+ *
+ * @param input - The raw argument string to split.
+ * @returns The parsed argument tokens.
+ */
+export function splitArgs(input: string): Array<string> {
+	const tokens: Array<string> = [];
+	let current = "";
+	let quote: "'" | '"' | undefined;
+	let hasToken = false;
+
+	for (const char of input) {
+		if (quote !== undefined) {
+			if (char === quote) {
+				quote = undefined;
+			} else {
+				current += char;
+			}
+
+			continue;
+		}
+
+		if (char === '"' || char === "'") {
+			quote = char;
+			hasToken = true;
+			continue;
+		}
+
+		if (char === " " || char === "\t" || char === "\n") {
+			if (hasToken) {
+				tokens.push(current);
+				current = "";
+				hasToken = false;
+			}
+
+			continue;
+		}
+
+		current += char;
+		hasToken = true;
+	}
+
+	if (hasToken) {
+		tokens.push(current);
+	}
+
+	return tokens;
+}
+
+/**
+ * Compose the oxlint child command.
+ *
+ * @param options - The parsed CLI options.
+ * @param context - The resolved composition context.
+ * @returns The oxlint child command.
+ */
+export function composeOxlintCommand(
+	options: LintCliOptions,
+	context: ComposeContext,
+): ChildCommand {
+	const args: Array<string> = [];
+	if (options.agents) {
+		args.push("--format", "agent");
+	}
+
+	if (context.oxlintTypeAware) {
+		args.push("--type-aware");
+	}
+
+	if (options.fix) {
+		args.push("--fix");
+	}
+
+	args.push(...options.oxlintArgs, ...context.paths);
+	return { args, bin: "oxlint", env: {}, label: "oxc" };
+}
+
+/**
+ * Compose the ESLint child command.
+ *
+ * @param options - The parsed CLI options.
+ * @param context - The resolved composition context.
+ * @returns The ESLint child command.
+ */
+export function composeEslintCommand(
+	options: LintCliOptions,
+	context: ComposeContext,
+): ChildCommand {
+	const args: Array<string> = [];
+	if (options.cache) {
+		args.push("--cache", "--cache-location", context.cacheLocation);
+	}
+
+	args.push("--no-warn-ignored", "--concurrency", String(context.concurrency));
+
+	if (options.cache && context.ci) {
+		args.push("--cache-strategy", "content");
+	}
+
+	if (options.agents) {
+		args.push("--format", context.agentsFormatterPath);
+	}
+
+	if (options.fix) {
+		args.push("--fix");
+	}
+
+	args.push(...options.eslintArgs, ...context.paths);
+
+	const environment: Record<string, string> =
+		options.typeAware !== undefined ? { ESLINT_TYPE_AWARE: options.typeAware } : {};
+
+	return { args, bin: "eslint", env: environment, label: "eslint" };
+}
+
+/**
+ * Render a command as a shell-equivalent line (env prefix + logical binary +
+ * arguments) for `--print`. Uses POSIX quoting for stable, cross-platform
+ * output.
+ *
+ * @param command - The child command to render.
+ * @returns The shell-equivalent command line.
+ */
+export function formatCommandLine(command: ChildCommand): string {
+	const environmentPrefix = Object.entries(command.env)
+		.map(([key, value]) => `${key}=${quotePosix(value)}`)
+		.join(" ");
+	const body = [command.bin, ...command.args].map(quotePosix).join(" ");
+	return environmentPrefix.length > 0 ? `${environmentPrefix} ${body}` : body;
+}
+
+/**
+ * Build the command string concurrently runs through a shell. The tool is
+ * launched via `node <binJs>` so no `.cmd`/`.ps1` shim quoting is involved.
+ *
+ * @param nodePath - Absolute path to the Node executable.
+ * @param binJsPath - Absolute path to the tool's JavaScript entry.
+ * @param args - The tool arguments.
+ * @param platform - The platform whose shell quoting rules to apply.
+ * @returns The shell command string.
+ */
+export function buildShellCommand(
+	nodePath: string,
+	binJsPath: string,
+	args: Array<string>,
+	platform: NodeJS.Platform,
+): string {
+	const quote = platform === "win32" ? quoteWindows : quotePosix;
+	return [nodePath, binJsPath, ...args].map(quote).join(" ");
+}
+
+function quotePosix(token: string): string {
+	if (token.length > 0 && SAFE_TOKEN.test(token)) {
+		return token;
+	}
+
+	return `'${token.replaceAll("'", "'\\''")}'`;
+}
+
+function quoteWindows(token: string): string {
+	if (token.length > 0 && SAFE_TOKEN.test(token)) {
+		return token;
+	}
+
+	return `"${token.replaceAll('"', '\\"')}"`;
+}

--- a/src/lint-cli/concurrency.ts
+++ b/src/lint-cli/concurrency.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_FAST_FILES_PER_WORKER, DEFAULT_FILES_PER_WORKER } from "./constants.ts";
+import { parseBoundedInteger } from "./parse.ts";
 
 /** Inputs to the (pure) worker-count heuristic. */
 export interface WorkerHeuristicInput {
@@ -81,14 +82,5 @@ export function computeWorkerCount({
 }
 
 function parsePositiveInteger(value: string | undefined): number | undefined {
-	if (value === undefined) {
-		return undefined;
-	}
-
-	const parsed = Number(value.trim());
-	if (!Number.isInteger(parsed) || parsed < 1) {
-		return undefined;
-	}
-
-	return parsed;
+	return parseBoundedInteger(value, 1);
 }

--- a/src/lint-cli/concurrency.ts
+++ b/src/lint-cli/concurrency.ts
@@ -1,0 +1,79 @@
+import { DEFAULT_FILES_PER_WORKER } from "./constants.ts";
+
+/** Inputs to the (pure) worker-count heuristic. */
+export interface WorkerHeuristicInput {
+	/** Number of files ESLint will actually re-lint. */
+	dirtyCount: number;
+	/** Target files handled by a single worker before adding another. */
+	filesPerWorker: number;
+	/** Upper bound on worker count. */
+	maxWorkers: number;
+}
+
+/** Resolved limits derived from the environment and available CPUs. */
+export interface WorkerLimits {
+	filesPerWorker: number;
+	maxWorkers: number;
+}
+
+/**
+ * Derive the worker limits from environment overrides, falling back to the
+ * default files-per-worker and a quarter of the available parallelism.
+ *
+ * Type-aware linting spends roughly `filesPerWorker^1.46` per worker with a
+ * fixed ~6.5s TypeScript program construction cost, so the sweet spot is
+ * ~200-400 files per worker rather than ESLint's syntax-tuned `auto`.
+ *
+ * @param environment - The environment variables to read overrides from.
+ * @param availableParallelism - The number of available CPUs.
+ * @returns The resolved worker limits.
+ */
+export function resolveWorkerLimits(
+	environment: NodeJS.ProcessEnv,
+	availableParallelism: number,
+): WorkerLimits {
+	const filesPerWorker =
+		parsePositiveInteger(environment["FILES_PER_WORKER"]) ?? DEFAULT_FILES_PER_WORKER;
+	const maxWorkers =
+		parsePositiveInteger(environment["LINT_MAX_WORKERS"]) ??
+		Math.floor(availableParallelism / 4);
+
+	return { filesPerWorker, maxWorkers };
+}
+
+/**
+ * Compute ESLint's `--concurrency` value. Returns `"off"` when a single worker
+ * (or fewer) would be used, since parallelism only pays off past that point.
+ *
+ * @param input - The dirty count and worker limits.
+ * @returns The worker count, or `"off"` to disable parallelism.
+ */
+export function computeWorkerCount({
+	dirtyCount,
+	filesPerWorker,
+	maxWorkers,
+}: WorkerHeuristicInput): "off" | number {
+	if (dirtyCount <= 0 || filesPerWorker <= 0 || maxWorkers <= 0) {
+		return "off";
+	}
+
+	const workers = Math.min(Math.ceil(dirtyCount / filesPerWorker), maxWorkers);
+	if (workers < 2) {
+		return "off";
+	}
+
+	return workers;
+}
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	const parsed = Number(value.trim());
+	if (!Number.isInteger(parsed) || parsed < 1) {
+		return undefined;
+	}
+
+	return parsed;
+}

--- a/src/lint-cli/concurrency.ts
+++ b/src/lint-cli/concurrency.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_FILES_PER_WORKER } from "./constants.ts";
+import { DEFAULT_FAST_FILES_PER_WORKER, DEFAULT_FILES_PER_WORKER } from "./constants.ts";
 
 /** Inputs to the (pure) worker-count heuristic. */
 export interface WorkerHeuristicInput {
@@ -39,6 +39,21 @@ export function resolveWorkerLimits(
 		Math.floor(availableParallelism / 4);
 
 	return { filesPerWorker, maxWorkers };
+}
+
+/**
+ * Resolve the fast pass's files-per-worker, honouring the
+ * `FAST_FILES_PER_WORKER` override. The fast pass lints each file syntactically
+ * in isolation, so its break-even worker size is far higher than the type-aware
+ * pass (see {@link DEFAULT_FAST_FILES_PER_WORKER}).
+ *
+ * @param environment - The environment variables to read the override from.
+ * @returns The resolved fast-pass files-per-worker.
+ */
+export function resolveFastFilesPerWorker(environment: NodeJS.ProcessEnv): number {
+	return (
+		parsePositiveInteger(environment["FAST_FILES_PER_WORKER"]) ?? DEFAULT_FAST_FILES_PER_WORKER
+	);
 }
 
 /**

--- a/src/lint-cli/constants.ts
+++ b/src/lint-cli/constants.ts
@@ -1,0 +1,61 @@
+// cspell:words lintable typeaware
+import type { TypeAwareMode } from "./types.ts";
+
+/** Default number of files a single ESLint worker should handle. */
+export const DEFAULT_FILES_PER_WORKER = 350;
+
+/** ESLint cache file used when no type-aware mode is selected. */
+export const CACHE_FILE_DEFAULT = ".eslintcache";
+
+/** ESLint cache file used for `--type-aware=off` (syntactic-only) runs. */
+export const CACHE_FILE_FAST = ".eslintcache-fast";
+
+/** ESLint cache file used for `--type-aware=only` runs. */
+export const CACHE_FILE_TYPE_AWARE = ".eslintcache-typeaware";
+
+/** Every ESLint cache file the runner manages, cleared on a config change. */
+export const ALL_CACHE_FILES = [
+	CACHE_FILE_DEFAULT,
+	CACHE_FILE_FAST,
+	CACHE_FILE_TYPE_AWARE,
+] as const;
+
+/** File extensions ESLint/oxlint are expected to lint. */
+export const LINTABLE_EXTENSIONS = ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"] as const;
+
+/**
+ * Glob patterns whose modification invalidates every ESLint cache. A bare
+ * `*` never crosses a path separator, so single-segment patterns (for example
+ * `*.config.*` or the lockfiles) only match root-level files, while
+ * `**` patterns match at any depth.
+ */
+export const CACHE_BUST_PATTERNS = [
+	"eslint.config.*",
+	"*.config.*",
+	"**/tsconfig*.json",
+	".oxlintrc*",
+	".prettierrc*",
+	"pnpm-lock.yaml",
+	"package-lock.json",
+	"yarn.lock",
+	"bun.lock",
+	"bun.lockb",
+] as const;
+
+/**
+ * Resolve the ESLint cache file for the given type-aware mode.
+ *
+ * @param mode - The active type-aware mode, if any.
+ * @returns The cache file name for that mode.
+ */
+export function cacheFileForMode(mode: TypeAwareMode | undefined): string {
+	if (mode === "off") {
+		return CACHE_FILE_FAST;
+	}
+
+	if (mode === "only") {
+		return CACHE_FILE_TYPE_AWARE;
+	}
+
+	return CACHE_FILE_DEFAULT;
+}

--- a/src/lint-cli/constants.ts
+++ b/src/lint-cli/constants.ts
@@ -1,5 +1,5 @@
 // cspell:words lintable typeaware undercounting
-import type { TypeAwareMode } from "./types.ts";
+import { parseBoundedInteger } from "./parse.ts";
 
 /** Default number of files a single ESLint worker should handle. */
 export const DEFAULT_FILES_PER_WORKER = 350;
@@ -36,51 +36,22 @@ export const ALL_CACHE_FILES = [
 	CACHE_FILE_TYPE_AWARE,
 ] as const;
 
-/**
- * File extensions the preset lints by default. Covers the TS/JS family plus
- * JSONC (including package.json), YAML, TOML, Markdown and Lua, which the
- * ESLint config enables unless the consumer opts out (see the enable* gates in
- * `src/eslint/factory.ts`).
- *
- * Trade-off. When a consumer disables one of these features those files never
- * enter the ESLint cache, so they count as dirty every run and mildly inflate
- * the worker count. That is harmless (a worker of cheap non-TS files never
- * builds a TS program) and preferable to undercounting, so there is no knob.
- */
-export const LINTABLE_EXTENSIONS = [
-	"ts",
-	"tsx",
-	"mts",
-	"cts",
-	"js",
-	"jsx",
-	"mjs",
-	"cjs",
-	"json",
-	"jsonc",
-	"json5",
-	"yaml",
-	"yml",
-	"toml",
-	"md",
-	"lua",
-] as const;
-
-/**
- * The TS/JS-family extensions the type-aware (`--type-aware=only`) config
- * lints. Only these files ever enter the type-aware cache, so the typed pass
- * sizes its worker count from just this subset of the dirty set.
- */
-export const TYPE_AWARE_EXTENSIONS = [
-	"ts",
-	"tsx",
-	"mts",
-	"cts",
-	"js",
-	"jsx",
-	"mjs",
-	"cjs",
-] as const;
+// The extension arrays live in `src/globs.ts` next to the glob patterns they
+// mirror, and are re-exported here under the names the lint CLI uses:
+//
+// - LINTABLE_EXTENSIONS (GLOB_LINTABLE_EXTENSIONS): every extension the preset
+//   lints by default — TS/JS family plus JSONC, YAML, TOML, Markdown and Lua.
+//   A consumer that disables one of these features never caches those files, so
+//   they count as dirty every run and mildly inflate the worker count. That is
+//   harmless (a worker of cheap non-TS files never builds a TS program) and
+//   preferable to undercounting, so there is no knob.
+// - TYPE_AWARE_EXTENSIONS (GLOB_SRC_EXTENSIONS): the TS/JS-family subset the
+//   type-aware (`--type-aware=only`) config lints and the only files that ever
+//   enter the type-aware cache, so the typed pass sizes from just this subset.
+export {
+	GLOB_LINTABLE_EXTENSIONS as LINTABLE_EXTENSIONS,
+	GLOB_SRC_EXTENSIONS as TYPE_AWARE_EXTENSIONS,
+} from "../globs.ts";
 
 /**
  * Glob patterns whose modification invalidates every ESLint cache. A bare
@@ -109,33 +80,8 @@ export const CACHE_BUST_PATTERNS = [
  * @returns The resolved threshold.
  */
 export function resolveAffectedBustThreshold(environment: NodeJS.ProcessEnv): number {
-	const raw = environment["LINT_AFFECTED_BUST_THRESHOLD"];
-	if (raw === undefined) {
-		return AFFECTED_BUST_THRESHOLD;
-	}
-
-	const parsed = Number(raw.trim());
-	if (!Number.isInteger(parsed) || parsed < 0) {
-		return AFFECTED_BUST_THRESHOLD;
-	}
-
-	return parsed;
-}
-
-/**
- * Resolve the ESLint cache file for the given type-aware mode.
- *
- * @param mode - The active type-aware mode, if any.
- * @returns The cache file name for that mode.
- */
-export function cacheFileForMode(mode: TypeAwareMode | undefined): string {
-	if (mode === "off") {
-		return CACHE_FILE_FAST;
-	}
-
-	if (mode === "only") {
-		return CACHE_FILE_TYPE_AWARE;
-	}
-
-	return CACHE_FILE_DEFAULT;
+	return (
+		parseBoundedInteger(environment["LINT_AFFECTED_BUST_THRESHOLD"], 0) ??
+		AFFECTED_BUST_THRESHOLD
+	);
 }

--- a/src/lint-cli/constants.ts
+++ b/src/lint-cli/constants.ts
@@ -1,8 +1,16 @@
-// cspell:words lintable typeaware
+// cspell:words lintable typeaware undercounting
 import type { TypeAwareMode } from "./types.ts";
 
 /** Default number of files a single ESLint worker should handle. */
 export const DEFAULT_FILES_PER_WORKER = 350;
+
+/**
+ * When the TS builder flags more than this many affected files, surgical
+ * removal stops paying off: the runner deletes the mode's cache file wholesale
+ * and treats every file as dirty. Overridable via
+ * `LINT_AFFECTED_BUST_THRESHOLD`.
+ */
+export const AFFECTED_BUST_THRESHOLD = 1000;
 
 /** ESLint cache file used when no type-aware mode is selected. */
 export const CACHE_FILE_DEFAULT = ".eslintcache";
@@ -20,8 +28,35 @@ export const ALL_CACHE_FILES = [
 	CACHE_FILE_TYPE_AWARE,
 ] as const;
 
-/** File extensions ESLint/oxlint are expected to lint. */
-export const LINTABLE_EXTENSIONS = ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"] as const;
+/**
+ * File extensions the preset lints by default. Covers the TS/JS family plus
+ * JSONC (including package.json), YAML, TOML, Markdown and Lua, which the
+ * ESLint config enables unless the consumer opts out (see the enable* gates in
+ * `src/eslint/factory.ts`).
+ *
+ * Trade-off. When a consumer disables one of these features those files never
+ * enter the ESLint cache, so they count as dirty every run and mildly inflate
+ * the worker count. That is harmless (a worker of cheap non-TS files never
+ * builds a TS program) and preferable to undercounting, so there is no knob.
+ */
+export const LINTABLE_EXTENSIONS = [
+	"ts",
+	"tsx",
+	"mts",
+	"cts",
+	"js",
+	"jsx",
+	"mjs",
+	"cjs",
+	"json",
+	"jsonc",
+	"json5",
+	"yaml",
+	"yml",
+	"toml",
+	"md",
+	"lua",
+] as const;
 
 /**
  * Glob patterns whose modification invalidates every ESLint cache. A bare
@@ -41,6 +76,27 @@ export const CACHE_BUST_PATTERNS = [
 	"bun.lock",
 	"bun.lockb",
 ] as const;
+
+/**
+ * Resolve the affected-set bust threshold, honouring the
+ * `LINT_AFFECTED_BUST_THRESHOLD` override.
+ *
+ * @param environment - The environment variables to read the override from.
+ * @returns The resolved threshold.
+ */
+export function resolveAffectedBustThreshold(environment: NodeJS.ProcessEnv): number {
+	const raw = environment["LINT_AFFECTED_BUST_THRESHOLD"];
+	if (raw === undefined) {
+		return AFFECTED_BUST_THRESHOLD;
+	}
+
+	const parsed = Number(raw.trim());
+	if (!Number.isInteger(parsed) || parsed < 0) {
+		return AFFECTED_BUST_THRESHOLD;
+	}
+
+	return parsed;
+}
 
 /**
  * Resolve the ESLint cache file for the given type-aware mode.

--- a/src/lint-cli/constants.ts
+++ b/src/lint-cli/constants.ts
@@ -5,6 +5,14 @@ import type { TypeAwareMode } from "./types.ts";
 export const DEFAULT_FILES_PER_WORKER = 350;
 
 /**
+ * Default files-per-worker for the fast (`--type-aware=off`) pass. A syntactic
+ * lint costs ~15ms/file against a fixed ~3s config-load per worker, so the
+ * break-even against spinning up another worker sits far higher than the
+ * type-aware pass — roughly 800 files. Overridable via `FAST_FILES_PER_WORKER`.
+ */
+export const DEFAULT_FAST_FILES_PER_WORKER = 800;
+
+/**
  * When the TS builder flags more than this many affected files, surgical
  * removal stops paying off: the runner deletes the mode's cache file wholesale
  * and treats every file as dirty. Overridable via
@@ -56,6 +64,22 @@ export const LINTABLE_EXTENSIONS = [
 	"toml",
 	"md",
 	"lua",
+] as const;
+
+/**
+ * The TS/JS-family extensions the type-aware (`--type-aware=only`) config
+ * lints. Only these files ever enter the type-aware cache, so the typed pass
+ * sizes its worker count from just this subset of the dirty set.
+ */
+export const TYPE_AWARE_EXTENSIONS = [
+	"ts",
+	"tsx",
+	"mts",
+	"cts",
+	"js",
+	"jsx",
+	"mjs",
+	"cjs",
 ] as const;
 
 /**

--- a/src/lint-cli/file-entry-cache.d.ts
+++ b/src/lint-cli/file-entry-cache.d.ts
@@ -7,10 +7,22 @@ declare module "file-entry-cache" {
 		notFound?: boolean;
 	}
 
+	// The underlying `flat-cache` store. Exposed so the runner can remove
+	// individual entries and persist them without pruning the (unvisited)
+	// remainder of the cache.
+	interface FlatCache {
+		keys: () => Array<string>;
+		removeKey: (key: string) => void;
+		save: (noPrune?: boolean) => void;
+	}
+
 	interface FileEntryCache {
+		cache: FlatCache;
 		getFileDescriptor: (file: string) => FileDescriptor;
 		getUpdatedFiles: (files: Array<string>) => Array<string>;
 		hasFileChanged: (file: string) => boolean;
+		reconcile: (noPrune?: boolean) => void;
+		removeEntry: (entryName: string) => void;
 	}
 
 	interface FileEntryCacheModule {

--- a/src/lint-cli/file-entry-cache.d.ts
+++ b/src/lint-cli/file-entry-cache.d.ts
@@ -1,0 +1,23 @@
+// Minimal ambient types for the subset of `file-entry-cache` v8 the lint
+// runner uses. The package ships no type declarations of its own.
+declare module "file-entry-cache" {
+	interface FileDescriptor {
+		key: string;
+		changed?: boolean;
+		notFound?: boolean;
+	}
+
+	interface FileEntryCache {
+		getFileDescriptor: (file: string) => FileDescriptor;
+		getUpdatedFiles: (files: Array<string>) => Array<string>;
+		hasFileChanged: (file: string) => boolean;
+	}
+
+	interface FileEntryCacheModule {
+		create: (cacheId: string, path?: string, useChecksum?: boolean) => FileEntryCache;
+		createFromFile: (filePath: string, useChecksum?: boolean) => FileEntryCache;
+	}
+
+	const fileEntryCache: FileEntryCacheModule;
+	export default fileEntryCache;
+}

--- a/src/lint-cli/files.ts
+++ b/src/lint-cli/files.ts
@@ -1,4 +1,4 @@
-// cspell:words lintable
+// cspell:words lintable pathspec
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -30,43 +30,102 @@ const TYPE_AWARE_EXTENSION_SET = new Set<string>(
 );
 
 /**
- * Collect the absolute paths of lintable TS/JS files under `targets`,
- * honouring `.gitignore` (via `git ls-files`) when inside a git repository.
+ * The repository file lists a run needs, all derived from one `git ls-files`.
+ */
+export interface RepoFiles {
+	/** Absolute paths of every cache-busting file (whole project). */
+	bustFiles: Array<string>;
+	/** Absolute paths of the lintable files within the lint targets. */
+	lintable: Array<string>;
+	/** The type-aware (TS/JS-family) subset of {@link RepoFiles.lintable}. */
+	typeAware: Array<string>;
+}
+
+/**
+ * Collect every file list a run needs from a single whole-project
+ * `git ls-files` (honouring `.gitignore`), rather than re-spawning git for each
+ * pass. The one scan feeds three filters: the cache-bust set (config files,
+ * tsconfigs, lockfiles — always whole-project), the lintable files restricted
+ * to `targets`, and their type-aware subset.
+ *
+ * @param cwd - The project root to scan.
+ * @param targets - The lint target paths that restrict the lintable set.
+ * @returns The cache-bust, lintable and type-aware file lists.
+ */
+export function collectRepoFiles(cwd: string, targets: Array<string>): RepoFiles {
+	const relatives = listFiles(cwd, ["."]);
+	const isBustFile = picomatch([...CACHE_BUST_PATTERNS], { dot: true });
+	const isWithinTargets = matchTargets(targets);
+
+	const bustFiles: Array<string> = [];
+	const lintable: Array<string> = [];
+	const typeAware: Array<string> = [];
+	for (const relative of relatives) {
+		if (isBustFile(relative)) {
+			bustFiles.push(path.resolve(cwd, relative));
+		}
+
+		if (isWithinTargets(relative) && hasLintableExtension(relative)) {
+			const absolute = path.resolve(cwd, relative);
+			lintable.push(absolute);
+			if (isTypeAwareFile(relative)) {
+				typeAware.push(absolute);
+			}
+		}
+	}
+
+	return { bustFiles, lintable, typeAware };
+}
+
+/**
+ * Collect the absolute paths of lintable files under `targets`, honouring
+ * `.gitignore` (via `git ls-files`) when inside a git repository. Thin wrapper
+ * over {@link collectRepoFiles}.
  *
  * @param cwd - The working directory to resolve targets against.
  * @param targets - The target paths to scan.
  * @returns The absolute paths of lintable files.
  */
 export function collectLintableFiles(cwd: string, targets: Array<string>): Array<string> {
-	return listFiles(cwd, targets)
-		.filter(hasLintableExtension)
-		.map((relative) => path.resolve(cwd, relative));
+	return collectRepoFiles(cwd, targets).lintable;
+}
+
+function normalizeTarget(target: string): string {
+	let value = toPosix(target);
+	if (value.startsWith("./")) {
+		value = value.slice(2);
+	}
+
+	while (value.endsWith("/")) {
+		value = value.slice(0, -1);
+	}
+
+	return value;
 }
 
 /**
- * Collect the absolute paths of every file whose modification busts the ESLint
- * cache (config files, tsconfigs, lockfiles). Always scans the whole project,
- * independent of the lint targets.
+ * Build a predicate for git-pathspec-style target membership: `.` matches
+ * everything, otherwise a relative path matches when it equals a target or sits
+ * beneath one. Faithful to `git ls-files -- <target>` for the plain directory
+ * and file targets consumers pass.
  *
- * @param cwd - The project root to scan.
- * @returns The absolute paths of cache-busting files.
+ * @param targets - The lint target paths.
+ * @returns A predicate testing whether a relative posix path is a target.
  */
-export function collectCacheBustFiles(cwd: string): Array<string> {
-	const isMatch = picomatch([...CACHE_BUST_PATTERNS], { dot: true });
-	return listFiles(cwd, ["."])
-		.filter((relative) => isMatch(relative))
-		.map((relative) => path.resolve(cwd, relative));
+function matchTargets(targets: Array<string>): (relative: string) => boolean {
+	const normalized = targets.map((target) => normalizeTarget(target));
+	if (normalized.some((target) => target === "" || target === ".")) {
+		return () => true;
+	}
+
+	return (relative) => {
+		return normalized.some(
+			(target) => relative === target || relative.startsWith(`${target}/`),
+		);
+	};
 }
 
-/**
- * Whether a file is a TS/JS-family file, meaning it is linted by the type-aware
- * (`--type-aware=only`) config. Used to size the typed pass from just the files
- * that can actually enter its cache.
- *
- * @param filePath - The file path to test.
- * @returns Whether the file is in the TS/JS family.
- */
-export function isTypeAwareFile(filePath: string): boolean {
+function isTypeAwareFile(filePath: string): boolean {
 	return TYPE_AWARE_EXTENSION_SET.has(path.extname(filePath).toLowerCase());
 }
 

--- a/src/lint-cli/files.ts
+++ b/src/lint-cli/files.ts
@@ -6,6 +6,15 @@ import picomatch from "picomatch";
 
 import { CACHE_BUST_PATTERNS, LINTABLE_EXTENSIONS, TYPE_AWARE_EXTENSIONS } from "./constants.ts";
 import { toPosix } from "./paths.ts";
+import { findWorkspaceRoot } from "./workspace.ts";
+
+// Per-directory (single-segment) forms of the cache-bust globs: strip the
+// leading `**/` so each matches against a bare basename. Used to scan the
+// cache-bust candidates in each workspace-root ancestor directory, which a
+// sub-package `git ls-files` never lists.
+const ANCESTOR_BUST_PATTERNS = CACHE_BUST_PATTERNS.map((pattern) => {
+	return pattern.startsWith("**/") ? pattern.slice(3) : pattern;
+});
 
 // Only reached in the non-git fallback walk; inside a repo `git ls-files`
 // already applies `.gitignore`. The canonical ignore knowledge lives in
@@ -37,6 +46,13 @@ export interface RepoFiles {
 	bustFiles: Array<string>;
 	/** Absolute paths of the lintable files within the lint targets. */
 	lintable: Array<string>;
+	/**
+	 * True when a lint target resolves outside `cwd` (a `..`-prefixed relative
+	 * path, or an absolute path not under `cwd`). Such targets are absent from
+	 * the cwd-relative listing, so it under-counts them; the runner then must
+	 * not auto-skip the typed pass, and sizes conservatively.
+	 */
+	targetsOutsideCwd: boolean;
 	/** The type-aware (TS/JS-family) subset of {@link RepoFiles.lintable}. */
 	typeAware: Array<string>;
 }
@@ -55,9 +71,11 @@ export interface RepoFiles {
 export function collectRepoFiles(cwd: string, targets: Array<string>): RepoFiles {
 	const relatives = listFiles(cwd, ["."]);
 	const isBustFile = picomatch([...CACHE_BUST_PATTERNS], { dot: true });
-	const isWithinTargets = matchTargets(targets);
+	const normalizedTargets = targets.map((target) => normalizeTarget(target, cwd));
+	const targetsOutsideCwd = normalizedTargets.some((target) => isOutsideCwd(target));
+	const isWithinTargets = matchTargets(normalizedTargets);
 
-	const bustFiles: Array<string> = [];
+	const bustFiles = collectAncestorBustFiles(cwd);
 	const lintable: Array<string> = [];
 	const typeAware: Array<string> = [];
 	for (const relative of relatives) {
@@ -74,7 +92,7 @@ export function collectRepoFiles(cwd: string, targets: Array<string>): RepoFiles
 		}
 	}
 
-	return { bustFiles, lintable, typeAware };
+	return { bustFiles, lintable, targetsOutsideCwd, typeAware };
 }
 
 /**
@@ -90,8 +108,63 @@ export function collectLintableFiles(cwd: string, targets: Array<string>): Array
 	return collectRepoFiles(cwd, targets).lintable;
 }
 
-function normalizeTarget(target: string): string {
-	let value = toPosix(target);
+/**
+ * Scan the single-segment cache-bust candidates in each directory from `cwd`'s
+ * parent up to and including the workspace root. A sub-package `git ls-files`
+ * only lists files under `cwd`, so a hoisted root lockfile, tsconfig or ESLint
+ * config change would otherwise never bust the caches. Returns absolute paths
+ * (fine for mtime comparison); empty when `cwd` is itself the root.
+ *
+ * @param cwd - The project (sub-package) root to walk up from.
+ * @returns Absolute paths of the ancestor cache-bust files.
+ */
+function collectAncestorBustFiles(cwd: string): Array<string> {
+	const root = findWorkspaceRoot(cwd);
+	if (root === cwd) {
+		return [];
+	}
+
+	const isBustName = picomatch([...ANCESTOR_BUST_PATTERNS], { dot: true });
+	const found: Array<string> = [];
+	let current = path.dirname(cwd);
+	for (;;) {
+		let entries: Array<fs.Dirent> = [];
+		try {
+			entries = fs.readdirSync(current, { withFileTypes: true });
+		} catch {
+			entries = [];
+		}
+
+		for (const entry of entries) {
+			if (entry.isFile() && isBustName(entry.name)) {
+				found.push(path.join(current, entry.name));
+			}
+		}
+
+		const parent = path.dirname(current);
+		if (current === root || parent === current) {
+			break;
+		}
+
+		current = parent;
+	}
+
+	return found;
+}
+
+/**
+ * Reduce a raw target to the cwd-relative posix form the listing is keyed by.
+ * Absolute targets (including Windows drive paths) are relativized against
+ * `cwd`; `./` prefixes and trailing slashes are stripped. A target that
+ * resolves to `cwd` itself becomes `""` (match-all). Targets outside `cwd` keep
+ * their `..`-prefixed relative form so {@link isOutsideCwd} can flag them.
+ *
+ * @param target - The raw lint target path.
+ * @param cwd - The working directory to relativize against.
+ * @returns The normalized cwd-relative posix target.
+ */
+function normalizeTarget(target: string, cwd: string): string {
+	let value = path.isAbsolute(target) ? toPosix(path.relative(cwd, target)) : toPosix(target);
 	if (value.startsWith("./")) {
 		value = value.slice(2);
 	}
@@ -104,16 +177,27 @@ function normalizeTarget(target: string): string {
 }
 
 /**
+ * Whether a normalized target lies outside `cwd`. A cwd-relative listing never
+ * starts with `..`, so any `..`-prefixed target can never match — its files are
+ * invisible to the dirty count.
+ *
+ * @param normalizedTarget - A target already run through {@link normalizeTarget}.
+ * @returns True when the target escapes `cwd`.
+ */
+function isOutsideCwd(normalizedTarget: string): boolean {
+	return normalizedTarget === ".." || normalizedTarget.startsWith("../");
+}
+
+/**
  * Build a predicate for git-pathspec-style target membership: `.` matches
  * everything, otherwise a relative path matches when it equals a target or sits
  * beneath one. Faithful to `git ls-files -- <target>` for the plain directory
  * and file targets consumers pass.
  *
- * @param targets - The lint target paths.
+ * @param normalized - The lint target paths, already normalized against cwd.
  * @returns A predicate testing whether a relative posix path is a target.
  */
-function matchTargets(targets: Array<string>): (relative: string) => boolean {
-	const normalized = targets.map((target) => normalizeTarget(target));
+function matchTargets(normalized: Array<string>): (relative: string) => boolean {
 	if (normalized.some((target) => target === "" || target === ".")) {
 		return () => true;
 	}

--- a/src/lint-cli/files.ts
+++ b/src/lint-cli/files.ts
@@ -1,0 +1,121 @@
+// cspell:words lintable
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import picomatch from "picomatch";
+
+import { CACHE_BUST_PATTERNS, LINTABLE_EXTENSIONS } from "./constants.ts";
+
+const IGNORED_WALK_DIRECTORIES = new Set([
+	".git",
+	".next",
+	".turbo",
+	"build",
+	"coverage",
+	"dist",
+	"node_modules",
+	"out",
+]);
+
+const LINTABLE_EXTENSION_SET = new Set<string>(
+	LINTABLE_EXTENSIONS.map((extension) => `.${extension}`),
+);
+
+/**
+ * Collect the absolute paths of lintable TS/JS files under `targets`,
+ * honouring `.gitignore` (via `git ls-files`) when inside a git repository.
+ *
+ * @param cwd - The working directory to resolve targets against.
+ * @param targets - The target paths to scan.
+ * @returns The absolute paths of lintable files.
+ */
+export function collectLintableFiles(cwd: string, targets: Array<string>): Array<string> {
+	return listFiles(cwd, targets)
+		.filter(hasLintableExtension)
+		.map((relative) => path.resolve(cwd, relative));
+}
+
+/**
+ * Collect the absolute paths of every file whose modification busts the ESLint
+ * cache (config files, tsconfigs, lockfiles). Always scans the whole project,
+ * independent of the lint targets.
+ *
+ * @param cwd - The project root to scan.
+ * @returns The absolute paths of cache-busting files.
+ */
+export function collectCacheBustFiles(cwd: string): Array<string> {
+	const isMatch = picomatch([...CACHE_BUST_PATTERNS], { dot: true });
+	return listFiles(cwd, ["."])
+		.filter((relative) => isMatch(relative))
+		.map((relative) => path.resolve(cwd, relative));
+}
+
+function hasLintableExtension(filePath: string): boolean {
+	return LINTABLE_EXTENSION_SET.has(path.extname(filePath).toLowerCase());
+}
+
+function gitListFiles(cwd: string, pathSpecs: Array<string>): Array<string> | undefined {
+	try {
+		const output = execFileSync(
+			"git",
+			["ls-files", "--cached", "--others", "--exclude-standard", "--", ...pathSpecs],
+			{ cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+		);
+		return output.split("\n").filter((line) => line.length > 0);
+	} catch {
+		return undefined;
+	}
+}
+
+function toPosix(value: string): string {
+	return value.split(path.sep).join("/");
+}
+
+function walkDirectory(root: string, current: string, accumulator: Array<string>): void {
+	let entries: Array<fs.Dirent>;
+	try {
+		entries = fs.readdirSync(current, { withFileTypes: true });
+	} catch {
+		return;
+	}
+
+	for (const entry of entries) {
+		const entryPath = path.join(current, entry.name);
+		if (entry.isDirectory()) {
+			if (!IGNORED_WALK_DIRECTORIES.has(entry.name)) {
+				walkDirectory(root, entryPath, accumulator);
+			}
+
+			continue;
+		}
+
+		if (entry.isFile()) {
+			accumulator.push(toPosix(path.relative(root, entryPath)));
+		}
+	}
+}
+
+function walkFallback(cwd: string, targets: Array<string>): Array<string> {
+	const files: Array<string> = [];
+	for (const target of targets) {
+		const absolute = path.resolve(cwd, target);
+		let stat: fs.Stats;
+		try {
+			stat = fs.statSync(absolute);
+		} catch {
+			continue;
+		}
+
+		if (stat.isDirectory()) {
+			walkDirectory(cwd, absolute, files);
+		} else if (stat.isFile()) {
+			files.push(toPosix(path.relative(cwd, absolute)));
+		}
+	}
+
+	return files;
+}
+
+function listFiles(cwd: string, targets: Array<string>): Array<string> {
+	return gitListFiles(cwd, targets) ?? walkFallback(cwd, targets);
+}

--- a/src/lint-cli/files.ts
+++ b/src/lint-cli/files.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import picomatch from "picomatch";
 
 import { CACHE_BUST_PATTERNS, LINTABLE_EXTENSIONS, TYPE_AWARE_EXTENSIONS } from "./constants.ts";
+import { toPosix } from "./paths.ts";
 
+// Only reached in the non-git fallback walk; inside a repo `git ls-files`
+// already applies `.gitignore`. The canonical ignore knowledge lives in
+// `src/globs.ts` GLOB_EXCLUDE — keep this in rough sync with it.
 const IGNORED_WALK_DIRECTORIES = new Set([
 	".git",
 	".next",
@@ -81,10 +85,6 @@ function gitListFiles(cwd: string, pathSpecs: Array<string>): Array<string> | un
 	} catch {
 		return undefined;
 	}
-}
-
-function toPosix(value: string): string {
-	return value.split(path.sep).join("/");
 }
 
 function walkDirectory(root: string, current: string, accumulator: Array<string>): void {

--- a/src/lint-cli/files.ts
+++ b/src/lint-cli/files.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import picomatch from "picomatch";
 
-import { CACHE_BUST_PATTERNS, LINTABLE_EXTENSIONS } from "./constants.ts";
+import { CACHE_BUST_PATTERNS, LINTABLE_EXTENSIONS, TYPE_AWARE_EXTENSIONS } from "./constants.ts";
 
 const IGNORED_WALK_DIRECTORIES = new Set([
 	".git",
@@ -19,6 +19,10 @@ const IGNORED_WALK_DIRECTORIES = new Set([
 
 const LINTABLE_EXTENSION_SET = new Set<string>(
 	LINTABLE_EXTENSIONS.map((extension) => `.${extension}`),
+);
+
+const TYPE_AWARE_EXTENSION_SET = new Set<string>(
+	TYPE_AWARE_EXTENSIONS.map((extension) => `.${extension}`),
 );
 
 /**
@@ -48,6 +52,18 @@ export function collectCacheBustFiles(cwd: string): Array<string> {
 	return listFiles(cwd, ["."])
 		.filter((relative) => isMatch(relative))
 		.map((relative) => path.resolve(cwd, relative));
+}
+
+/**
+ * Whether a file is a TS/JS-family file, meaning it is linted by the type-aware
+ * (`--type-aware=only`) config. Used to size the typed pass from just the files
+ * that can actually enter its cache.
+ *
+ * @param filePath - The file path to test.
+ * @returns Whether the file is in the TS/JS family.
+ */
+export function isTypeAwareFile(filePath: string): boolean {
+	return TYPE_AWARE_EXTENSION_SET.has(path.extname(filePath).toLowerCase());
 }
 
 function hasLintableExtension(filePath: string): boolean {

--- a/src/lint-cli/hybrid-status.ts
+++ b/src/lint-cli/hybrid-status.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+/**
+ * Directory (relative to the project root) where the CLI keeps its cache
+ * artifacts. Lives under `node_modules/.cache` so it is discarded with the
+ * dependency tree and never committed.
+ */
+const CACHE_DIRECTORY = path.join("node_modules", ".cache", "isentinel-lint");
+
+/** File recording whether the resolved ESLint config runs in hybrid mode. */
+const STATUS_FILE = "hybrid-status";
+
+/**
+ * The persisted hybrid status: whether the resolved ESLint config enabled the
+ * factory's `oxlint` option (hybrid mode). Written passively by the factory on
+ * every config evaluation and read by the CLI to decide whether running both
+ * engines would duplicate work.
+ */
+export interface HybridStatus {
+	/** Whether the ESLint config runs in hybrid (oxlint) mode. */
+	oxlint: boolean;
+}
+
+/**
+ * Absolute path to the hybrid-status file for a project root.
+ *
+ * @param cwd - The project root.
+ * @returns The absolute status-file path.
+ */
+export function hybridStatusPath(cwd: string): string {
+	return path.resolve(cwd, CACHE_DIRECTORY, STATUS_FILE);
+}
+
+/**
+ * Passively record whether the resolved ESLint config runs in hybrid mode.
+ * Called from the factory on every config evaluation, so it is write-if-changed
+ * (read first, skip identical content) to avoid churning the file when editors
+ * and both lint passes re-evaluate the config. Every failure is swallowed:
+ * config evaluation must never throw for this, and the CLI treats a missing or
+ * stale file as "unknown" and re-probes.
+ *
+ * Skipped entirely when `node_modules` is absent (nothing installed, so no
+ * cache home and no CLI to read it).
+ *
+ * @param cwd - The project root.
+ * @param oxlint - Whether the config enabled hybrid mode.
+ */
+export function writeHybridStatus(cwd: string, oxlint: boolean): void {
+	try {
+		if (!fs.existsSync(path.resolve(cwd, "node_modules"))) {
+			return;
+		}
+
+		const filePath = hybridStatusPath(cwd);
+		const content = `${JSON.stringify({ oxlint })}\n`;
+
+		let existing: string | undefined;
+		try {
+			existing = fs.readFileSync(filePath, "utf8");
+		} catch {
+			existing = undefined;
+		}
+
+		if (existing === content) {
+			return;
+		}
+
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, content);
+	} catch {
+		// Best-effort: the CLI re-probes when the status is missing or
+		// unreadable.
+	}
+}
+
+/**
+ * Read the persisted hybrid status, or `undefined` when the file is missing,
+ * unreadable or malformed (the CLI then treats the status as unknown).
+ *
+ * @param cwd - The project root.
+ * @returns The parsed status, or `undefined`.
+ */
+export function readHybridStatus(cwd: string): HybridStatus | undefined {
+	let raw: string;
+	try {
+		raw = fs.readFileSync(hybridStatusPath(cwd), "utf8");
+	} catch {
+		return undefined;
+	}
+
+	try {
+		const parsed = JSON.parse(raw) as unknown;
+		if (
+			typeof parsed === "object" &&
+			parsed !== null &&
+			typeof (parsed as Record<string, unknown>)["oxlint"] === "boolean"
+		) {
+			return { oxlint: (parsed as HybridStatus).oxlint };
+		}
+	} catch {
+		return undefined;
+	}
+
+	return undefined;
+}
+
+/**
+ * Convenience wrapper defaulting the project root to `process.cwd()`, used by
+ * the factory so the passive write stays a one-liner at the call site.
+ *
+ * @param oxlint - Whether the config enabled hybrid mode.
+ */
+export function writeHybridStatusForCwd(oxlint: boolean): void {
+	writeHybridStatus(process.cwd(), oxlint);
+}

--- a/src/lint-cli/hybrid-status.ts
+++ b/src/lint-cli/hybrid-status.ts
@@ -64,6 +64,13 @@ export function writeHybridStatus(cwd: string, oxlint: boolean): void {
 		}
 
 		if (existing === content) {
+			// Content is unchanged, but refresh the mtime so the CLI freshness
+			// check (status mtime >= config mtime) keeps passing after the config
+			// is touched. Without this the mtime freezes at first write and every
+			// later lint needlessly re-runs the ~3s probe. The passive factory
+			// write thus keeps the status perpetually fresh.
+			const now = Date.now() / 1000;
+			fs.utimesSync(filePath, now, now);
 			return;
 		}
 

--- a/src/lint-cli/hybrid.ts
+++ b/src/lint-cli/hybrid.ts
@@ -1,0 +1,216 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+
+import { maxMtimeMs } from "./cache.ts";
+import type { RepoFiles } from "./files.ts";
+import { hybridStatusPath, readHybridStatus, writeHybridStatus } from "./hybrid-status.ts";
+import type { HybridStatus } from "./hybrid-status.ts";
+import { resolveLocalBin } from "./resolve.ts";
+
+/** Matches the flat-config entry point (`eslint.config.js`, `.ts`, `.mjs`…). */
+const ESLINT_CONFIG_FILE_PATTERN = /^eslint\.config\./;
+
+/**
+ * The stderr warning emitted when the resolved ESLint config is not hybrid, so
+ * running oxlint too would double-lint every mapped rule. Oxlint is dropped.
+ */
+export const NON_HYBRID_WARNING =
+	"isentinel-lint: the ESLint config does not enable hybrid mode (`oxlint: true`), " +
+	"so oxlint would re-run rules ESLint already checks. Running ESLint only; enable " +
+	"hybrid mode in your config or pass --oxlint to run oxlint explicitly.\n";
+
+/**
+ * The stderr warning emitted when the hybrid status cannot be determined (the
+ * probe failed). The run fails open: both engines run, as before.
+ */
+export const HYBRID_UNKNOWN_WARNING =
+	"isentinel-lint: could not determine whether the ESLint config enables hybrid " +
+	"mode; running both engines.\n";
+
+/**
+ * Probe the resolved ESLint config for the hybrid marker by spawning
+ * `eslint --print-config <target>` and reading `settings["isentinel/oxlint"]`.
+ * Returns `undefined` on any failure (missing bin, non-zero exit, malformed
+ * output) so the caller can fail open.
+ */
+export type HybridProbe = (cwd: string, target: string) => HybridStatus | undefined;
+
+/** Inputs to {@link resolveOxlintRun}, assembled once in the plan phase. */
+export interface OxlintRunInput {
+	/** The project root. */
+	cwd: string;
+	/** The collected repo file lists (config-file subset + a probe target). */
+	files: RepoFiles;
+	/**
+	 * Whether the plan may mutate (false for `--print`: never probe or write).
+	 */
+	mutate: boolean;
+	/** Whether ESLint would run (false for `--oxlint`). */
+	runEslint: boolean;
+	/** Whether oxlint would run (false for `--eslint`). */
+	runOxlint: boolean;
+}
+
+/** The oxlint run decision produced in the plan phase. */
+export interface OxlintRunDecision {
+	/** A stderr warning to emit, or `undefined`. */
+	reason: string | undefined;
+	/** Whether the oxlint child runs. */
+	run: boolean;
+}
+
+/**
+ * Decide whether the oxlint child runs. When both engines would run (default
+ * mode or `--fix`, i.e. Neither `--eslint` nor `--oxlint`), the ESLint config
+ * must be hybrid or oxlint would double-lint every mapped rule; a non-hybrid
+ * config drops oxlint with a warning. Explicit single-tool runs skip the check
+ * entirely and keep today's behaviour.
+ *
+ * The hybrid status is trusted from the on-disk `hybrid-status` file when it is
+ * at least as new as the ESLint config; otherwise the resolved config is
+ * actively probed (unless `mutate` is false, e.g. `--print`, which never probes
+ * and assumes hybrid). A probe failure fails open: both engines run.
+ *
+ * @param input - The assembled plan-phase inputs.
+ * @param probe - The config prober (injected in tests).
+ * @returns The oxlint run decision.
+ */
+export function resolveOxlintRun(
+	input: OxlintRunInput,
+	probe: HybridProbe = probeHybridConfig,
+): OxlintRunDecision {
+	// Explicit single-tool selection: no check, no probe. `--eslint` leaves
+	// `runOxlint` false (oxlint already off); `--oxlint` leaves `runEslint`
+	// false (this branch never runs a hybrid check against it).
+	if (!input.runOxlint || !input.runEslint) {
+		return { reason: undefined, run: input.runOxlint };
+	}
+
+	const status = resolveHybridStatus(input, probe);
+	if (status === undefined) {
+		// Could not determine the status (probe failed): fail open.
+		return { reason: HYBRID_UNKNOWN_WARNING, run: true };
+	}
+
+	if (!status.oxlint) {
+		return { reason: NON_HYBRID_WARNING, run: false };
+	}
+
+	return { reason: undefined, run: true };
+}
+
+/**
+ * Read the cached hybrid status only when it is at least as new as the ESLint
+ * config; a stale or missing file yields `undefined` (the caller then probes).
+ *
+ * @param cwd - The project root.
+ * @param configMtime - The newest ESLint-config mtime, or `undefined` when none.
+ * @returns The fresh cached status, or `undefined`.
+ */
+function readFreshHybridStatus(
+	cwd: string,
+	configMtime: number | undefined,
+): HybridStatus | undefined {
+	const status = readHybridStatus(cwd);
+	if (status === undefined) {
+		return undefined;
+	}
+
+	if (configMtime === undefined) {
+		return status;
+	}
+
+	const statusMtime = maxMtimeMs([hybridStatusPath(cwd)]);
+	if (statusMtime === undefined || statusMtime < configMtime) {
+		return undefined;
+	}
+
+	return status;
+}
+
+/**
+ * The ESLint-config subset of the cache-bust files: the files whose change
+ * should invalidate the cached hybrid status. Lockfiles and tsconfigs are
+ * excluded — only the ESLint config decides the `oxlint` option.
+ *
+ * @param bustFiles - The whole cache-bust file set.
+ * @returns Every bust file whose basename is a flat-config entry point.
+ */
+function eslintConfigFiles(bustFiles: Array<string>): Array<string> {
+	return bustFiles.filter((file) => ESLINT_CONFIG_FILE_PATTERN.test(path.basename(file)));
+}
+
+/**
+ * Resolve the hybrid status, trusting a fresh cache file and otherwise probing.
+ * Returns `undefined` only when a probe was attempted and failed.
+ *
+ * @param input - The assembled plan-phase inputs.
+ * @param probe - The config prober.
+ * @returns The hybrid status, or `undefined` when a probe failed.
+ */
+function resolveHybridStatus(
+	{ cwd, files, mutate }: OxlintRunInput,
+	probe: HybridProbe,
+): HybridStatus | undefined {
+	const configMtime = maxMtimeMs(eslintConfigFiles(files.bustFiles));
+
+	const cached = readFreshHybridStatus(cwd, configMtime);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	if (!mutate) {
+		// `--print` never probes (it would spawn a slow child) or writes; assume
+		// hybrid so the both-engines composition prints unchanged.
+		return { oxlint: true };
+	}
+
+	const target = files.typeAware[0] ?? eslintConfigFiles(files.bustFiles)[0];
+	if (target === undefined) {
+		return undefined;
+	}
+
+	const probed = probe(cwd, target);
+	if (probed === undefined) {
+		return undefined;
+	}
+
+	// The probe pays once per config change: persist so later runs read it back.
+	writeHybridStatus(cwd, probed.oxlint);
+	return probed;
+}
+
+/**
+ * The real prober: spawn the resolved local ESLint with `--print-config` and
+ * read the hybrid marker from the merged `settings`.
+ *
+ * @param cwd - The project root.
+ * @param target - A file whose resolved config carries the marker.
+ * @returns The probed status, or `undefined` on any failure.
+ */
+function probeHybridConfig(cwd: string, target: string): HybridStatus | undefined {
+	let binJs: string;
+	try {
+		binJs = resolveLocalBin("eslint", cwd);
+	} catch {
+		return undefined;
+	}
+
+	const result = spawnSync(process.execPath, [binJs, "--print-config", target], {
+		cwd,
+		encoding: "utf8",
+		maxBuffer: 64 * 1024 * 1024,
+	});
+
+	if (result.status !== 0 || typeof result.stdout !== "string") {
+		return undefined;
+	}
+
+	try {
+		const config = JSON.parse(result.stdout) as { settings?: Record<string, unknown> };
+		return { oxlint: config.settings?.["isentinel/oxlint"] === true };
+	} catch {
+		return undefined;
+	}
+}

--- a/src/lint-cli/hybrid.ts
+++ b/src/lint-cli/hybrid.ts
@@ -1,3 +1,4 @@
+// cspell:words mtimes unparseable
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import process from "node:process";
@@ -61,6 +62,32 @@ export interface OxlintRunDecision {
 }
 
 /**
+ * Read the hybrid marker from `eslint --print-config` stdout. Config evaluation
+ * can print non-JSON before the payload (plugin/editor-detection logs), so the
+ * JSON object is isolated (first `{` to last `}`) before parsing. Returns
+ * `undefined` when no JSON object is present or it fails to parse.
+ *
+ * @param stdout - The raw `--print-config` stdout.
+ * @returns The probed status, or `undefined` when unparseable.
+ */
+export function parseHybridPrintConfig(stdout: string): HybridStatus | undefined {
+	const first = stdout.indexOf("{");
+	const last = stdout.lastIndexOf("}");
+	if (first === -1 || last < first) {
+		return undefined;
+	}
+
+	try {
+		const config = JSON.parse(stdout.slice(first, last + 1)) as {
+			settings?: Record<string, unknown>;
+		};
+		return { oxlint: config.settings?.["isentinel/oxlint"] === true };
+	} catch {
+		return undefined;
+	}
+}
+
+/**
  * Decide whether the oxlint child runs. When both engines would run (default
  * mode or `--fix`, i.e. Neither `--eslint` nor `--oxlint`), the ESLint config
  * must be hybrid or oxlint would double-lint every mapped rule; a non-hybrid
@@ -103,6 +130,11 @@ export function resolveOxlintRun(
 /**
  * Read the cached hybrid status only when it is at least as new as the ESLint
  * config; a stale or missing file yields `undefined` (the caller then probes).
+ *
+ * Known limitation: freshness tracks `eslint.config.*` mtimes only, so toggling
+ * hybrid mode from a module the config *imports* (rather than the config file
+ * itself) is trusted from the cache for one more run before the factory's
+ * passive write corrects it — it self-heals on the next invocation.
  *
  * @param cwd - The project root.
  * @param configMtime - The newest ESLint-config mtime, or `undefined` when none.
@@ -207,10 +239,5 @@ function probeHybridConfig(cwd: string, target: string): HybridStatus | undefine
 		return undefined;
 	}
 
-	try {
-		const config = JSON.parse(result.stdout) as { settings?: Record<string, unknown> };
-		return { oxlint: config.settings?.["isentinel/oxlint"] === true };
-	} catch {
-		return undefined;
-	}
+	return parseHybridPrintConfig(result.stdout);
 }

--- a/src/lint-cli/index.ts
+++ b/src/lint-cli/index.ts
@@ -14,7 +14,9 @@ Flags:
   --oxlint                 Run only oxlint.
   --fix                    Apply fixes: oxlint --fix then eslint --fix.
   --agents                 Emit agent-friendly output.
-  --type-aware=off|only    ESLint type-aware mode (off is fast, cache-split).
+  --type-aware=off|only|full
+                           Force a single ESLint pass. Default runs the fast and
+                           type-aware passes concurrently; full is the escape hatch.
   --no-oxlint-type-aware   Skip oxlint's type-aware rules (no tsgolint needed).
   --no-cache               Disable ESLint's cache.
   --concurrency <n|off>    Override the concurrency heuristic.

--- a/src/lint-cli/index.ts
+++ b/src/lint-cli/index.ts
@@ -1,0 +1,56 @@
+import process from "node:process";
+
+import packageJson from "../../package.json" with { type: "json" };
+import { runLint } from "./run.ts";
+import { CliError } from "./types.ts";
+
+const HELP = `isentinel-lint [flags] [paths...]
+
+Runs oxlint and ESLint together, sizing ESLint's --concurrency from how many
+files actually need re-linting and managing per-mode caches.
+
+Flags:
+  --eslint                 Run only ESLint.
+  --oxlint                 Run only oxlint.
+  --fix                    Apply fixes: oxlint --fix then eslint --fix.
+  --agents                 Emit agent-friendly output.
+  --type-aware=off|only    ESLint type-aware mode (off is fast, cache-split).
+  --no-oxlint-type-aware   Skip oxlint's type-aware rules (no tsgolint needed).
+  --no-cache               Disable ESLint's cache.
+  --concurrency <n|off>    Override the concurrency heuristic.
+  --eslint-args "<args>"   Extra arguments for ESLint.
+  --oxlint-args "<args>"   Extra arguments for oxlint.
+  --print                  Print the composed commands without running them.
+  -- <args>                Forward args to the single selected tool.
+  -h, --help               Show this help.
+  -v, --version            Show the version.
+`;
+
+async function main(): Promise<number> {
+	const argv = process.argv.slice(2);
+	if (argv.includes("--help") || argv.includes("-h")) {
+		process.stdout.write(`${HELP}\n`);
+		return 0;
+	}
+
+	if (argv.includes("--version") || argv.includes("-v")) {
+		process.stdout.write(`${packageJson.version}\n`);
+		return 0;
+	}
+
+	return runLint(argv);
+}
+
+main()
+	.then((code) => {
+		process.exitCode = code;
+	})
+	.catch((err: unknown) => {
+		if (err instanceof CliError) {
+			console.error(err.message);
+		} else {
+			console.error(err);
+		}
+
+		process.exitCode = 1;
+	});

--- a/src/lint-cli/invalidation.ts
+++ b/src/lint-cli/invalidation.ts
@@ -77,25 +77,29 @@ export function applyTypeAwareInvalidation({
 		return { busted: false, firstRun: true, invalidated: [], skipped: false };
 	}
 
-	const threshold = resolveAffectedBustThreshold(environment);
-	if (result.affected.size > threshold) {
-		fs.rmSync(cacheLocation, { force: true });
-		return { busted: true, firstRun: false, invalidated: [], skipped: false };
-	}
-
 	const targets = new Set<string>();
 	for (const file of targetFiles) {
 		targets.add(normalizePath(file));
 	}
 
-	const invalidated: Array<string> = [];
+	// Only affected files that are lint targets ever get surgically removed, so
+	// gauge the escape valve against that intersection rather than the whole
+	// in-project affected set (which counts files this run will never touch).
+	const affectedTargets: Array<string> = [];
 	for (const affected of result.affected) {
 		const key = normalizePath(affected);
-		if (targets.has(key) && !alreadyDirty.has(key)) {
-			invalidated.push(key);
+		if (targets.has(key)) {
+			affectedTargets.push(key);
 		}
 	}
 
+	const threshold = resolveAffectedBustThreshold(environment);
+	if (affectedTargets.length > threshold) {
+		fs.rmSync(cacheLocation, { force: true });
+		return { busted: true, firstRun: false, invalidated: [], skipped: false };
+	}
+
+	const invalidated = affectedTargets.filter((key) => !alreadyDirty.has(key));
 	if (cache !== undefined) {
 		cache.removeEntries(invalidated);
 	} else {

--- a/src/lint-cli/invalidation.ts
+++ b/src/lint-cli/invalidation.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 
 import { computeAffectedFiles } from "./affected.ts";
+import type { DirtyCache } from "./cache.ts";
 import { normalizePath, removeCacheEntries } from "./cache.ts";
 import { resolveAffectedBustThreshold } from "./constants.ts";
 import type { TypeAwareMode } from "./types.ts";
@@ -10,6 +11,11 @@ import type { TypeAwareMode } from "./types.ts";
 export interface InvalidationRequest {
 	/** Normalised paths already dirty by mtime/checksum. */
 	alreadyDirty: ReadonlySet<string>;
+	/**
+	 * The already-loaded cache to remove entries from, reusing the handle the
+	 * caller opened for the dirty query. When omitted, opened afresh.
+	 */
+	cache?: DirtyCache;
 	/** Absolute path to the mode's ESLint cache file. */
 	cacheLocation: string;
 	/** The consumer project root. */
@@ -55,6 +61,7 @@ export interface InvalidationOutcome {
  */
 export function applyTypeAwareInvalidation({
 	alreadyDirty,
+	cache,
 	cacheLocation,
 	cwd,
 	environment,
@@ -89,6 +96,11 @@ export function applyTypeAwareInvalidation({
 		}
 	}
 
-	removeCacheEntries(cacheLocation, invalidated);
+	if (cache !== undefined) {
+		cache.removeEntries(invalidated);
+	} else {
+		removeCacheEntries(cacheLocation, invalidated);
+	}
+
 	return { busted: false, firstRun: false, invalidated, skipped: false };
 }

--- a/src/lint-cli/invalidation.ts
+++ b/src/lint-cli/invalidation.ts
@@ -1,0 +1,94 @@
+// cspell:words normalised
+import fs from "node:fs";
+
+import { computeAffectedFiles } from "./affected.ts";
+import { normalizePath, removeCacheEntries } from "./cache.ts";
+import { resolveAffectedBustThreshold } from "./constants.ts";
+import type { TypeAwareMode } from "./types.ts";
+
+/** Inputs to one type-aware invalidation pass. */
+export interface InvalidationRequest {
+	/** Normalised paths already dirty by mtime/checksum. */
+	alreadyDirty: ReadonlySet<string>;
+	/** Absolute path to the mode's ESLint cache file. */
+	cacheLocation: string;
+	/** The consumer project root. */
+	cwd: string;
+	/** Environment variables (for the bust-threshold override). */
+	environment: NodeJS.ProcessEnv;
+	/** The active ESLint type-aware mode (never `"off"`). */
+	mode: TypeAwareMode | undefined;
+	/** The lint-target files for this run. */
+	targetFiles: Array<string>;
+}
+
+/** Outcome of one type-aware invalidation pass. */
+export interface InvalidationOutcome {
+	/** True when the escape valve deleted the whole mode cache file. */
+	busted: boolean;
+	/**
+	 * True when the builder ran for the first time (state persisted, no bust).
+	 */
+	firstRun: boolean;
+	/** Normalised paths whose cache entries were removed this run. */
+	invalidated: Array<string>;
+	/** True when the builder path was skipped or failed. */
+	skipped: boolean;
+}
+
+/**
+ * Fold TypeScript builder-based invalidation into the ESLint cache. Computes
+ * the affected set (files whose type-aware results may have changed because a
+ * file they import changed), then either:
+ *
+ * - persists state only, when this is the builder's first run (its affected set
+ *   is meaningless — everything is "affected");
+ * - deletes the mode cache wholesale, when the affected set exceeds the bust
+ *   threshold (surgical removal stops paying off);
+ * - surgically removes the affected files that are lint targets and not already
+ *   dirty by mtime/checksum.
+ *
+ * Never throws: a skipped/failed builder yields a no-op outcome.
+ *
+ * @param request - The invalidation inputs.
+ * @returns The invalidation outcome.
+ */
+export function applyTypeAwareInvalidation({
+	alreadyDirty,
+	cacheLocation,
+	cwd,
+	environment,
+	mode,
+	targetFiles,
+}: InvalidationRequest): InvalidationOutcome {
+	const result = computeAffectedFiles(cwd, mode);
+	if (result === undefined) {
+		return { busted: false, firstRun: false, invalidated: [], skipped: true };
+	}
+
+	if (result.firstRun) {
+		return { busted: false, firstRun: true, invalidated: [], skipped: false };
+	}
+
+	const threshold = resolveAffectedBustThreshold(environment);
+	if (result.affected.size > threshold) {
+		fs.rmSync(cacheLocation, { force: true });
+		return { busted: true, firstRun: false, invalidated: [], skipped: false };
+	}
+
+	const targets = new Set<string>();
+	for (const file of targetFiles) {
+		targets.add(normalizePath(file));
+	}
+
+	const invalidated: Array<string> = [];
+	for (const affected of result.affected) {
+		const key = normalizePath(affected);
+		if (targets.has(key) && !alreadyDirty.has(key)) {
+			invalidated.push(key);
+		}
+	}
+
+	removeCacheEntries(cacheLocation, invalidated);
+	return { busted: false, firstRun: false, invalidated, skipped: false };
+}

--- a/src/lint-cli/options.ts
+++ b/src/lint-cli/options.ts
@@ -1,6 +1,7 @@
 import yargs from "yargs";
 
 import { splitArgs } from "./command.ts";
+import { parseBoundedInteger } from "./parse.ts";
 import type { LintCliOptions } from "./types.ts";
 import { CliError } from "./types.ts";
 
@@ -161,8 +162,8 @@ function parseConcurrency(value: string | undefined): "off" | number | undefined
 		return "off";
 	}
 
-	const parsed = Number(value);
-	if (!Number.isInteger(parsed) || parsed < 1) {
+	const parsed = parseBoundedInteger(value, 1);
+	if (parsed === undefined) {
 		throw new CliError(
 			`Invalid --concurrency "${value}"; expected a positive integer or "off".`,
 		);

--- a/src/lint-cli/options.ts
+++ b/src/lint-cli/options.ts
@@ -45,7 +45,7 @@ export function parseArguments(argv: Array<string>): LintCliOptions {
 			type: "boolean",
 		})
 		.option("type-aware", {
-			choices: ["off", "only"] as const,
+			choices: ["off", "only", "full"] as const,
 			description: "ESLint type-aware mode.",
 			type: "string",
 		})

--- a/src/lint-cli/options.ts
+++ b/src/lint-cli/options.ts
@@ -1,0 +1,172 @@
+import yargs from "yargs";
+
+import { splitArgs } from "./command.ts";
+import type { LintCliOptions } from "./types.ts";
+import { CliError } from "./types.ts";
+
+interface ExtractResult {
+	rest: Array<string>;
+	value: string | undefined;
+}
+
+/**
+ * Parse and validate an `isentinel-lint` argv slice (without the node/bin
+ * prefix). Throws {@link CliError} on any invalid combination.
+ *
+ * @param argv - The argument slice to parse.
+ * @returns The parsed and validated options.
+ */
+export function parseArguments(argv: Array<string>): LintCliOptions {
+	// Everything after a bare `--` is verbatim passthrough; never scan it for
+	// the per-tool arg options.
+	const separator = argv.indexOf("--");
+	const head = separator === -1 ? argv : argv.slice(0, separator);
+	const tail = separator === -1 ? [] : argv.slice(separator);
+
+	const eslintExtract = extractValueOption(head, "eslint-args");
+	const oxlintExtract = extractValueOption(eslintExtract.rest, "oxlint-args");
+
+	const parsed = yargs([...oxlintExtract.rest, ...tail])
+		.scriptName("isentinel-lint")
+		.parserConfiguration({ "boolean-negation": true, "populate--": true })
+		.option("eslint", { description: "Run only ESLint.", type: "boolean" })
+		.option("oxlint", { description: "Run only oxlint.", type: "boolean" })
+		.option("fix", { description: "Apply fixes (oxlint then ESLint).", type: "boolean" })
+		.option("agents", { description: "Agent-friendly output.", type: "boolean" })
+		.option("print", { description: "Print the composed commands.", type: "boolean" })
+		.option("cache", {
+			default: true,
+			description: "Use ESLint's on-disk cache.",
+			type: "boolean",
+		})
+		.option("oxlint-type-aware", {
+			default: true,
+			description: "Pass --type-aware to oxlint.",
+			type: "boolean",
+		})
+		.option("type-aware", {
+			choices: ["off", "only"] as const,
+			description: "ESLint type-aware mode.",
+			type: "string",
+		})
+		.option("concurrency", {
+			description: "ESLint concurrency override (<n> or off).",
+			type: "string",
+		})
+		.conflicts("eslint", "oxlint")
+		.strictOptions()
+		.exitProcess(false)
+		.fail((message: string | undefined, error: Error | undefined) => {
+			throw new CliError(message ?? error?.message ?? "Invalid arguments.");
+		})
+		.parseSync();
+
+	const eslintOnly = parsed.eslint === true;
+	const oxlintOnly = parsed.oxlint === true;
+	const { typeAware } = parsed;
+	const fix = parsed.fix === true;
+
+	if (fix && typeAware !== undefined) {
+		throw new CliError(
+			"Cannot combine --fix with --type-aware; --fix always uses the full config.",
+		);
+	}
+
+	const eslintArgs = eslintExtract.value !== undefined ? splitArgs(eslintExtract.value) : [];
+	const oxlintArgs = oxlintExtract.value !== undefined ? splitArgs(oxlintExtract.value) : [];
+
+	const rawPassthrough = parsed["--"];
+	const passthrough = Array.isArray(rawPassthrough) ? rawPassthrough.map(String) : [];
+	if (passthrough.length > 0) {
+		if (eslintOnly === oxlintOnly) {
+			throw new CliError(
+				"`--` passthrough requires a single tool; use it with --eslint or --oxlint.",
+			);
+		}
+
+		if (eslintOnly) {
+			eslintArgs.push(...passthrough);
+		} else {
+			oxlintArgs.push(...passthrough);
+		}
+	}
+
+	const paths = parsed._.map(String).filter((value) => value.length > 0);
+
+	return {
+		agents: parsed.agents === true,
+		cache: parsed.cache,
+		concurrency: parseConcurrency(parsed.concurrency),
+		eslint: eslintOnly,
+		eslintArgs,
+		fix,
+		oxlint: oxlintOnly,
+		oxlintArgs,
+		oxlintTypeAware: parsed.oxlintTypeAware,
+		paths: paths.length > 0 ? paths : ["."],
+		print: parsed.print === true,
+		typeAware,
+	};
+}
+
+/**
+ * Pull a single `--name <value>` / `--name=<value>` option out of an argv
+ * slice. Done before yargs because yargs refuses dash-prefixed values (for
+ * example `--eslint-args "--max-warnings 0"`).
+ *
+ * @param argv - The argument slice to scan.
+ * @param name - The option name (without leading dashes).
+ * @returns The extracted value and the remaining arguments.
+ */
+function extractValueOption(argv: Array<string>, name: string): ExtractResult {
+	const flag = `--${name}`;
+	const inline = `${flag}=`;
+	const rest: Array<string> = [];
+	let value: string | undefined;
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const token = argv[index];
+		if (token === undefined) {
+			continue;
+		}
+
+		if (token === flag) {
+			const next = argv[index + 1];
+			if (next === undefined) {
+				throw new CliError(`Option ${flag} requires a value.`);
+			}
+
+			value = next;
+			index += 1;
+			continue;
+		}
+
+		if (token.startsWith(inline)) {
+			value = token.slice(inline.length);
+			continue;
+		}
+
+		rest.push(token);
+	}
+
+	return { rest, value };
+}
+
+function parseConcurrency(value: string | undefined): "off" | number | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	if (value === "off") {
+		return "off";
+	}
+
+	const parsed = Number(value);
+	if (!Number.isInteger(parsed) || parsed < 1) {
+		throw new CliError(
+			`Invalid --concurrency "${value}"; expected a positive integer or "off".`,
+		);
+	}
+
+	return parsed;
+}

--- a/src/lint-cli/package-hash.ts
+++ b/src/lint-cli/package-hash.ts
@@ -1,0 +1,144 @@
+// cspell:words typeaware
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { CACHE_FILE_DEFAULT, CACHE_FILE_TYPE_AWARE } from "./constants.ts";
+
+/**
+ * Root `package.json` fields whose edits can change the types a consumer's
+ * importers see (resolution surface + dependency versions). A change to any of
+ * these must invalidate the type-aware caches; unrelated edits (`scripts`,
+ * `version`, metadata) must not.
+ */
+const RESOLUTION_FIELDS = [
+	"exports",
+	"imports",
+	"main",
+	"module",
+	"types",
+	"typesVersions",
+	"dependencies",
+	"devDependencies",
+	"peerDependencies",
+] as const;
+
+/** Outcome of the package.json resolution-hash check. */
+export interface PackageJsonBustOutcome {
+	/** True when the hash changed and the type-aware caches were deleted. */
+	busted: boolean;
+	/** True when no prior hash existed (state stored, no bust). */
+	firstRun: boolean;
+}
+
+/**
+ * Resolve the persisted package.json resolution-hash file. Stored alongside the
+ * builder state so it is cleaned with `node_modules`.
+ *
+ * @param cwd - The consumer project root.
+ * @returns The absolute path to the stored-hash file.
+ */
+export function packageHashStatePath(cwd: string): string {
+	return path.join(cwd, "node_modules", ".cache", "isentinel-lint", "package-json-hash");
+}
+
+/**
+ * Hash the resolution-relevant fields of the root `package.json` as sorted,
+ * stable JSON. Returns `undefined` when there is no readable/parseable
+ * `package.json` (the caller then treats the check as a no-op).
+ *
+ * @param cwd - The consumer project root.
+ * @returns The hex digest, or `undefined` when unavailable.
+ */
+export function computePackageJsonHash(cwd: string): string | undefined {
+	let raw: string;
+	try {
+		raw = fs.readFileSync(path.join(cwd, "package.json"), "utf8");
+	} catch {
+		return undefined;
+	}
+
+	let parsed: Record<string, unknown>;
+	try {
+		parsed = JSON.parse(raw) as Record<string, unknown>;
+	} catch {
+		return undefined;
+	}
+
+	const subset: Record<string, unknown> = {};
+	for (const field of RESOLUTION_FIELDS) {
+		if (Object.hasOwn(parsed, field)) {
+			subset[field] = parsed[field];
+		}
+	}
+
+	return crypto.createHash("sha256").update(stableStringify(subset)).digest("hex");
+}
+
+/**
+ * Bust the type-aware caches when the root `package.json` resolution surface
+ * changed since the last run. Deletes `.eslintcache-typeaware` and
+ * `.eslintcache` (both type-aware configs) while leaving `.eslintcache-fast`
+ * (syntactic-only) intact, since resolution changes cannot alter a syntactic
+ * lint. The first run only stores the hash.
+ *
+ * @param cwd - The consumer project root.
+ * @returns The bust outcome.
+ */
+export function applyPackageJsonBust(cwd: string): PackageJsonBustOutcome {
+	const hash = computePackageJsonHash(cwd);
+	if (hash === undefined) {
+		return { busted: false, firstRun: false };
+	}
+
+	const statePath = packageHashStatePath(cwd);
+	const stored = safeRead(statePath);
+	if (stored === hash) {
+		return { busted: false, firstRun: false };
+	}
+
+	writeHash(statePath, hash);
+	if (stored === undefined) {
+		return { busted: false, firstRun: true };
+	}
+
+	fs.rmSync(path.resolve(cwd, CACHE_FILE_TYPE_AWARE), { force: true });
+	fs.rmSync(path.resolve(cwd, CACHE_FILE_DEFAULT), { force: true });
+	return { busted: true, firstRun: false };
+}
+
+/**
+ * Serialize a value to JSON with object keys sorted at every depth so the
+ * digest is insensitive to key ordering.
+ *
+ * @param value - The value to stringify.
+ * @returns The stable JSON string.
+ */
+function stableStringify(value: unknown): string {
+	if (Array.isArray(value)) {
+		return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+	}
+
+	if (value !== null && typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		const entries = Object.keys(record)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`);
+		return `{${entries.join(",")}}`;
+	}
+
+	return JSON.stringify(value);
+}
+
+function safeRead(filePath: string): string | undefined {
+	try {
+		return fs.readFileSync(filePath, "utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+function writeHash(statePath: string, hash: string): void {
+	fs.mkdirSync(path.dirname(statePath), { recursive: true });
+	fs.writeFileSync(statePath, hash);
+}

--- a/src/lint-cli/package-hash.ts
+++ b/src/lint-cli/package-hash.ts
@@ -1,15 +1,17 @@
-// cspell:words typeaware
+// cspell:words typeaware unparseable
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
 import { CACHE_FILE_DEFAULT, CACHE_FILE_TYPE_AWARE } from "./constants.ts";
+import { findWorkspaceRoot } from "./workspace.ts";
 
 /**
  * Root `package.json` fields whose edits can change the types a consumer's
  * importers see (resolution surface + dependency versions). A change to any of
  * these must invalidate the type-aware caches; unrelated edits (`scripts`,
- * `version`, metadata) must not.
+ * `version`, metadata) must not. `pnpm` (overrides/patchedDependencies) and
+ * `optionalDependencies` can silently swap a resolved version too.
  */
 const RESOLUTION_FIELDS = [
 	"exports",
@@ -21,6 +23,8 @@ const RESOLUTION_FIELDS = [
 	"dependencies",
 	"devDependencies",
 	"peerDependencies",
+	"optionalDependencies",
+	"pnpm",
 ] as const;
 
 /** Outcome of the package.json resolution-hash check. */
@@ -43,36 +47,33 @@ export function packageHashStatePath(cwd: string): string {
 }
 
 /**
- * Hash the resolution-relevant fields of the root `package.json` as sorted,
- * stable JSON. Returns `undefined` when there is no readable/parseable
- * `package.json` (the caller then treats the check as a no-op).
+ * Hash the resolution-relevant fields of the consumer's `package.json` as
+ * sorted, stable JSON. When `cwd` sits in a workspace whose root differs, the
+ * root `package.json`'s resolution fields fold into the same digest — a hoisted
+ * root dependency bump changes the types a sub-package sees even though its own
+ * `package.json` text is untouched. Returns `undefined` when there is no
+ * readable/parseable local `package.json` (the caller then treats the check as
+ * a no-op).
  *
  * @param cwd - The consumer project root.
  * @returns The hex digest, or `undefined` when unavailable.
  */
 export function computePackageJsonHash(cwd: string): string | undefined {
-	let raw: string;
-	try {
-		raw = fs.readFileSync(path.join(cwd, "package.json"), "utf8");
-	} catch {
+	const local = resolutionSubset(cwd);
+	if (local === undefined) {
 		return undefined;
 	}
 
-	let parsed: Record<string, unknown>;
-	try {
-		parsed = JSON.parse(raw) as Record<string, unknown>;
-	} catch {
-		return undefined;
-	}
-
-	const subset: Record<string, unknown> = {};
-	for (const field of RESOLUTION_FIELDS) {
-		if (Object.hasOwn(parsed, field)) {
-			subset[field] = parsed[field];
+	const combined: Record<string, unknown> = { local };
+	const root = findWorkspaceRoot(cwd);
+	if (root !== cwd) {
+		const rootSubset = resolutionSubset(root);
+		if (rootSubset !== undefined) {
+			combined["root"] = rootSubset;
 		}
 	}
 
-	return crypto.createHash("sha256").update(stableStringify(subset)).digest("hex");
+	return crypto.createHash("sha256").update(stableStringify(combined)).digest("hex");
 }
 
 /**
@@ -105,6 +106,38 @@ export function applyPackageJsonBust(cwd: string): PackageJsonBustOutcome {
 	fs.rmSync(path.resolve(cwd, CACHE_FILE_TYPE_AWARE), { force: true });
 	fs.rmSync(path.resolve(cwd, CACHE_FILE_DEFAULT), { force: true });
 	return { busted: true, firstRun: false };
+}
+
+/**
+ * Read a directory's `package.json` and project it down to the resolution
+ * fields, or `undefined` when it is absent or unparseable.
+ *
+ * @param directory - The directory whose `package.json` to read.
+ * @returns The resolution-field subset, or `undefined`.
+ */
+function resolutionSubset(directory: string): Record<string, unknown> | undefined {
+	let raw: string;
+	try {
+		raw = fs.readFileSync(path.join(directory, "package.json"), "utf8");
+	} catch {
+		return undefined;
+	}
+
+	let parsed: Record<string, unknown>;
+	try {
+		parsed = JSON.parse(raw) as Record<string, unknown>;
+	} catch {
+		return undefined;
+	}
+
+	const subset: Record<string, unknown> = {};
+	for (const field of RESOLUTION_FIELDS) {
+		if (Object.hasOwn(parsed, field)) {
+			subset[field] = parsed[field];
+		}
+	}
+
+	return subset;
 }
 
 /**

--- a/src/lint-cli/parse.ts
+++ b/src/lint-cli/parse.ts
@@ -1,0 +1,23 @@
+/**
+ * Parse an integer that must be at least `min`, returning `undefined` for any
+ * value that is missing, non-numeric, fractional or below the bound. The three
+ * env-derived numeric knobs (concurrency, files-per-worker, affected-bust
+ * threshold) share this parse and keep their differing failure actions
+ * (undefined vs throw vs default) at their call sites.
+ *
+ * @param value - The raw string to parse (usually an environment variable).
+ * @param min - The inclusive lower bound the parsed integer must meet.
+ * @returns The parsed integer, or `undefined` when it is absent or invalid.
+ */
+export function parseBoundedInteger(value: string | undefined, min: number): number | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	const parsed = Number(value.trim());
+	if (!Number.isInteger(parsed) || parsed < min) {
+		return undefined;
+	}
+
+	return parsed;
+}

--- a/src/lint-cli/passes.ts
+++ b/src/lint-cli/passes.ts
@@ -72,17 +72,20 @@ export const FULL_PASS: PassDescriptor = {
 };
 
 /**
- * Select the ESLint passes for the resolved mode. CI, `--fix` and the explicit
- * `--type-aware=full` escape hatch collapse to the single full pass;
- * `--type-aware=off`/`=only` run their one pass; the default runs the fast and
- * type-aware passes concurrently (the typed one may later be skipped).
+ * Select the ESLint passes for the resolved mode. An explicit `--type-aware`
+ * always wins: `=full` (and `--fix`) collapse to the single full pass, while
+ * `=off`/`=only` run their one pass even in CI. Only when no mode is given does
+ * CI change the default — collapsing the concurrent two-pass split to one full
+ * pass; a local default run keeps the split (the typed pass may later be
+ * skipped). CI's `--cache-strategy content` is applied by the command composer
+ * to whichever pass runs, independently of this selection.
  *
  * @param options - The parsed CLI options.
  * @param ci - Whether the run is in CI.
  * @returns The pass descriptors to plan, in run order.
  */
 export function selectPasses(options: LintCliOptions, ci: boolean): Array<PassDescriptor> {
-	if (ci || options.fix || options.typeAware === "full") {
+	if (options.fix || options.typeAware === "full") {
 		return [FULL_PASS];
 	}
 
@@ -92,6 +95,11 @@ export function selectPasses(options: LintCliOptions, ci: boolean): Array<PassDe
 
 	if (options.typeAware === "only") {
 		return [TYPED_PASS];
+	}
+
+	// No explicit selection: CI collapses the default split to one full pass.
+	if (ci) {
+		return [FULL_PASS];
 	}
 
 	return [FAST_PASS, TYPED_PASS];

--- a/src/lint-cli/passes.ts
+++ b/src/lint-cli/passes.ts
@@ -1,0 +1,98 @@
+// cspell:words typeaware
+import { resolveFastFilesPerWorker } from "./concurrency.ts";
+import type { WorkerLimits } from "./concurrency.ts";
+import { CACHE_FILE_DEFAULT, CACHE_FILE_FAST, CACHE_FILE_TYPE_AWARE } from "./constants.ts";
+import type { LintCliOptions, ToolLabel, TypeAwareMode } from "./types.ts";
+
+/**
+ * The invariant tuple describing one ESLint pass: its cache file, the
+ * `ESLINT_TYPE_AWARE` value it runs under, whether (and how) it folds TS
+ * builder invalidation into its dirty count, the extension family it sizes
+ * from, and how it resolves its files-per-worker. Restated nowhere else — the
+ * mode branches just pick descriptors.
+ */
+export interface PassDescriptor {
+	/** ESLint cache file this pass reads and writes. */
+	cacheFile: string;
+	/**
+	 * Resolve the files-per-worker for this pass from the shared limits and the
+	 * environment. The fast pass uses its own higher break-even.
+	 *
+	 * @param limits - The shared worker limits.
+	 * @param environment - The process environment (for overrides).
+	 * @returns The files-per-worker for this pass.
+	 */
+	filesPerWorker: (limits: WorkerLimits, environment: NodeJS.ProcessEnv) => number;
+	/**
+	 * How the pass folds TS builder invalidation into its dirty count: `"none"`
+	 * runs no builder (the syntactic fast pass); `"only"`/`"full"` run it.
+	 */
+	invalidation: "full" | "none" | "only";
+	/** `concurrently` prefix / ESLint child label. */
+	label: ToolLabel;
+	/**
+	 * Value for the child's `ESLINT_TYPE_AWARE`, moving in lockstep with the
+	 * label. `undefined` leaves it unset (the full config).
+	 */
+	typeAwareEnv: TypeAwareMode | undefined;
+	/** When true, size from TS/JS-family files only (the typed pass). */
+	typeAwareOnly: boolean;
+}
+
+/**
+ * The syntactic-only fast pass (`ESLINT_TYPE_AWARE=off`, `.eslintcache-fast`).
+ */
+export const FAST_PASS: PassDescriptor = {
+	cacheFile: CACHE_FILE_FAST,
+	filesPerWorker: (_limits, environment) => resolveFastFilesPerWorker(environment),
+	invalidation: "none",
+	label: "fast",
+	typeAwareEnv: "off",
+	typeAwareOnly: false,
+};
+
+/** The type-aware pass (`ESLINT_TYPE_AWARE=only`, `.eslintcache-typeaware`). */
+export const TYPED_PASS: PassDescriptor = {
+	cacheFile: CACHE_FILE_TYPE_AWARE,
+	filesPerWorker: (limits) => limits.filesPerWorker,
+	invalidation: "only",
+	label: "typed",
+	typeAwareEnv: "only",
+	typeAwareOnly: true,
+};
+
+/** The full-config pass (env unset, `.eslintcache`): CI, `--fix`, `=full`. */
+export const FULL_PASS: PassDescriptor = {
+	cacheFile: CACHE_FILE_DEFAULT,
+	filesPerWorker: (limits) => limits.filesPerWorker,
+	invalidation: "full",
+	label: "eslint",
+	typeAwareEnv: undefined,
+	typeAwareOnly: false,
+};
+
+/**
+ * Select the ESLint passes for the resolved mode. CI, `--fix` and the explicit
+ * `--type-aware=full` escape hatch collapse to the single full pass;
+ * `--type-aware=off`/`=only` run their one pass; the default runs the fast and
+ * type-aware passes concurrently (the typed one may later be skipped).
+ *
+ * @param options - The parsed CLI options.
+ * @param ci - Whether the run is in CI.
+ * @returns The pass descriptors to plan, in run order.
+ */
+export function selectPasses(options: LintCliOptions, ci: boolean): Array<PassDescriptor> {
+	if (ci || options.fix || options.typeAware === "full") {
+		return [FULL_PASS];
+	}
+
+	if (options.typeAware === "off") {
+		return [FAST_PASS];
+	}
+
+	if (options.typeAware === "only") {
+		return [TYPED_PASS];
+	}
+
+	return [FAST_PASS, TYPED_PASS];
+}

--- a/src/lint-cli/paths.ts
+++ b/src/lint-cli/paths.ts
@@ -1,0 +1,13 @@
+import path from "node:path";
+
+/**
+ * Rewrite a path to forward slashes. The shared separator-splitting primitive
+ * that both the cache-key `normalizePath` and the file walk build on, so there
+ * is a single place that translates OS-native separators to POSIX.
+ *
+ * @param value - The path to rewrite.
+ * @returns The path with every separator as a forward slash.
+ */
+export function toPosix(value: string): string {
+	return value.split(path.sep).join("/");
+}

--- a/src/lint-cli/resolve.ts
+++ b/src/lint-cli/resolve.ts
@@ -1,0 +1,45 @@
+import { getPackageInfoSync } from "local-pkg";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { CliError } from "./types.ts";
+
+/**
+ * Resolve the JavaScript entry of a locally installed CLI (eslint / oxlint)
+ * from the consumer's `node_modules`, walking up from `cwd`. Returning the JS
+ * file lets the caller spawn it with `process.execPath` and no shell, avoiding
+ * Windows `.cmd`/`.ps1` quoting hazards.
+ *
+ * @param name - The package name to resolve (for example `eslint`).
+ * @param cwd - The directory to resolve from.
+ * @returns The absolute path to the package's JavaScript entry.
+ */
+export function resolveLocalBin(name: string, cwd: string): string {
+	const info = getPackageInfoSync(name, { paths: [cwd] });
+	if (info === undefined) {
+		throw new CliError(
+			`Could not find "${name}". Install it in this project to run isentinel-lint.`,
+		);
+	}
+
+	const { bin } = info.packageJson;
+	const relative = typeof bin === "string" ? bin : bin?.[name];
+	if (relative === undefined) {
+		throw new CliError(`Package "${name}" does not declare a "${name}" bin entry.`);
+	}
+
+	return path.resolve(info.rootPath, relative);
+}
+
+/**
+ * Resolve the agent-friendly ESLint formatter shipped alongside this entry.
+ *
+ * TODO(agents-formatter): the `formatter-agents.mjs` module is ported by a
+ * separate change. This resolves its expected dist location lazily so builds
+ * succeed before it lands; it is only ever called when `--agents` is used.
+ *
+ * @returns The absolute path to the agent ESLint formatter.
+ */
+export function resolveAgentsFormatter(): string {
+	return fileURLToPath(new URL("./formatter-agents.mjs", import.meta.url));
+}

--- a/src/lint-cli/resolve.ts
+++ b/src/lint-cli/resolve.ts
@@ -4,17 +4,27 @@ import { fileURLToPath } from "node:url";
 
 import { CliError } from "./types.ts";
 
+/** Memoised {@link resolveLocalBin} results, keyed by `cwd\0name`. */
+const localBinCache = new Map<string, string>();
+
 /**
  * Resolve the JavaScript entry of a locally installed CLI (eslint / oxlint)
  * from the consumer's `node_modules`, walking up from `cwd`. Returning the JS
  * file lets the caller spawn it with `process.execPath` and no shell, avoiding
- * Windows `.cmd`/`.ps1` quoting hazards.
+ * Windows `.cmd`/`.ps1` quoting hazards. Memoised so the two ESLint passes
+ * resolve the same bin once.
  *
  * @param name - The package name to resolve (for example `eslint`).
  * @param cwd - The directory to resolve from.
  * @returns The absolute path to the package's JavaScript entry.
  */
 export function resolveLocalBin(name: string, cwd: string): string {
+	const cacheKey = `${cwd}\0${name}`;
+	const cached = localBinCache.get(cacheKey);
+	if (cached !== undefined) {
+		return cached;
+	}
+
 	const info = getPackageInfoSync(name, { paths: [cwd] });
 	if (info === undefined) {
 		throw new CliError(
@@ -28,7 +38,9 @@ export function resolveLocalBin(name: string, cwd: string): string {
 		throw new CliError(`Package "${name}" does not declare a "${name}" bin entry.`);
 	}
 
-	return path.resolve(info.rootPath, relative);
+	const resolved = path.resolve(info.rootPath, relative);
+	localBinCache.set(cacheKey, resolved);
+	return resolved;
 }
 
 /**

--- a/src/lint-cli/resolve.ts
+++ b/src/lint-cli/resolve.ts
@@ -44,11 +44,9 @@ export function resolveLocalBin(name: string, cwd: string): string {
 }
 
 /**
- * Resolve the agent-friendly ESLint formatter shipped alongside this entry.
- *
- * TODO(agents-formatter): the `formatter-agents.mjs` module is ported by a
- * separate change. This resolves its expected dist location lazily so builds
- * succeed before it lands; it is only ever called when `--agents` is used.
+ * Resolve the agent-friendly ESLint formatter shipped alongside this entry
+ * (built from `src/formatter-agents.ts` to `formatter-agents.mjs`). Resolved
+ * lazily so it is only touched when `--agents` is used.
  *
  * @returns The absolute path to the agent ESLint formatter.
  */

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -7,25 +7,24 @@ import path from "node:path";
 import process from "node:process";
 
 import { isCi } from "../utils.ts";
-import { clearAllCaches, isCacheBusted, listDirtyFiles, normalizePath } from "./cache.ts";
+import type { DirtyCache } from "./cache.ts";
+import { clearAllCaches, isCacheStale, maxMtimeMs, normalizePath, openCache } from "./cache.ts";
 import {
 	buildShellCommand,
 	composeEslintCommand,
 	composeOxlintCommand,
 	formatCommandLine,
 } from "./command.ts";
-import {
-	computeWorkerCount,
-	resolveFastFilesPerWorker,
-	resolveWorkerLimits,
-} from "./concurrency.ts";
-import { CACHE_FILE_DEFAULT, CACHE_FILE_FAST, CACHE_FILE_TYPE_AWARE } from "./constants.ts";
-import { collectCacheBustFiles, collectLintableFiles, isTypeAwareFile } from "./files.ts";
+import { computeWorkerCount, resolveWorkerLimits } from "./concurrency.ts";
+import { collectRepoFiles } from "./files.ts";
+import type { RepoFiles } from "./files.ts";
 import { applyTypeAwareInvalidation } from "./invalidation.ts";
 import { parseArguments } from "./options.ts";
 import { applyPackageJsonBust } from "./package-hash.ts";
+import { selectPasses, TYPED_PASS } from "./passes.ts";
+import type { PassDescriptor } from "./passes.ts";
 import { resolveAgentsFormatter, resolveLocalBin } from "./resolve.ts";
-import type { ChildCommand, ComposeContext, LintCliOptions, ToolLabel } from "./types.ts";
+import type { ChildCommand, LintCliOptions, ToolLabel } from "./types.ts";
 import { CliError } from "./types.ts";
 
 /** Prefix colour per child label for `concurrently`; kept visually distinct. */
@@ -35,6 +34,53 @@ const PREFIX_COLOR: Record<ToolLabel, string> = {
 	oxc: "magenta",
 	typed: "cyan",
 };
+
+/** The stderr notice emitted when the type-aware pass is skipped. */
+const TYPED_SKIP_NOTICE =
+	"isentinel-lint: skipping the type-aware ESLint pass; no type-relevant files " +
+	"changed since the last run.\n";
+
+/** Where a run looks, and whether it may mutate (planning `dryRun` inverse). */
+export interface SizingContext {
+	/** The working directory. */
+	cwd: string;
+	/** When true, never run the builder or delete cache files (`--print`). */
+	dryRun: boolean;
+	/** The process environment. */
+	environment: NodeJS.ProcessEnv;
+}
+
+/** One planned ESLint pass: its descriptor, sizing and run/skip decision. */
+export interface PassPlan {
+	/** The concurrency resolved for the pass. */
+	concurrency: "off" | number;
+	/** The pass descriptor (cache file, label, type-aware env, sizing). */
+	descriptor: PassDescriptor;
+	/** Whether the pass runs; false when auto-skipped. */
+	shouldRun: boolean;
+	/** The stderr notice to emit when skipped, else undefined. */
+	skipReason: string | undefined;
+}
+
+/**
+ * A composed run as plain data: all I/O and mutation happen once in
+ * {@link plan} to build it, then {@link compose} turns it into child commands
+ * with no further I/O.
+ */
+export interface RunPlan {
+	/**
+	 * Absolute path to the agent ESLint formatter (empty unless `--agents`).
+	 */
+	agentsFormatterPath: string;
+	/** Whether the run is in CI. */
+	ci: boolean;
+	/** Whether the oxlint child runs. */
+	oxlint: boolean;
+	/** Whether oxlint receives `--type-aware`. */
+	oxlintTypeAware: boolean;
+	/** The ESLint passes, in run order (empty for oxlint-only runs). */
+	passes: Array<PassPlan>;
+}
 
 /** A composed run: the child commands plus an optional stderr notice. */
 export interface CommandPlan {
@@ -47,129 +93,132 @@ export interface CommandPlan {
 	notice: string | undefined;
 }
 
-/** Shared inputs for sizing a pass: where to look and whether to mutate. */
-interface SizingContext {
-	/** The working directory. */
+/** Shared inputs threaded into {@link sizePass}. */
+interface SizePassContext {
 	cwd: string;
-	/** When true, never run the builder or delete cache files (`--print`). */
-	dryRun: boolean;
-	/** The process environment. */
 	environment: NodeJS.ProcessEnv;
-}
-
-/** Builds an ESLint child command from a partial pass context. */
-type EslintCommandBuilder = (context: Partial<ComposeContext>) => ChildCommand;
-
-/** Inputs to the per-pass dirty-count computation. */
-interface CountDirtyRequest {
-	/** The cache file for this pass. */
-	cacheFileName: string;
-	/** The sizing context (cwd, environment, dry-run flag). */
-	context: SizingContext;
-	/**
-	 * The type-aware invalidation to fold in. `"none"` skips the builder and
-	 * the package.json bust (the fast pass); `"only"`/`"full"` run them.
-	 */
-	invalidation: "full" | "none" | "only";
-	/** When true, size from TS/JS-family files only (the typed pass). */
-	typeAwareOnly: boolean;
+	files: RepoFiles;
+	limits: ReturnType<typeof resolveWorkerLimits>;
+	multiPass: boolean;
+	mutate: boolean;
+	newestBustMtime: number | undefined;
+	options: LintCliOptions;
 }
 
 /**
- * Compose the child commands for the selected mode. Pure with respect to
- * `context.dryRun`: when set it never runs the TS builder, deletes caches or
- * skips the typed pass, keeping `--print` side-effect-free.
+ * Plan the run: collect the repo file list once, apply the package.json and
+ * mtime busts and TypeScript builder invalidation, size each pass and decide
+ * which run. All I/O and mutation happen here, exactly once. When `mutate` is
+ * false (`--print`) the whole mutation step is skipped — no builder, no cache
+ * deletion, no state writes and no auto-skip — while still sizing from the
+ * on-disk caches. The returned value is plain data.
  *
- * The default local mode (no `--type-aware`, no `--fix`, not CI) runs three
- * children concurrently: oxlint, a fast syntactic ESLint pass and a type-aware
- * ESLint pass. The type-aware pass is skipped when nothing type-relevant is
- * dirty (see {@link sizeTypedPass}). Explicit `--type-aware`, `--fix` and CI
- * runs collapse to their single ESLint pass.
+ * @param options - The parsed CLI options.
+ * @param cwd - The working directory.
+ * @param environment - The process environment.
+ * @param mutate - Whether the plan may mutate (false for `--print`).
+ * @returns The run plan.
+ */
+export function plan(
+	options: LintCliOptions,
+	cwd: string,
+	environment: NodeJS.ProcessEnv,
+	mutate: boolean,
+): RunPlan {
+	const ci = isCi(environment);
+	const runOxlint = !options.eslint;
+	const runEslint = !options.oxlint;
+	const oxlintTypeAware = resolveOxlintTypeAware(options);
+	const agentsFormatterPath = options.agents ? resolveAgentsFormatter() : "";
+
+	if (!runEslint) {
+		return { agentsFormatterPath, ci, oxlint: runOxlint, oxlintTypeAware, passes: [] };
+	}
+
+	const descriptors = selectPasses(options, ci);
+	const files = collectRepoFiles(cwd, options.paths);
+	const newestBustMtime = maxMtimeMs(files.bustFiles);
+	const limits = resolveWorkerLimits(environment, availableParallelism());
+
+	// The one mutation gate: bust the type-aware caches when the root
+	// package.json resolution surface changed. Per-pass cache clearing and
+	// builder invalidation follow inside `sizePass`, also gated by `mutate`.
+	// Only meaningful with caching on; `--no-cache` never touches cache state.
+	const hasTypeAwarePass = descriptors.some((descriptor) => descriptor.invalidation !== "none");
+	if (mutate && hasTypeAwarePass && options.cache) {
+		applyPackageJsonBust(cwd);
+	}
+
+	const multiPass = descriptors.length > 1;
+	const passes = descriptors.map((descriptor) => {
+		return sizePass(descriptor, {
+			cwd,
+			environment,
+			files,
+			limits,
+			multiPass,
+			mutate,
+			newestBustMtime,
+			options,
+		});
+	});
+
+	return { agentsFormatterPath, ci, oxlint: runOxlint, oxlintTypeAware, passes };
+}
+
+/**
+ * Turn a {@link RunPlan} into child commands. Pure: no I/O and no mutation, so
+ * it is safe to run for `--print`.
+ *
+ * @param runPlan - The planned run.
+ * @param options - The parsed CLI options (paths and per-tool args).
+ * @returns The composed command plan.
+ */
+export function compose(runPlan: RunPlan, options: LintCliOptions): CommandPlan {
+	const commands: Array<ChildCommand> = [];
+	let notice: string | undefined;
+
+	if (runPlan.oxlint) {
+		commands.push(
+			composeOxlintCommand(options, {
+				oxlintTypeAware: runPlan.oxlintTypeAware,
+				paths: options.paths,
+			}),
+		);
+	}
+
+	for (const pass of runPlan.passes) {
+		if (!pass.shouldRun) {
+			notice = pass.skipReason;
+			continue;
+		}
+
+		commands.push(
+			composeEslintCommand(options, {
+				agentsFormatterPath: runPlan.agentsFormatterPath,
+				cacheLocation: pass.descriptor.cacheFile,
+				ci: runPlan.ci,
+				concurrency: pass.concurrency,
+				eslintLabel: pass.descriptor.label,
+				paths: options.paths,
+				typeAwareEnv: pass.descriptor.typeAwareEnv,
+			}),
+		);
+	}
+
+	return { commands, notice };
+}
+
+/**
+ * Compose the child commands for the selected mode. Compatibility wrapper over
+ * {@link plan} + {@link compose}; `context.dryRun` maps to a non-mutating plan.
  *
  * @param options - The parsed CLI options.
  * @param context - The sizing context (cwd, environment, dry-run flag).
  * @returns The composed command plan.
  */
 export function composeCommands(options: LintCliOptions, context: SizingContext): CommandPlan {
-	const runEslint = !options.oxlint;
-	const runOxlint = !options.eslint;
-	const ci = isCi(context.environment);
-	const oxlintTypeAware = runOxlint && options.oxlintTypeAware && options.typeAware !== "off";
-	const agentsFormatterPath = options.agents ? resolveAgentsFormatter() : "";
-
-	const commands: Array<ChildCommand> = [];
-	let notice: string | undefined;
-
-	if (runOxlint) {
-		commands.push(
-			composeOxlintCommand(options, {
-				agentsFormatterPath,
-				cacheLocation: "",
-				ci,
-				concurrency: "off",
-				eslintLabel: "eslint",
-				oxlintTypeAware,
-				paths: options.paths,
-				typeAwareEnv: undefined,
-			}),
-		);
-	}
-
-	if (!runEslint) {
-		return { commands, notice };
-	}
-
-	function build(overrides: Partial<ComposeContext>): ChildCommand {
-		return composeEslintCommand(options, {
-			agentsFormatterPath,
-			cacheLocation: CACHE_FILE_DEFAULT,
-			ci,
-			concurrency: "off",
-			eslintLabel: "eslint",
-			oxlintTypeAware,
-			paths: options.paths,
-			typeAwareEnv: undefined,
-			...overrides,
-		});
-	}
-
-	if (ci || options.fix || options.typeAware === "full") {
-		// The full config (env unset, `.eslintcache`): --fix writers, CI (needs
-		// unused-disable reporting), and the explicit `full` escape hatch.
-		commands.push(
-			build({
-				cacheLocation: CACHE_FILE_DEFAULT,
-				concurrency: sizeFullPass(options, context),
-			}),
-		);
-		return { commands, notice };
-	}
-
-	if (options.typeAware === "off") {
-		commands.push(fastPassCommand(build, options, context));
-		return { commands, notice };
-	}
-
-	if (options.typeAware === "only") {
-		const { concurrency } = sizeTypedPass(options, context);
-		commands.push(typedPassCommand(build, concurrency));
-		return { commands, notice };
-	}
-
-	// Default: fast pass ∥ typed pass, skipping the typed pass when nothing
-	// type-relevant changed.
-	commands.push(fastPassCommand(build, options, context));
-
-	const { concurrency, dirtyCount } = sizeTypedPass(options, context);
-	if (dirtyCount === 0 && !context.dryRun) {
-		notice =
-			"isentinel-lint: skipping the type-aware ESLint pass; no type-relevant files " +
-			"changed since the last run.\n";
-	} else {
-		commands.push(typedPassCommand(build, concurrency));
-	}
-
-	return { commands, notice };
+	return compose(plan(options, context.cwd, context.environment, !context.dryRun), options);
 }
 
 /**
@@ -227,8 +276,7 @@ export async function runLint(argv: Array<string>): Promise<number> {
 	const environment = process.env;
 
 	const runOxlint = !options.eslint;
-	const oxlintTypeAware = runOxlint && options.oxlintTypeAware && options.typeAware !== "off";
-
+	const oxlintTypeAware = resolveOxlintTypeAware(options);
 	if (runOxlint && oxlintTypeAware && !isPackageExists("oxlint-tsgolint", { paths: [cwd] })) {
 		throw new CliError(
 			"oxlint-tsgolint is not installed, so oxlint cannot run type-aware rules. " +
@@ -236,11 +284,7 @@ export async function runLint(argv: Array<string>): Promise<number> {
 		);
 	}
 
-	const { commands, notice } = composeCommands(options, {
-		cwd,
-		dryRun: options.print,
-		environment,
-	});
+	const { commands, notice } = compose(plan(options, cwd, environment, !options.print), options);
 
 	if (options.print) {
 		for (const command of commands) {
@@ -261,70 +305,49 @@ export async function runLint(argv: Array<string>): Promise<number> {
 	return runConcurrent(commands, cwd);
 }
 
+function resolveOxlintTypeAware(options: LintCliOptions): boolean {
+	return !options.eslint && options.oxlintTypeAware && options.typeAware !== "off";
+}
+
 /**
- * Count the files a pass will re-lint: the union of the mtime/checksum-dirty
- * files and the TypeScript builder's affected set (for type-aware passes),
- * restricted to the pass's own cache and extension family.
+ * Dirty count for a real run: clear the cache wholesale when stale, then fold
+ * TS builder invalidation in, reusing a single loaded cache for the dirty query
+ * and the surgical entry removal.
  *
- * For type-aware passes it first busts the type-aware caches when the root
- * package.json resolution surface changed, then runs the builder. A resolved
- * `.json` edit still propagates: the builder reads its file set from tsconfig
- * (not `targetFiles`), so a `resolveJsonModule` import flags its `.ts`
- * importers as affected even though the `.json` file itself is filtered out of
- * `targetFiles` here — the `.json` never enters the type-aware cache, so
- * removing it would be a no-op.
- *
- * @param options - The parsed CLI options.
- * @param request - The per-pass count request.
+ * @param descriptor - The pass being sized.
+ * @param cacheLocation - The resolved cache file path.
+ * @param targetFiles - The candidate files for this pass.
+ * @param context - The shared sizing inputs.
  * @returns The number of dirty files.
  */
-function countDirty(
-	options: LintCliOptions,
-	{ cacheFileName, context, invalidation, typeAwareOnly }: CountDirtyRequest,
+function mutatingDirtyCount(
+	descriptor: PassDescriptor,
+	cacheLocation: string,
+	targetFiles: Array<string>,
+	{ cwd, environment, newestBustMtime }: SizePassContext,
 ): number {
-	const { cwd, dryRun, environment } = context;
-	const all = collectLintableFiles(cwd, options.paths);
-	const files = typeAwareOnly ? all.filter(isTypeAwareFile) : all;
-	if (!options.cache) {
-		return files.length;
+	if (isCacheStale(cacheLocation, newestBustMtime)) {
+		clearAllCaches(cwd);
+		return targetFiles.length;
 	}
 
-	const cacheLocation = path.resolve(cwd, cacheFileName);
-	const typeAware = invalidation !== "none";
+	const cache: DirtyCache | undefined = openCache(cacheLocation, isCi(environment));
+	const dirty = new Set(
+		(cache?.getUpdatedFiles(targetFiles) ?? targetFiles).map((file) => normalizePath(file)),
+	);
 
-	// Bust the type-aware caches (never `.eslintcache-fast`) when the root
-	// package.json resolution surface changed; a missing cache below then reads
-	// as fully dirty.
-	if (typeAware && !dryRun) {
-		applyPackageJsonBust(cwd);
-	}
-
-	const bustFiles = collectCacheBustFiles(cwd);
-	if (isCacheBusted(cacheLocation, bustFiles)) {
-		if (!dryRun) {
-			clearAllCaches(cwd);
-		}
-
-		return files.length;
-	}
-
-	const dirty = new Set<string>();
-	const dirtyFiles = listDirtyFiles(cacheLocation, files, isCi(environment));
-	for (const file of dirtyFiles) {
-		dirty.add(normalizePath(file));
-	}
-
-	if (typeAware && !dryRun) {
+	if (descriptor.invalidation !== "none") {
 		const outcome = applyTypeAwareInvalidation({
 			alreadyDirty: dirty,
+			cache,
 			cacheLocation,
 			cwd,
 			environment,
-			mode: invalidation === "only" ? "only" : undefined,
-			targetFiles: files,
+			mode: descriptor.invalidation === "only" ? "only" : undefined,
+			targetFiles,
 		});
 		if (outcome.busted) {
-			return files.length;
+			return targetFiles.length;
 		}
 
 		for (const file of outcome.invalidated) {
@@ -336,129 +359,75 @@ function countDirty(
 }
 
 /**
- * Size the fast pass from its own dirty count against `.eslintcache-fast` over
- * every lintable extension. The fast pass lints in isolation, so it never runs
- * the TS builder and uses the higher {@link resolveFastFilesPerWorker}
- * break-even.
+ * Dirty count for `--print`: reflect cache staleness but never delete it, and
+ * never run the builder. Only the mtime/checksum-dirty files count.
  *
- * @param options - The parsed CLI options.
- * @param context - The sizing context.
- * @returns The resolved concurrency value.
+ * @param cacheLocation - The resolved cache file path.
+ * @param targetFiles - The candidate files for this pass.
+ * @param context - The shared sizing inputs.
+ * @returns The number of dirty files.
  */
-function sizeFastPass(options: LintCliOptions, context: SizingContext): "off" | number {
-	if (options.concurrency !== undefined) {
-		return options.concurrency;
+function readOnlyDirtyCount(
+	cacheLocation: string,
+	targetFiles: Array<string>,
+	{ environment, newestBustMtime }: SizePassContext,
+): number {
+	if (isCacheStale(cacheLocation, newestBustMtime)) {
+		return targetFiles.length;
 	}
 
-	const dirtyCount = countDirty(options, {
-		cacheFileName: CACHE_FILE_FAST,
-		context,
-		invalidation: "none",
-		typeAwareOnly: false,
-	});
-	const { maxWorkers } = resolveWorkerLimits(context.environment, availableParallelism());
-	return computeWorkerCount({
-		dirtyCount,
-		filesPerWorker: resolveFastFilesPerWorker(context.environment),
-		maxWorkers,
-	});
+	const cache = openCache(cacheLocation, isCi(environment));
+	return (cache?.getUpdatedFiles(targetFiles) ?? targetFiles).length;
 }
 
 /**
- * Build the fast (syntactic, `ESLINT_TYPE_AWARE=off`) ESLint pass command.
+ * Count the files a pass will re-lint. Routes on `mutate`: the mutating path
+ * clears stale caches and folds builder invalidation into the count (reusing
+ * one loaded cache for the dirty query and the surgical removal); the read-only
+ * path only reports the mtime/checksum-dirty files.
  *
- * @param build - The pass-context command builder.
- * @param options - The parsed CLI options.
- * @param context - The sizing context.
- * @returns The fast-pass child command.
+ * @param descriptor - The pass being sized.
+ * @param context - The shared sizing inputs.
+ * @returns The number of dirty files.
  */
-function fastPassCommand(
-	build: EslintCommandBuilder,
-	options: LintCliOptions,
-	context: SizingContext,
-): ChildCommand {
-	return build({
-		cacheLocation: CACHE_FILE_FAST,
-		concurrency: sizeFastPass(options, context),
-		eslintLabel: "fast",
-		typeAwareEnv: "off",
-	});
-}
-
-/**
- * Build the type-aware (`ESLINT_TYPE_AWARE=only`) ESLint pass command.
- *
- * @param build - The pass-context command builder.
- * @param concurrency - The resolved concurrency for the pass.
- * @returns The typed-pass child command.
- */
-function typedPassCommand(build: EslintCommandBuilder, concurrency: "off" | number): ChildCommand {
-	return build({
-		cacheLocation: CACHE_FILE_TYPE_AWARE,
-		concurrency,
-		eslintLabel: "typed",
-		typeAwareEnv: "only",
-	});
-}
-
-/**
- * Size the type-aware pass from its own dirty count against
- * `.eslintcache-typeaware`, restricted to TS/JS-family files and computed after
- * builder invalidation runs. Returns the dirty count so the caller can skip the
- * pass when nothing type-relevant changed.
- *
- * @param options - The parsed CLI options.
- * @param context - The sizing context.
- * @returns The resolved concurrency and the (post-invalidation) dirty count.
- */
-function sizeTypedPass(
-	options: LintCliOptions,
-	context: SizingContext,
-): { concurrency: "off" | number; dirtyCount: number } {
-	const dirtyCount = countDirty(options, {
-		cacheFileName: CACHE_FILE_TYPE_AWARE,
-		context,
-		invalidation: "only",
-		typeAwareOnly: true,
-	});
-	if (options.concurrency !== undefined) {
-		return { concurrency: options.concurrency, dirtyCount };
+function passDirtyCount(descriptor: PassDescriptor, context: SizePassContext): number {
+	const targetFiles = descriptor.typeAwareOnly ? context.files.typeAware : context.files.lintable;
+	if (!context.options.cache) {
+		return targetFiles.length;
 	}
 
-	const { filesPerWorker, maxWorkers } = resolveWorkerLimits(
-		context.environment,
-		availableParallelism(),
-	);
-	return {
-		concurrency: computeWorkerCount({ dirtyCount, filesPerWorker, maxWorkers }),
-		dirtyCount,
-	};
+	const cacheLocation = path.resolve(context.cwd, descriptor.cacheFile);
+	return context.mutate
+		? mutatingDirtyCount(descriptor, cacheLocation, targetFiles, context)
+		: readOnlyDirtyCount(cacheLocation, targetFiles, context);
 }
 
 /**
- * Size the full-config pass from every dirty lintable file against
- * `.eslintcache`, running builder invalidation for the full type-aware config.
+ * Size one pass: count its dirty files, resolve concurrency and decide whether
+ * it runs. The default-mode type-aware pass is skipped when nothing
+ * type-relevant is dirty; an explicit single-pass mode never skips.
  *
- * @param options - The parsed CLI options.
- * @param context - The sizing context.
- * @returns The resolved concurrency value.
+ * @param descriptor - The pass being sized.
+ * @param context - The shared sizing inputs.
+ * @returns The planned pass.
  */
-function sizeFullPass(options: LintCliOptions, context: SizingContext): "off" | number {
-	if (options.concurrency !== undefined) {
-		return options.concurrency;
+function sizePass(descriptor: PassDescriptor, context: SizePassContext): PassPlan {
+	const dirtyCount = passDirtyCount(descriptor, context);
+
+	const concurrency =
+		context.options.concurrency ??
+		computeWorkerCount({
+			dirtyCount,
+			filesPerWorker: descriptor.filesPerWorker(context.limits, context.environment),
+			maxWorkers: context.limits.maxWorkers,
+		});
+
+	const canSkip = context.mutate && context.multiPass && descriptor === TYPED_PASS;
+	if (canSkip && dirtyCount === 0) {
+		return { concurrency, descriptor, shouldRun: false, skipReason: TYPED_SKIP_NOTICE };
 	}
 
-	const dirtyCount = countDirty(options, {
-		cacheFileName: CACHE_FILE_DEFAULT,
-		context,
-		invalidation: "full",
-		typeAwareOnly: false,
-	});
-	const { filesPerWorker, maxWorkers } = resolveWorkerLimits(
-		context.environment,
-		availableParallelism(),
-	);
-	return computeWorkerCount({ dirtyCount, filesPerWorker, maxWorkers });
+	return { concurrency, descriptor, shouldRun: true, skipReason: undefined };
 }
 
 async function spawnChild(command: ChildCommand, cwd: string): Promise<number> {

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -6,6 +6,7 @@ import { availableParallelism } from "node:os";
 import path from "node:path";
 import process from "node:process";
 
+import { isCi } from "../utils.ts";
 import { clearAllCaches, isCacheBusted, listDirtyFiles, normalizePath } from "./cache.ts";
 import {
 	buildShellCommand,
@@ -72,17 +73,6 @@ interface CountDirtyRequest {
 	invalidation: "full" | "none" | "only";
 	/** When true, size from TS/JS-family files only (the typed pass). */
 	typeAwareOnly: boolean;
-}
-
-/**
- * Whether the environment signals a CI run.
- *
- * @param environment - The environment variables to inspect.
- * @returns Whether CI is active.
- */
-export function isCi(environment: NodeJS.ProcessEnv): boolean {
-	const value = environment["CI"];
-	return value !== undefined && value !== "" && value !== "false" && value !== "0";
 }
 
 /**

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -1,3 +1,4 @@
+// cspell:words lintable typeaware
 import concurrently from "concurrently";
 import { isPackageExists } from "local-pkg";
 import { spawn } from "node:child_process";
@@ -12,14 +13,66 @@ import {
 	composeOxlintCommand,
 	formatCommandLine,
 } from "./command.ts";
-import { computeWorkerCount, resolveWorkerLimits } from "./concurrency.ts";
-import { cacheFileForMode } from "./constants.ts";
-import { collectCacheBustFiles, collectLintableFiles } from "./files.ts";
+import {
+	computeWorkerCount,
+	resolveFastFilesPerWorker,
+	resolveWorkerLimits,
+} from "./concurrency.ts";
+import { CACHE_FILE_DEFAULT, CACHE_FILE_FAST, CACHE_FILE_TYPE_AWARE } from "./constants.ts";
+import { collectCacheBustFiles, collectLintableFiles, isTypeAwareFile } from "./files.ts";
 import { applyTypeAwareInvalidation } from "./invalidation.ts";
 import { parseArguments } from "./options.ts";
+import { applyPackageJsonBust } from "./package-hash.ts";
 import { resolveAgentsFormatter, resolveLocalBin } from "./resolve.ts";
-import type { ChildCommand, ComposeContext, LintCliOptions } from "./types.ts";
+import type { ChildCommand, ComposeContext, LintCliOptions, ToolLabel } from "./types.ts";
 import { CliError } from "./types.ts";
+
+/** Prefix colour per child label for `concurrently`; kept visually distinct. */
+const PREFIX_COLOR: Record<ToolLabel, string> = {
+	eslint: "blue",
+	fast: "blue",
+	oxc: "magenta",
+	typed: "cyan",
+};
+
+/** A composed run: the child commands plus an optional stderr notice. */
+export interface CommandPlan {
+	/** The child commands to run (or print). */
+	commands: Array<ChildCommand>;
+	/**
+	 * A stderr line to emit before running (for example the skipped typed
+	 * pass).
+	 */
+	notice: string | undefined;
+}
+
+/** Shared inputs for sizing a pass: where to look and whether to mutate. */
+interface SizingContext {
+	/** The working directory. */
+	cwd: string;
+	/** When true, never run the builder or delete cache files (`--print`). */
+	dryRun: boolean;
+	/** The process environment. */
+	environment: NodeJS.ProcessEnv;
+}
+
+/** Builds an ESLint child command from a partial pass context. */
+type EslintCommandBuilder = (context: Partial<ComposeContext>) => ChildCommand;
+
+/** Inputs to the per-pass dirty-count computation. */
+interface CountDirtyRequest {
+	/** The cache file for this pass. */
+	cacheFileName: string;
+	/** The sizing context (cwd, environment, dry-run flag). */
+	context: SizingContext;
+	/**
+	 * The type-aware invalidation to fold in. `"none"` skips the builder and
+	 * the package.json bust (the fast pass); `"only"`/`"full"` run them.
+	 */
+	invalidation: "full" | "none" | "only";
+	/** When true, size from TS/JS-family files only (the typed pass). */
+	typeAwareOnly: boolean;
+}
 
 /**
  * Whether the environment signals a CI run.
@@ -33,6 +86,145 @@ export function isCi(environment: NodeJS.ProcessEnv): boolean {
 }
 
 /**
+ * Compose the child commands for the selected mode. Pure with respect to
+ * `context.dryRun`: when set it never runs the TS builder, deletes caches or
+ * skips the typed pass, keeping `--print` side-effect-free.
+ *
+ * The default local mode (no `--type-aware`, no `--fix`, not CI) runs three
+ * children concurrently: oxlint, a fast syntactic ESLint pass and a type-aware
+ * ESLint pass. The type-aware pass is skipped when nothing type-relevant is
+ * dirty (see {@link sizeTypedPass}). Explicit `--type-aware`, `--fix` and CI
+ * runs collapse to their single ESLint pass.
+ *
+ * @param options - The parsed CLI options.
+ * @param context - The sizing context (cwd, environment, dry-run flag).
+ * @returns The composed command plan.
+ */
+export function composeCommands(options: LintCliOptions, context: SizingContext): CommandPlan {
+	const runEslint = !options.oxlint;
+	const runOxlint = !options.eslint;
+	const ci = isCi(context.environment);
+	const oxlintTypeAware = runOxlint && options.oxlintTypeAware && options.typeAware !== "off";
+	const agentsFormatterPath = options.agents ? resolveAgentsFormatter() : "";
+
+	const commands: Array<ChildCommand> = [];
+	let notice: string | undefined;
+
+	if (runOxlint) {
+		commands.push(
+			composeOxlintCommand(options, {
+				agentsFormatterPath,
+				cacheLocation: "",
+				ci,
+				concurrency: "off",
+				eslintLabel: "eslint",
+				oxlintTypeAware,
+				paths: options.paths,
+				typeAwareEnv: undefined,
+			}),
+		);
+	}
+
+	if (!runEslint) {
+		return { commands, notice };
+	}
+
+	function build(overrides: Partial<ComposeContext>): ChildCommand {
+		return composeEslintCommand(options, {
+			agentsFormatterPath,
+			cacheLocation: CACHE_FILE_DEFAULT,
+			ci,
+			concurrency: "off",
+			eslintLabel: "eslint",
+			oxlintTypeAware,
+			paths: options.paths,
+			typeAwareEnv: undefined,
+			...overrides,
+		});
+	}
+
+	if (ci || options.fix || options.typeAware === "full") {
+		// The full config (env unset, `.eslintcache`): --fix writers, CI (needs
+		// unused-disable reporting), and the explicit `full` escape hatch.
+		commands.push(
+			build({
+				cacheLocation: CACHE_FILE_DEFAULT,
+				concurrency: sizeFullPass(options, context),
+			}),
+		);
+		return { commands, notice };
+	}
+
+	if (options.typeAware === "off") {
+		commands.push(fastPassCommand(build, options, context));
+		return { commands, notice };
+	}
+
+	if (options.typeAware === "only") {
+		const { concurrency } = sizeTypedPass(options, context);
+		commands.push(typedPassCommand(build, concurrency));
+		return { commands, notice };
+	}
+
+	// Default: fast pass ∥ typed pass, skipping the typed pass when nothing
+	// type-relevant changed.
+	commands.push(fastPassCommand(build, options, context));
+
+	const { concurrency, dirtyCount } = sizeTypedPass(options, context);
+	if (dirtyCount === 0 && !context.dryRun) {
+		notice =
+			"isentinel-lint: skipping the type-aware ESLint pass; no type-relevant files " +
+			"changed since the last run.\n";
+	} else {
+		commands.push(typedPassCommand(build, concurrency));
+	}
+
+	return { commands, notice };
+}
+
+/**
+ * Run every command concurrently to completion and aggregate their exit codes.
+ * Unlike the previous `killOthersOn: ["failure"]` behaviour, an ordinary lint
+ * failure in one child no longer kills its siblings — each runs to the end so
+ * the user keeps every result. The returned code is non-zero when any child
+ * exited non-zero.
+ *
+ * @param commands - The child commands to run.
+ * @param cwd - The working directory.
+ * @returns The aggregated exit code.
+ */
+export async function runConcurrent(commands: Array<ChildCommand>, cwd: string): Promise<number> {
+	const { result } = concurrently(
+		commands.map((command) => {
+			return {
+				name: command.label,
+				command: buildShellCommand(
+					process.execPath,
+					resolveLocalBin(command.bin, cwd),
+					command.args,
+					process.platform,
+				),
+				env: command.env,
+				prefixColor: PREFIX_COLOR[command.label],
+			};
+		}),
+		{
+			cwd,
+			group: true,
+		},
+	);
+
+	try {
+		await result;
+		return 0;
+	} catch {
+		// Every child ran to completion (no kill-on-failure); the promise rejects
+		// when any exited non-zero.
+		return 1;
+	}
+}
+
+/**
  * Parse, validate, compose and run the hybrid oxlint + ESLint invocation.
  *
  * @param argv - The argument slice (without the node/bin prefix).
@@ -42,9 +234,8 @@ export function isCi(environment: NodeJS.ProcessEnv): boolean {
 export async function runLint(argv: Array<string>): Promise<number> {
 	const options = parseArguments(argv);
 	const cwd = process.cwd();
-	const { env } = process;
+	const environment = process.env;
 
-	const runEslint = !options.oxlint;
 	const runOxlint = !options.eslint;
 	const oxlintTypeAware = runOxlint && options.oxlintTypeAware && options.typeAware !== "off";
 
@@ -55,25 +246,11 @@ export async function runLint(argv: Array<string>): Promise<number> {
 		);
 	}
 
-	const concurrency = runEslint ? resolveEslintConcurrency(options, cwd, options.print) : "off";
-
-	const context: ComposeContext = {
-		agentsFormatterPath: options.agents ? resolveAgentsFormatter() : "",
-		cacheLocation: cacheFileForMode(options.typeAware),
-		ci: isCi(env),
-		concurrency,
-		oxlintTypeAware,
-		paths: options.paths,
-	};
-
-	const commands: Array<ChildCommand> = [];
-	if (runOxlint) {
-		commands.push(composeOxlintCommand(options, context));
-	}
-
-	if (runEslint) {
-		commands.push(composeEslintCommand(options, context));
-	}
+	const { commands, notice } = composeCommands(options, {
+		cwd,
+		dryRun: options.print,
+		environment,
+	});
 
 	if (options.print) {
 		for (const command of commands) {
@@ -83,7 +260,11 @@ export async function runLint(argv: Array<string>): Promise<number> {
 		return 0;
 	}
 
-	if (options.fix || commands.length === 1) {
+	if (notice !== undefined) {
+		process.stderr.write(notice);
+	}
+
+	if (options.fix || commands.length <= 1) {
 		return runSequential(commands, cwd);
 	}
 
@@ -91,27 +272,43 @@ export async function runLint(argv: Array<string>): Promise<number> {
 }
 
 /**
- * Count the files ESLint will re-lint under the target paths, sizing the dirty
- * set as the union of the mtime/checksum-dirty files and the TypeScript builder
- * affected set. Busts the cache (unless `dryRun`) when a config change is
- * detected, treating all as dirty.
+ * Count the files a pass will re-lint: the union of the mtime/checksum-dirty
+ * files and the TypeScript builder's affected set (for type-aware passes),
+ * restricted to the pass's own cache and extension family.
  *
- * The builder pass is side-effecting (it removes stale cache entries and
- * persists incremental state), so it is skipped entirely when `dryRun` is set
- * — this keeps `--print` free of side effects.
+ * For type-aware passes it first busts the type-aware caches when the root
+ * package.json resolution surface changed, then runs the builder. A resolved
+ * `.json` edit still propagates: the builder reads its file set from tsconfig
+ * (not `targetFiles`), so a `resolveJsonModule` import flags its `.ts`
+ * importers as affected even though the `.json` file itself is filtered out of
+ * `targetFiles` here — the `.json` never enters the type-aware cache, so
+ * removing it would be a no-op.
  *
  * @param options - The parsed CLI options.
- * @param cwd - The working directory.
- * @param dryRun - When true, never delete cache files or run the builder.
+ * @param request - The per-pass count request.
  * @returns The number of dirty files.
  */
-function countDirty(options: LintCliOptions, cwd: string, dryRun: boolean): number {
-	const files = collectLintableFiles(cwd, options.paths);
+function countDirty(
+	options: LintCliOptions,
+	{ cacheFileName, context, invalidation, typeAwareOnly }: CountDirtyRequest,
+): number {
+	const { cwd, dryRun, environment } = context;
+	const all = collectLintableFiles(cwd, options.paths);
+	const files = typeAwareOnly ? all.filter(isTypeAwareFile) : all;
 	if (!options.cache) {
 		return files.length;
 	}
 
-	const cacheLocation = path.resolve(cwd, cacheFileForMode(options.typeAware));
+	const cacheLocation = path.resolve(cwd, cacheFileName);
+	const typeAware = invalidation !== "none";
+
+	// Bust the type-aware caches (never `.eslintcache-fast`) when the root
+	// package.json resolution surface changed; a missing cache below then reads
+	// as fully dirty.
+	if (typeAware && !dryRun) {
+		applyPackageJsonBust(cwd);
+	}
+
 	const bustFiles = collectCacheBustFiles(cwd);
 	if (isCacheBusted(cacheLocation, bustFiles)) {
 		if (!dryRun) {
@@ -121,21 +318,19 @@ function countDirty(options: LintCliOptions, cwd: string, dryRun: boolean): numb
 		return files.length;
 	}
 
-	const dirtyFiles = listDirtyFiles(cacheLocation, files, isCi(process.env));
 	const dirty = new Set<string>();
+	const dirtyFiles = listDirtyFiles(cacheLocation, files, isCi(environment));
 	for (const file of dirtyFiles) {
 		dirty.add(normalizePath(file));
 	}
 
-	// A `--type-aware=off` pass lints each file in isolation, so cross-file type
-	// flow can't change its result and builder invalidation is unnecessary.
-	if (!dryRun && options.typeAware !== "off") {
+	if (typeAware && !dryRun) {
 		const outcome = applyTypeAwareInvalidation({
 			alreadyDirty: dirty,
 			cacheLocation,
 			cwd,
-			environment: process.env,
-			mode: options.typeAware,
+			environment,
+			mode: invalidation === "only" ? "only" : undefined,
 			targetFiles: files,
 		});
 		if (outcome.busted) {
@@ -151,26 +346,128 @@ function countDirty(options: LintCliOptions, cwd: string, dryRun: boolean): numb
 }
 
 /**
- * Size ESLint's `--concurrency` from how many files it will actually re-lint.
- * Never writes the cache; when a config change busts it, deletes every cache
- * file (unless `dryRun`) and treats everything as dirty.
+ * Size the fast pass from its own dirty count against `.eslintcache-fast` over
+ * every lintable extension. The fast pass lints in isolation, so it never runs
+ * the TS builder and uses the higher {@link resolveFastFilesPerWorker}
+ * break-even.
  *
  * @param options - The parsed CLI options.
- * @param cwd - The working directory.
- * @param dryRun - When true, never delete cache files.
+ * @param context - The sizing context.
  * @returns The resolved concurrency value.
  */
-function resolveEslintConcurrency(
-	options: LintCliOptions,
-	cwd: string,
-	dryRun: boolean,
-): "off" | number {
+function sizeFastPass(options: LintCliOptions, context: SizingContext): "off" | number {
 	if (options.concurrency !== undefined) {
 		return options.concurrency;
 	}
 
-	const dirtyCount = countDirty(options, cwd, dryRun);
-	const { filesPerWorker, maxWorkers } = resolveWorkerLimits(process.env, availableParallelism());
+	const dirtyCount = countDirty(options, {
+		cacheFileName: CACHE_FILE_FAST,
+		context,
+		invalidation: "none",
+		typeAwareOnly: false,
+	});
+	const { maxWorkers } = resolveWorkerLimits(context.environment, availableParallelism());
+	return computeWorkerCount({
+		dirtyCount,
+		filesPerWorker: resolveFastFilesPerWorker(context.environment),
+		maxWorkers,
+	});
+}
+
+/**
+ * Build the fast (syntactic, `ESLINT_TYPE_AWARE=off`) ESLint pass command.
+ *
+ * @param build - The pass-context command builder.
+ * @param options - The parsed CLI options.
+ * @param context - The sizing context.
+ * @returns The fast-pass child command.
+ */
+function fastPassCommand(
+	build: EslintCommandBuilder,
+	options: LintCliOptions,
+	context: SizingContext,
+): ChildCommand {
+	return build({
+		cacheLocation: CACHE_FILE_FAST,
+		concurrency: sizeFastPass(options, context),
+		eslintLabel: "fast",
+		typeAwareEnv: "off",
+	});
+}
+
+/**
+ * Build the type-aware (`ESLINT_TYPE_AWARE=only`) ESLint pass command.
+ *
+ * @param build - The pass-context command builder.
+ * @param concurrency - The resolved concurrency for the pass.
+ * @returns The typed-pass child command.
+ */
+function typedPassCommand(build: EslintCommandBuilder, concurrency: "off" | number): ChildCommand {
+	return build({
+		cacheLocation: CACHE_FILE_TYPE_AWARE,
+		concurrency,
+		eslintLabel: "typed",
+		typeAwareEnv: "only",
+	});
+}
+
+/**
+ * Size the type-aware pass from its own dirty count against
+ * `.eslintcache-typeaware`, restricted to TS/JS-family files and computed after
+ * builder invalidation runs. Returns the dirty count so the caller can skip the
+ * pass when nothing type-relevant changed.
+ *
+ * @param options - The parsed CLI options.
+ * @param context - The sizing context.
+ * @returns The resolved concurrency and the (post-invalidation) dirty count.
+ */
+function sizeTypedPass(
+	options: LintCliOptions,
+	context: SizingContext,
+): { concurrency: "off" | number; dirtyCount: number } {
+	const dirtyCount = countDirty(options, {
+		cacheFileName: CACHE_FILE_TYPE_AWARE,
+		context,
+		invalidation: "only",
+		typeAwareOnly: true,
+	});
+	if (options.concurrency !== undefined) {
+		return { concurrency: options.concurrency, dirtyCount };
+	}
+
+	const { filesPerWorker, maxWorkers } = resolveWorkerLimits(
+		context.environment,
+		availableParallelism(),
+	);
+	return {
+		concurrency: computeWorkerCount({ dirtyCount, filesPerWorker, maxWorkers }),
+		dirtyCount,
+	};
+}
+
+/**
+ * Size the full-config pass from every dirty lintable file against
+ * `.eslintcache`, running builder invalidation for the full type-aware config.
+ *
+ * @param options - The parsed CLI options.
+ * @param context - The sizing context.
+ * @returns The resolved concurrency value.
+ */
+function sizeFullPass(options: LintCliOptions, context: SizingContext): "off" | number {
+	if (options.concurrency !== undefined) {
+		return options.concurrency;
+	}
+
+	const dirtyCount = countDirty(options, {
+		cacheFileName: CACHE_FILE_DEFAULT,
+		context,
+		invalidation: "full",
+		typeAwareOnly: false,
+	});
+	const { filesPerWorker, maxWorkers } = resolveWorkerLimits(
+		context.environment,
+		availableParallelism(),
+	);
 	return computeWorkerCount({ dirtyCount, filesPerWorker, maxWorkers });
 }
 
@@ -201,34 +498,4 @@ async function runSequential(commands: Array<ChildCommand>, cwd: string): Promis
 	}
 
 	return exitCode;
-}
-
-async function runConcurrent(commands: Array<ChildCommand>, cwd: string): Promise<number> {
-	const { result } = concurrently(
-		commands.map((command) => {
-			return {
-				name: command.label,
-				command: buildShellCommand(
-					process.execPath,
-					resolveLocalBin(command.bin, cwd),
-					command.args,
-					process.platform,
-				),
-				env: command.env,
-				prefixColor: command.label === "oxc" ? "magenta" : "blue",
-			};
-		}),
-		{
-			cwd,
-			group: true,
-			killOthersOn: ["failure"],
-		},
-	);
-
-	try {
-		await result;
-		return 0;
-	} catch {
-		return 1;
-	}
 }

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -18,6 +18,7 @@ import {
 import { computeWorkerCount, resolveWorkerLimits } from "./concurrency.ts";
 import { collectRepoFiles } from "./files.ts";
 import type { RepoFiles } from "./files.ts";
+import { resolveOxlintRun } from "./hybrid.ts";
 import { applyTypeAwareInvalidation } from "./invalidation.ts";
 import { parseArguments } from "./options.ts";
 import { applyPackageJsonBust } from "./package-hash.ts";
@@ -76,6 +77,11 @@ export interface RunPlan {
 	ci: boolean;
 	/** Whether the oxlint child runs. */
 	oxlint: boolean;
+	/**
+	 * A stderr warning about the oxlint decision (non-hybrid config drop or an
+	 * undeterminable hybrid status), or `undefined`.
+	 */
+	oxlintReason: string | undefined;
 	/** Whether oxlint receives `--type-aware`. */
 	oxlintTypeAware: boolean;
 	/** The ESLint passes, in run order (empty for oxlint-only runs). */
@@ -132,13 +138,26 @@ export function plan(
 	const agentsFormatterPath = options.agents ? resolveAgentsFormatter() : "";
 
 	if (!runEslint) {
-		return { agentsFormatterPath, ci, oxlint: runOxlint, oxlintTypeAware, passes: [] };
+		return {
+			agentsFormatterPath,
+			ci,
+			oxlint: runOxlint,
+			oxlintReason: undefined,
+			oxlintTypeAware,
+			passes: [],
+		};
 	}
 
 	const descriptors = selectPasses(options, ci);
 	const files = collectRepoFiles(cwd, options.paths);
 	const newestBustMtime = maxMtimeMs(files.bustFiles);
 	const limits = resolveWorkerLimits(environment, availableParallelism());
+
+	// Hybrid gate: when both engines would run, oxlint only runs if the resolved
+	// ESLint config is hybrid (`oxlint: true`); otherwise the two engines would
+	// double-lint every mapped rule. Decided here (before any child spawns) so
+	// `--fix` never runs oxlint's fixes against a non-hybrid config.
+	const oxlintDecision = resolveOxlintRun({ cwd, files, mutate, runEslint, runOxlint });
 
 	// The one mutation gate: bust the type-aware caches when the root
 	// package.json resolution surface changed. Per-pass cache clearing and
@@ -163,7 +182,14 @@ export function plan(
 		});
 	});
 
-	return { agentsFormatterPath, ci, oxlint: runOxlint, oxlintTypeAware, passes };
+	return {
+		agentsFormatterPath,
+		ci,
+		oxlint: oxlintDecision.run,
+		oxlintReason: oxlintDecision.reason,
+		oxlintTypeAware,
+		passes,
+	};
 }
 
 /**
@@ -176,7 +202,11 @@ export function plan(
  */
 export function compose(runPlan: RunPlan, options: LintCliOptions): CommandPlan {
 	const commands: Array<ChildCommand> = [];
-	let notice: string | undefined;
+	const notices: Array<string> = [];
+
+	if (runPlan.oxlintReason !== undefined) {
+		notices.push(runPlan.oxlintReason);
+	}
 
 	if (runPlan.oxlint) {
 		commands.push(
@@ -189,7 +219,10 @@ export function compose(runPlan: RunPlan, options: LintCliOptions): CommandPlan 
 
 	for (const pass of runPlan.passes) {
 		if (!pass.shouldRun) {
-			notice = pass.skipReason;
+			if (pass.skipReason !== undefined) {
+				notices.push(pass.skipReason);
+			}
+
 			continue;
 		}
 
@@ -206,7 +239,7 @@ export function compose(runPlan: RunPlan, options: LintCliOptions): CommandPlan 
 		);
 	}
 
-	return { commands, notice };
+	return { commands, notice: notices.length > 0 ? notices.join("") : undefined };
 }
 
 /**

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -1,0 +1,201 @@
+import concurrently from "concurrently";
+import { isPackageExists } from "local-pkg";
+import { spawn } from "node:child_process";
+import { availableParallelism } from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+import { clearAllCaches, countDirtyFiles, isCacheBusted } from "./cache.ts";
+import {
+	buildShellCommand,
+	composeEslintCommand,
+	composeOxlintCommand,
+	formatCommandLine,
+} from "./command.ts";
+import { computeWorkerCount, resolveWorkerLimits } from "./concurrency.ts";
+import { cacheFileForMode } from "./constants.ts";
+import { collectCacheBustFiles, collectLintableFiles } from "./files.ts";
+import { parseArguments } from "./options.ts";
+import { resolveAgentsFormatter, resolveLocalBin } from "./resolve.ts";
+import type { ChildCommand, ComposeContext, LintCliOptions } from "./types.ts";
+import { CliError } from "./types.ts";
+
+/**
+ * Whether the environment signals a CI run.
+ *
+ * @param environment - The environment variables to inspect.
+ * @returns Whether CI is active.
+ */
+export function isCi(environment: NodeJS.ProcessEnv): boolean {
+	const value = environment["CI"];
+	return value !== undefined && value !== "" && value !== "false" && value !== "0";
+}
+
+/**
+ * Parse, validate, compose and run the hybrid oxlint + ESLint invocation.
+ *
+ * @param argv - The argument slice (without the node/bin prefix).
+ * @returns The process exit code.
+ * @rejects {CliError} When the arguments are invalid or a tool is missing.
+ */
+export async function runLint(argv: Array<string>): Promise<number> {
+	const options = parseArguments(argv);
+	const cwd = process.cwd();
+	const { env } = process;
+
+	const runEslint = !options.oxlint;
+	const runOxlint = !options.eslint;
+	const oxlintTypeAware = runOxlint && options.oxlintTypeAware && options.typeAware !== "off";
+
+	if (runOxlint && oxlintTypeAware && !isPackageExists("oxlint-tsgolint", { paths: [cwd] })) {
+		throw new CliError(
+			"oxlint-tsgolint is not installed, so oxlint cannot run type-aware rules. " +
+				"Install oxlint-tsgolint, or pass --no-oxlint-type-aware to skip type-aware linting.",
+		);
+	}
+
+	const concurrency = runEslint ? resolveEslintConcurrency(options, cwd, options.print) : "off";
+
+	const context: ComposeContext = {
+		agentsFormatterPath: options.agents ? resolveAgentsFormatter() : "",
+		cacheLocation: cacheFileForMode(options.typeAware),
+		ci: isCi(env),
+		concurrency,
+		oxlintTypeAware,
+		paths: options.paths,
+	};
+
+	const commands: Array<ChildCommand> = [];
+	if (runOxlint) {
+		commands.push(composeOxlintCommand(options, context));
+	}
+
+	if (runEslint) {
+		commands.push(composeEslintCommand(options, context));
+	}
+
+	if (options.print) {
+		for (const command of commands) {
+			process.stdout.write(`${formatCommandLine(command)}\n`);
+		}
+
+		return 0;
+	}
+
+	if (options.fix || commands.length === 1) {
+		return runSequential(commands, cwd);
+	}
+
+	return runConcurrent(commands, cwd);
+}
+
+/**
+ * Count the files ESLint will re-lint under the target paths. Busts the cache
+ * (unless `dryRun`) when a config change is detected, treating all as dirty.
+ *
+ * @param options - The parsed CLI options.
+ * @param cwd - The working directory.
+ * @param dryRun - When true, never delete cache files.
+ * @returns The number of dirty files.
+ */
+function countDirty(options: LintCliOptions, cwd: string, dryRun: boolean): number {
+	const files = collectLintableFiles(cwd, options.paths);
+	if (!options.cache) {
+		return files.length;
+	}
+
+	const cacheLocation = path.resolve(cwd, cacheFileForMode(options.typeAware));
+	const bustFiles = collectCacheBustFiles(cwd);
+	if (isCacheBusted(cacheLocation, bustFiles)) {
+		if (!dryRun) {
+			clearAllCaches(cwd);
+		}
+
+		return files.length;
+	}
+
+	return countDirtyFiles(cacheLocation, files, isCi(process.env));
+}
+
+/**
+ * Size ESLint's `--concurrency` from how many files it will actually re-lint.
+ * Never writes the cache; when a config change busts it, deletes every cache
+ * file (unless `dryRun`) and treats everything as dirty.
+ *
+ * @param options - The parsed CLI options.
+ * @param cwd - The working directory.
+ * @param dryRun - When true, never delete cache files.
+ * @returns The resolved concurrency value.
+ */
+function resolveEslintConcurrency(
+	options: LintCliOptions,
+	cwd: string,
+	dryRun: boolean,
+): "off" | number {
+	if (options.concurrency !== undefined) {
+		return options.concurrency;
+	}
+
+	const dirtyCount = countDirty(options, cwd, dryRun);
+	const { filesPerWorker, maxWorkers } = resolveWorkerLimits(process.env, availableParallelism());
+	return computeWorkerCount({ dirtyCount, filesPerWorker, maxWorkers });
+}
+
+async function spawnChild(command: ChildCommand, cwd: string): Promise<number> {
+	const binJsPath = resolveLocalBin(command.bin, cwd);
+	return new Promise((resolve) => {
+		const child = spawn(process.execPath, [binJsPath, ...command.args], {
+			cwd,
+			env: { ...process.env, ...command.env },
+			stdio: "inherit",
+		});
+		child.on("error", () => {
+			resolve(1);
+		});
+		child.on("close", (code) => {
+			resolve(code ?? 1);
+		});
+	});
+}
+
+async function runSequential(commands: Array<ChildCommand>, cwd: string): Promise<number> {
+	let exitCode = 0;
+	for (const command of commands) {
+		const code = await spawnChild(command, cwd);
+		if (code !== 0) {
+			exitCode = code;
+		}
+	}
+
+	return exitCode;
+}
+
+async function runConcurrent(commands: Array<ChildCommand>, cwd: string): Promise<number> {
+	const { result } = concurrently(
+		commands.map((command) => {
+			return {
+				name: command.label,
+				command: buildShellCommand(
+					process.execPath,
+					resolveLocalBin(command.bin, cwd),
+					command.args,
+					process.platform,
+				),
+				env: command.env,
+				prefixColor: command.label === "oxc" ? "magenta" : "blue",
+			};
+		}),
+		{
+			cwd,
+			group: true,
+			killOthersOn: ["failure"],
+		},
+	);
+
+	try {
+		await result;
+		return 0;
+	} catch {
+		return 1;
+	}
+}

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -5,7 +5,7 @@ import { availableParallelism } from "node:os";
 import path from "node:path";
 import process from "node:process";
 
-import { clearAllCaches, countDirtyFiles, isCacheBusted } from "./cache.ts";
+import { clearAllCaches, isCacheBusted, listDirtyFiles, normalizePath } from "./cache.ts";
 import {
 	buildShellCommand,
 	composeEslintCommand,
@@ -15,6 +15,7 @@ import {
 import { computeWorkerCount, resolveWorkerLimits } from "./concurrency.ts";
 import { cacheFileForMode } from "./constants.ts";
 import { collectCacheBustFiles, collectLintableFiles } from "./files.ts";
+import { applyTypeAwareInvalidation } from "./invalidation.ts";
 import { parseArguments } from "./options.ts";
 import { resolveAgentsFormatter, resolveLocalBin } from "./resolve.ts";
 import type { ChildCommand, ComposeContext, LintCliOptions } from "./types.ts";
@@ -90,12 +91,18 @@ export async function runLint(argv: Array<string>): Promise<number> {
 }
 
 /**
- * Count the files ESLint will re-lint under the target paths. Busts the cache
- * (unless `dryRun`) when a config change is detected, treating all as dirty.
+ * Count the files ESLint will re-lint under the target paths, sizing the dirty
+ * set as the union of the mtime/checksum-dirty files and the TypeScript builder
+ * affected set. Busts the cache (unless `dryRun`) when a config change is
+ * detected, treating all as dirty.
+ *
+ * The builder pass is side-effecting (it removes stale cache entries and
+ * persists incremental state), so it is skipped entirely when `dryRun` is set
+ * — this keeps `--print` free of side effects.
  *
  * @param options - The parsed CLI options.
  * @param cwd - The working directory.
- * @param dryRun - When true, never delete cache files.
+ * @param dryRun - When true, never delete cache files or run the builder.
  * @returns The number of dirty files.
  */
 function countDirty(options: LintCliOptions, cwd: string, dryRun: boolean): number {
@@ -114,7 +121,33 @@ function countDirty(options: LintCliOptions, cwd: string, dryRun: boolean): numb
 		return files.length;
 	}
 
-	return countDirtyFiles(cacheLocation, files, isCi(process.env));
+	const dirtyFiles = listDirtyFiles(cacheLocation, files, isCi(process.env));
+	const dirty = new Set<string>();
+	for (const file of dirtyFiles) {
+		dirty.add(normalizePath(file));
+	}
+
+	// A `--type-aware=off` pass lints each file in isolation, so cross-file type
+	// flow can't change its result and builder invalidation is unnecessary.
+	if (!dryRun && options.typeAware !== "off") {
+		const outcome = applyTypeAwareInvalidation({
+			alreadyDirty: dirty,
+			cacheLocation,
+			cwd,
+			environment: process.env,
+			mode: options.typeAware,
+			targetFiles: files,
+		});
+		if (outcome.busted) {
+			return files.length;
+		}
+
+		for (const file of outcome.invalidated) {
+			dirty.add(file);
+		}
+	}
+
+	return dirty.size;
 }
 
 /**

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -41,6 +41,11 @@ const TYPED_SKIP_NOTICE =
 	"isentinel-lint: skipping the type-aware ESLint pass; no type-relevant files " +
 	"changed since the last run.\n";
 
+/** The stderr notice emitted when a lint target resolves outside the cwd. */
+const OUTSIDE_CWD_NOTICE =
+	"isentinel-lint: a lint target resolves outside the working directory; sizing " +
+	"conservatively and not auto-skipping the type-aware pass.\n";
+
 /** Where a run looks, and whether it may mutate (planning `dryRun` inverse). */
 export interface SizingContext {
 	/** The working directory. */
@@ -86,6 +91,11 @@ export interface RunPlan {
 	oxlintTypeAware: boolean;
 	/** The ESLint passes, in run order (empty for oxlint-only runs). */
 	passes: Array<PassPlan>;
+	/**
+	 * Whether a lint target resolved outside the cwd, so the passes were sized
+	 * conservatively and the typed-pass auto-skip was disabled. Emits a notice.
+	 */
+	targetsOutsideCwd: boolean;
 }
 
 /** A composed run: the child commands plus an optional stderr notice. */
@@ -101,6 +111,12 @@ export interface CommandPlan {
 
 /** Shared inputs threaded into {@link sizePass}. */
 interface SizePassContext {
+	/**
+	 * Whether every ESLint cache was already cleared up front (an mtime bust
+	 * affecting some selected pass). When true, every file counts as dirty and
+	 * the builder is skipped — everything re-lints regardless.
+	 */
+	cachesCleared: boolean;
 	cwd: string;
 	environment: NodeJS.ProcessEnv;
 	files: RepoFiles;
@@ -145,6 +161,7 @@ export function plan(
 			oxlintReason: undefined,
 			oxlintTypeAware,
 			passes: [],
+			targetsOutsideCwd: false,
 		};
 	}
 
@@ -159,18 +176,31 @@ export function plan(
 	// `--fix` never runs oxlint's fixes against a non-hybrid config.
 	const oxlintDecision = resolveOxlintRun({ cwd, files, mutate, runEslint, runOxlint });
 
-	// The one mutation gate: bust the type-aware caches when the root
-	// package.json resolution surface changed. Per-pass cache clearing and
-	// builder invalidation follow inside `sizePass`, also gated by `mutate`.
-	// Only meaningful with caching on; `--no-cache` never touches cache state.
+	// Evaluate every bust up front, before sizing any pass, then clear once. This
+	// ordering is load-bearing: a per-pass staleness check that cleared caches
+	// mid-loop could delete a cache an earlier pass was already sized against,
+	// under-provisioning that pass's workers. Only meaningful with caching on;
+	// `--no-cache` never touches cache state, and `--print` (mutate=false) never
+	// mutates.
+	//
+	// The package.json bust runs first and deletes only the type-aware caches (a
+	// syntactic lint is immune to resolution changes), so it does NOT set
+	// `cachesCleared` — the fast cache survives it. The mtime bust below is the
+	// wholesale one.
+	const canMutateCaches = mutate && options.cache;
 	const hasTypeAwarePass = descriptors.some((descriptor) => descriptor.invalidation !== "none");
-	if (mutate && hasTypeAwarePass && options.cache) {
+	if (canMutateCaches && hasTypeAwarePass) {
 		applyPackageJsonBust(cwd);
 	}
+
+	const cachesCleared = canMutateCaches
+		? clearStaleCaches(descriptors, cwd, newestBustMtime)
+		: false;
 
 	const multiPass = descriptors.length > 1;
 	const passes = descriptors.map((descriptor) => {
 		return sizePass(descriptor, {
+			cachesCleared,
 			cwd,
 			environment,
 			files,
@@ -189,6 +219,7 @@ export function plan(
 		oxlintReason: oxlintDecision.reason,
 		oxlintTypeAware,
 		passes,
+		targetsOutsideCwd: files.targetsOutsideCwd,
 	};
 }
 
@@ -206,6 +237,10 @@ export function compose(runPlan: RunPlan, options: LintCliOptions): CommandPlan 
 
 	if (runPlan.oxlintReason !== undefined) {
 		notices.push(runPlan.oxlintReason);
+	}
+
+	if (runPlan.targetsOutsideCwd) {
+		notices.push(OUTSIDE_CWD_NOTICE);
 	}
 
 	if (runPlan.oxlint) {
@@ -300,22 +335,17 @@ export async function runConcurrent(commands: Array<ChildCommand>, cwd: string):
  * Parse, validate, compose and run the hybrid oxlint + ESLint invocation.
  *
  * @param argv - The argument slice (without the node/bin prefix).
+ * @param cwd - The working directory (defaults to `process.cwd()`; injected in tests).
+ * @param environment - The process environment (defaults to `process.env`).
  * @returns The process exit code.
  * @rejects {CliError} When the arguments are invalid or a tool is missing.
  */
-export async function runLint(argv: Array<string>): Promise<number> {
+export async function runLint(
+	argv: Array<string>,
+	cwd: string = process.cwd(),
+	environment: NodeJS.ProcessEnv = process.env,
+): Promise<number> {
 	const options = parseArguments(argv);
-	const cwd = process.cwd();
-	const environment = process.env;
-
-	const runOxlint = !options.eslint;
-	const oxlintTypeAware = resolveOxlintTypeAware(options);
-	if (runOxlint && oxlintTypeAware && !isPackageExists("oxlint-tsgolint", { paths: [cwd] })) {
-		throw new CliError(
-			"oxlint-tsgolint is not installed, so oxlint cannot run type-aware rules. " +
-				"Install oxlint-tsgolint, or pass --no-oxlint-type-aware to skip type-aware linting.",
-		);
-	}
 
 	const { commands, notice } = compose(plan(options, cwd, environment, !options.print), options);
 
@@ -325,6 +355,22 @@ export async function runLint(argv: Array<string>): Promise<number> {
 		}
 
 		return 0;
+	}
+
+	// Only require oxlint-tsgolint when an oxlint child that actually carries
+	// `--type-aware` survived composition. The hybrid gate may have dropped
+	// oxlint (non-hybrid config), in which case the run degrades to ESLint-only
+	// rather than hard-erroring; `--print` returned above and never errors.
+	// Explicit `--oxlint` bypasses the gate but still composes the child, so the
+	// check still applies to it.
+	const needsTsgolint = commands.some(
+		(command) => command.bin === "oxlint" && command.args.includes("--type-aware"),
+	);
+	if (needsTsgolint && !isPackageExists("oxlint-tsgolint", { paths: [cwd] })) {
+		throw new CliError(
+			"oxlint-tsgolint is not installed, so oxlint cannot run type-aware rules. " +
+				"Install oxlint-tsgolint, or pass --no-oxlint-type-aware to skip type-aware linting.",
+		);
 	}
 
 	if (notice !== undefined) {
@@ -353,14 +399,40 @@ function resolveOxlintTypeAware(options: LintCliOptions): boolean {
  * @param context - The shared sizing inputs.
  * @returns The number of dirty files.
  */
+/**
+ * Evaluate the mtime bust for every selected pass's cache file and, if any is
+ * stale, clear all managed caches exactly once. Returns whether the wholesale
+ * clear happened so sizing can treat every file as dirty without re-checking.
+ *
+ * @param descriptors - The selected pass descriptors.
+ * @param cwd - The working directory.
+ * @param newestBustMtime - The newest cache-bust mtime (see {@link maxMtimeMs}).
+ * @returns True when the caches were cleared.
+ */
+function clearStaleCaches(
+	descriptors: Array<PassDescriptor>,
+	cwd: string,
+	newestBustMtime: number | undefined,
+): boolean {
+	const stale = descriptors.some((descriptor) => {
+		return isCacheStale(path.resolve(cwd, descriptor.cacheFile), newestBustMtime);
+	});
+	if (stale) {
+		clearAllCaches(cwd);
+	}
+
+	return stale;
+}
+
 function mutatingDirtyCount(
 	descriptor: PassDescriptor,
 	cacheLocation: string,
 	targetFiles: Array<string>,
-	{ cwd, environment, newestBustMtime }: SizePassContext,
+	{ cachesCleared, cwd, environment }: SizePassContext,
 ): number {
-	if (isCacheStale(cacheLocation, newestBustMtime)) {
-		clearAllCaches(cwd);
+	if (cachesCleared) {
+		// A bust already cleared every cache up front (see `plan`), so every file
+		// is dirty and the builder would be pure waste — everything re-lints.
 		return targetFiles.length;
 	}
 
@@ -446,16 +518,31 @@ function passDirtyCount(descriptor: PassDescriptor, context: SizePassContext): n
  */
 function sizePass(descriptor: PassDescriptor, context: SizePassContext): PassPlan {
 	const dirtyCount = passDirtyCount(descriptor, context);
+	const conservative = context.files.targetsOutsideCwd;
+	const filesPerWorker = descriptor.filesPerWorker(context.limits, context.environment);
+
+	// Outside-cwd targets are absent from the cwd-relative listing, so the dirty
+	// count under-counts them — size for the worker cap instead (maxWorkers *
+	// filesPerWorker ceils back to exactly maxWorkers).
+	const sizingDirtyCount = conservative ? context.limits.maxWorkers * filesPerWorker : dirtyCount;
 
 	const concurrency =
 		context.options.concurrency ??
 		computeWorkerCount({
-			dirtyCount,
-			filesPerWorker: descriptor.filesPerWorker(context.limits, context.environment),
+			dirtyCount: sizingDirtyCount,
+			filesPerWorker,
 			maxWorkers: context.limits.maxWorkers,
 		});
 
-	const canSkip = context.mutate && context.multiPass && descriptor === TYPED_PASS;
+	// The typed pass may only auto-skip when the dirty count is trustworthy; an
+	// outside-cwd target makes it unknowable, so never skip in that case.
+	//
+	// Known limitation: a skipped pass never runs, so ESLint's own per-entry
+	// config hash cannot catch a config change that arrived through a module the
+	// `eslint.config.*` imports (only the config file's own mtime busts here).
+	// Touch the config, or run with `--no-cache`, after editing such a module.
+	const canSkip =
+		context.mutate && context.multiPass && descriptor === TYPED_PASS && !conservative;
 	if (canSkip && dirtyCount === 0) {
 		return { concurrency, descriptor, shouldRun: false, skipReason: TYPED_SKIP_NOTICE };
 	}

--- a/src/lint-cli/types.ts
+++ b/src/lint-cli/types.ts
@@ -67,7 +67,11 @@ export interface ChildCommand {
 	label: ToolLabel;
 }
 
-/** Resolved inputs shared by both command composers. */
+/**
+ * Resolved inputs for composing the ESLint child. The `cacheLocation`,
+ * `eslintLabel` and `typeAwareEnv` triple comes from the pass descriptor, so it
+ * is set once per pass rather than restated across the mode branches.
+ */
 export interface ComposeContext {
 	/** Absolute path to the agent ESLint formatter (resolved lazily). */
 	agentsFormatterPath: string;
@@ -79,8 +83,6 @@ export interface ComposeContext {
 	concurrency: "off" | number;
 	/** Label for the composed ESLint child (`eslint`, `fast` or `typed`). */
 	eslintLabel: ToolLabel;
-	/** Whether oxlint should receive `--type-aware`. */
-	oxlintTypeAware: boolean;
 	/** Target paths to lint. */
 	paths: Array<string>;
 	/**
@@ -88,6 +90,14 @@ export interface ComposeContext {
 	 * unset (the full config).
 	 */
 	typeAwareEnv: TypeAwareMode | undefined;
+}
+
+/** Resolved inputs for composing the oxlint child. */
+export interface OxlintComposeContext {
+	/** Whether oxlint should receive `--type-aware`. */
+	oxlintTypeAware: boolean;
+	/** Target paths to lint. */
+	paths: Array<string>;
 }
 
 /**

--- a/src/lint-cli/types.ts
+++ b/src/lint-cli/types.ts
@@ -1,0 +1,75 @@
+/** Which type-aware linting mode ESLint should run in. */
+export type TypeAwareMode = "off" | "only";
+
+/** Logical identifier for each linter the runner drives. */
+export type ToolLabel = "eslint" | "oxc";
+
+/** Logical binary name resolved from the consumer's `node_modules`. */
+export type ToolBin = "eslint" | "oxlint";
+
+/**
+ * Fully parsed and validated `isentinel-lint` invocation. All ambiguity has
+ * been resolved by `parseArguments` before this shape is produced.
+ */
+export interface LintCliOptions {
+	/** Emit agent-friendly output for both linters. */
+	agents: boolean;
+	/** Whether ESLint should use its on-disk cache. */
+	cache: boolean;
+	/** Explicit `--concurrency` override; bypasses the heuristic when set. */
+	concurrency: "off" | number | undefined;
+	/** Run only ESLint. */
+	eslint: boolean;
+	/** Extra arguments forwarded verbatim to ESLint. */
+	eslintArgs: Array<string>;
+	/** Apply fixes: `oxlint --fix` then `eslint --fix`, sequentially. */
+	fix: boolean;
+	/** Whether to pass `--type-aware` to oxlint. */
+	oxlint: boolean;
+	/** Extra arguments forwarded verbatim to oxlint. */
+	oxlintArgs: Array<string>;
+	/** When false, omit `--type-aware` from the oxlint invocation. */
+	oxlintTypeAware: boolean;
+	/** Target paths to lint. Defaults to `["."]`. */
+	paths: Array<string>;
+	/** Print the composed command lines instead of running them. */
+	print: boolean;
+	/** ESLint type-aware mode; sets `ESLINT_TYPE_AWARE` for the child. */
+	typeAware: TypeAwareMode | undefined;
+}
+
+/** A single linter child process, described independently of the shell. */
+export interface ChildCommand {
+	/** Logical arguments (paths and flags), excluding the binary itself. */
+	args: Array<string>;
+	/** Logical binary name, resolved to a real path at spawn time. */
+	bin: ToolBin;
+	/** Extra environment variables layered on top of `process.env`. */
+	env: Record<string, string>;
+	/** Prefix/name used for concurrently output and logging. */
+	label: ToolLabel;
+}
+
+/** Resolved inputs shared by both command composers. */
+export interface ComposeContext {
+	/** Absolute path to the agent ESLint formatter (resolved lazily). */
+	agentsFormatterPath: string;
+	/** ESLint cache file for the active type-aware mode. */
+	cacheLocation: string;
+	/** Whether the process is running in CI (`process.env.CI`). */
+	ci: boolean;
+	/** Concurrency value passed to ESLint's `--concurrency`. */
+	concurrency: "off" | number;
+	/** Whether oxlint should receive `--type-aware`. */
+	oxlintTypeAware: boolean;
+	/** Target paths to lint. */
+	paths: Array<string>;
+}
+
+/**
+ * User-facing error. When thrown from the runner the message is printed
+ * without a stack trace and the process exits non-zero.
+ */
+export class CliError extends Error {
+	public override name = "CliError";
+}

--- a/src/lint-cli/types.ts
+++ b/src/lint-cli/types.ts
@@ -61,8 +61,13 @@ export interface ChildCommand {
 	args: Array<string>;
 	/** Logical binary name, resolved to a real path at spawn time. */
 	bin: ToolBin;
-	/** Extra environment variables layered on top of `process.env`. */
-	env: Record<string, string>;
+	/**
+	 * Environment overrides layered on top of `process.env` at spawn time. A
+	 * value of `undefined` explicitly REMOVES the variable from the child (Node
+	 * drops undefined env entries), so an inherited `ESLINT_TYPE_AWARE` cannot
+	 * leak into the full-config pass.
+	 */
+	env: Record<string, string | undefined>;
 	/** Prefix/name used for concurrently output and logging. */
 	label: ToolLabel;
 }

--- a/src/lint-cli/types.ts
+++ b/src/lint-cli/types.ts
@@ -1,8 +1,22 @@
-/** Which type-aware linting mode ESLint should run in. */
+/**
+ * Which type-aware ESLint cache/builder a pass targets. `"off"` is the
+ * syntactic-only fast pass, `"only"` the type-aware pass; the full config
+ * (env unset) is represented by `undefined`.
+ */
 export type TypeAwareMode = "off" | "only";
 
-/** Logical identifier for each linter the runner drives. */
-export type ToolLabel = "eslint" | "oxc";
+/**
+ * User-selectable `--type-aware` value. `"full"` forces today's single
+ * full-config pass (the escape hatch); omitting the flag selects the default
+ * concurrent two-pass mode.
+ */
+export type TypeAwareOption = "full" | "off" | "only";
+
+/**
+ * Logical identifier for each linter child the runner drives. `"fast"` and
+ * `"typed"` are the two ESLint passes of the default concurrent mode.
+ */
+export type ToolLabel = "eslint" | "fast" | "oxc" | "typed";
 
 /** Logical binary name resolved from the consumer's `node_modules`. */
 export type ToolBin = "eslint" | "oxlint";
@@ -34,8 +48,11 @@ export interface LintCliOptions {
 	paths: Array<string>;
 	/** Print the composed command lines instead of running them. */
 	print: boolean;
-	/** ESLint type-aware mode; sets `ESLINT_TYPE_AWARE` for the child. */
-	typeAware: TypeAwareMode | undefined;
+	/**
+	 * Explicit `--type-aware` selection. `undefined` means the default
+	 * concurrent two-pass mode (fast + typed).
+	 */
+	typeAware: TypeAwareOption | undefined;
 }
 
 /** A single linter child process, described independently of the shell. */
@@ -54,16 +71,23 @@ export interface ChildCommand {
 export interface ComposeContext {
 	/** Absolute path to the agent ESLint formatter (resolved lazily). */
 	agentsFormatterPath: string;
-	/** ESLint cache file for the active type-aware mode. */
+	/** ESLint cache file for this pass. */
 	cacheLocation: string;
 	/** Whether the process is running in CI (`process.env.CI`). */
 	ci: boolean;
 	/** Concurrency value passed to ESLint's `--concurrency`. */
 	concurrency: "off" | number;
+	/** Label for the composed ESLint child (`eslint`, `fast` or `typed`). */
+	eslintLabel: ToolLabel;
 	/** Whether oxlint should receive `--type-aware`. */
 	oxlintTypeAware: boolean;
 	/** Target paths to lint. */
 	paths: Array<string>;
+	/**
+	 * Value for the ESLint child's `ESLINT_TYPE_AWARE`. `undefined` leaves it
+	 * unset (the full config).
+	 */
+	typeAwareEnv: TypeAwareMode | undefined;
 }
 
 /**

--- a/src/lint-cli/workspace.ts
+++ b/src/lint-cli/workspace.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Markers that identify a repository or pnpm-workspace root. `.git` may be a
+ * directory (normal clone) or a file (a worktree pointer); `existsSync` accepts
+ * both.
+ */
+const WORKSPACE_ROOT_MARKERS = [".git", "pnpm-workspace.yaml"] as const;
+
+/**
+ * Walk up from `cwd` to the nearest directory that looks like a repository or
+ * pnpm-workspace root (contains `.git` or `pnpm-workspace.yaml`). Returns `cwd`
+ * unchanged when it is itself the root, or when no marker is found before the
+ * filesystem root — in both cases there is no ancestor to fold in.
+ *
+ * @param cwd - The directory to walk up from.
+ * @returns The workspace root, or `cwd` when there is no distinct ancestor root.
+ */
+export function findWorkspaceRoot(cwd: string): string {
+	let current = cwd;
+	for (;;) {
+		for (const marker of WORKSPACE_ROOT_MARKERS) {
+			if (fs.existsSync(path.join(current, marker))) {
+				return current;
+			}
+		}
+
+		const parent = path.dirname(current);
+		if (parent === current) {
+			// Reached the filesystem root without a marker: treat cwd as the root
+			// so no ancestor directories are scanned.
+			return cwd;
+		}
+
+		current = parent;
+	}
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,7 @@ import prettier from "prettier";
 import { minVersion } from "semver";
 
 import type { PrettierOptions } from "./eslint/configs/index.ts";
+import type { TypeAwareSplitMode } from "./eslint/type-aware-split.ts";
 import type { OptionsConfig } from "./eslint/types.ts";
 import { GLOB_SRC_EXT } from "./globs.ts";
 import type { Awaitable, TypedFlatConfigItem } from "./types.ts";
@@ -360,6 +361,36 @@ export function isInEditorEnvironment(): boolean {
 		process.env["VIM"],
 		process.env["NVIM"],
 	].some(Boolean);
+}
+
+/**
+ * Read the `ESLINT_TYPE_AWARE` environment variable so a wrapper CLI can drive
+ * the factory's type-aware split without every consumer wiring the `typeAware`
+ * option themselves.
+ *
+ * Recognized values: `off` selects the non-type-aware pass (drop every
+ * type-aware rule and the TypeScript program); `only` selects the
+ * type-aware-only pass. `false` is a legacy alias for `off` — the canonical
+ * vocabulary is `off`/`only`. Any other value, or an unset variable, has no
+ * effect.
+ *
+ * An explicitly passed `typeAware` option always takes precedence: the factory
+ * only consults this variable when the option is left `undefined`.
+ *
+ * @returns The split mode requested by the environment, or `undefined` when the
+ *   variable is unset or holds an unrecognized value.
+ */
+export function typeAwareSplitFromEnvironment(): TypeAwareSplitMode | undefined {
+	const value = process.env["ESLINT_TYPE_AWARE"];
+	if (value === "off" || value === "false") {
+		return false;
+	}
+
+	if (value === "only") {
+		return "only";
+	}
+
+	return undefined;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,19 @@ type Parser = NonNullable<TypedFlatConfigItem["languageOptions"]>["parser"];
 
 export const require = createRequire(import.meta.url);
 
+/**
+ * Whether the environment signals a CI run. Treats an unset, empty, `"false"`
+ * or `"0"` `CI` value as not-CI, so a deliberately falsy `CI=false` is honoured
+ * rather than read as truthy.
+ *
+ * @param environment - The environment variables to inspect.
+ * @returns Whether CI is active.
+ */
+export function isCi(environment: NodeJS.ProcessEnv = process.env): boolean {
+	const value = environment["CI"];
+	return value !== undefined && value !== "" && value !== "false" && value !== "0";
+}
+
 export const parserPlain = {
 	meta: {
 		name: "parser-plain",
@@ -136,7 +149,7 @@ export function createTsParser({
 }
 
 export async function ensurePackages(packages: Array<string | undefined>): Promise<void> {
-	if ((process.env["CI"] ?? "") || !process.stdout.isTTY) {
+	if (isCi() || !process.stdout.isTTY) {
 		return;
 	}
 
@@ -346,7 +359,7 @@ export function isInEditorEnvironment(): boolean {
 		return explicitValue === "true" || explicitValue === "1";
 	}
 
-	if (process.env["CI"] ?? "") {
+	if (isCi()) {
 		return false;
 	}
 

--- a/test/formatter-agents.spec.ts
+++ b/test/formatter-agents.spec.ts
@@ -1,0 +1,224 @@
+import type { ESLint, Linter } from "eslint";
+import path from "node:path";
+import process from "node:process";
+import { describe, expect, it } from "vitest";
+
+import eslintFormatterAgents from "../src/formatter-agents.ts";
+
+const ROOT = process.cwd();
+
+/** Convenience shape for authoring lint messages in fixtures. */
+type MessageInput = Partial<Linter.LintMessage> & Pick<Linter.LintMessage, "message" | "severity">;
+
+/**
+ * Build a fully typed {@link ESLint.LintResult} from a handful of messages,
+ * computing the summary counts the way ESLint does.
+ *
+ * @param fileName - File name placed under {@link ROOT}.
+ * @param messages - The lint messages for the file.
+ * @param suppressedMessages - Messages suppressed by inline directives.
+ * @returns A lint result suitable for feeding to the formatter.
+ */
+function makeResult(
+	fileName: string,
+	messages: ReadonlyArray<MessageInput>,
+	suppressedMessages: ReadonlyArray<MessageInput> = [],
+): ESLint.LintResult {
+	const fullMessages = messages.map<Linter.LintMessage>((message) => {
+		return {
+			column: 1,
+			line: 1,
+			ruleId: null,
+			...message,
+		};
+	});
+
+	const errorCount = fullMessages.filter((message) => message.severity === 2).length;
+
+	return {
+		errorCount,
+		fatalErrorCount: fullMessages.filter((message) => message.fatal === true).length,
+		filePath: path.join(ROOT, fileName),
+		fixableErrorCount: 0,
+		fixableWarningCount: 0,
+		messages: fullMessages,
+		suppressedMessages: suppressedMessages.map<Linter.SuppressedLintMessage>((message) => {
+			return {
+				column: 1,
+				line: 1,
+				ruleId: null,
+				suppressions: [{ justification: "", kind: "directive" }],
+				...message,
+			};
+		}),
+		usedDeprecatedRules: [],
+		warningCount: fullMessages.length - errorCount,
+	};
+}
+
+/** Run metadata that relativizes file paths against {@link ROOT}. */
+const DATA: ESLint.LintResultData = { cwd: ROOT, rulesMeta: {} };
+
+describe("eslintFormatterAgents", () => {
+	it("returns an empty string when nothing was reported", () => {
+		expect.hasAssertions();
+		expect(eslintFormatterAgents([makeResult("clean.ts", [])], DATA)).toBe("");
+	});
+
+	it("returns an empty string for empty result lists", () => {
+		expect.hasAssertions();
+		expect(eslintFormatterAgents([], DATA)).toBe("");
+	});
+
+	it("formats errors and warnings sorted by position within a file", () => {
+		expect.hasAssertions();
+
+		const output = eslintFormatterAgents(
+			[
+				makeResult("foo.ts", [
+					{
+						column: 5,
+						line: 3,
+						message: "Unexpected any.",
+						ruleId: "ts/no-explicit-any",
+						severity: 2,
+					},
+					{
+						column: 10,
+						line: 1,
+						message: "Do not use null.",
+						ruleId: "unicorn/no-null",
+						severity: 1,
+					},
+				]),
+			],
+			DATA,
+		);
+
+		expect(output).toMatchInlineSnapshot(`
+			"foo.ts:1:10: warning unicorn/no-null: Do not use null.
+			foo.ts:3:5: error ts/no-explicit-any: Unexpected any.
+			"
+		`);
+	});
+
+	it("labels fatal parse errors as errors under the eslint rule id", () => {
+		expect.hasAssertions();
+
+		const output = eslintFormatterAgents(
+			[
+				makeResult("bad.ts", [
+					{
+						column: 1,
+						fatal: true,
+						line: 2,
+						message: "Parsing error: Unexpected token",
+						ruleId: null,
+						severity: 2,
+					},
+				]),
+			],
+			DATA,
+		);
+
+		expect(output).toMatchInlineSnapshot(`
+			"bad.ts:2:1: error eslint: Parsing error: Unexpected token
+			"
+		`);
+	});
+
+	it("sorts messages across multiple files by relative path", () => {
+		expect.hasAssertions();
+
+		const output = eslintFormatterAgents(
+			[
+				makeResult("b.ts", [
+					{ column: 1, line: 1, message: "Warn B.", ruleId: "y/warn", severity: 1 },
+				]),
+				makeResult("a.ts", [
+					{ column: 1, line: 1, message: "Error A.", ruleId: "x/error", severity: 2 },
+				]),
+			],
+			DATA,
+		);
+
+		expect(output).toMatchInlineSnapshot(`
+			"a.ts:1:1: error x/error: Error A.
+			b.ts:1:1: warning y/warn: Warn B.
+			"
+		`);
+	});
+
+	it("breaks position ties by severity then rule id", () => {
+		expect.hasAssertions();
+
+		const output = eslintFormatterAgents(
+			[
+				makeResult("tie.ts", [
+					{ column: 1, line: 1, message: "Warn.", ruleId: "a/warn", severity: 1 },
+					{ column: 1, line: 1, message: "Error Z.", ruleId: "z/error", severity: 2 },
+					{ column: 1, line: 1, message: "Error A.", ruleId: "a/error", severity: 2 },
+				]),
+			],
+			DATA,
+		);
+
+		expect(output).toMatchInlineSnapshot(`
+			"tie.ts:1:1: error a/error: Error A.
+			tie.ts:1:1: error z/error: Error Z.
+			tie.ts:1:1: warning a/warn: Warn.
+			"
+		`);
+	});
+
+	it("collapses message whitespace onto a single line", () => {
+		expect.hasAssertions();
+
+		const output = eslintFormatterAgents(
+			[
+				makeResult("multiline.ts", [
+					{
+						column: 2,
+						line: 4,
+						message: "Line one\n   Line two\t\tend  ",
+						ruleId: "sonar/msg",
+						severity: 2,
+					},
+				]),
+			],
+			DATA,
+		);
+
+		expect(output).toMatchInlineSnapshot(`
+			"multiline.ts:4:2: error sonar/msg: Line one Line two end
+			"
+		`);
+	});
+
+	it("ignores suppressed messages and fixable counts", () => {
+		expect.hasAssertions();
+
+		const result = makeResult(
+			"suppressed.ts",
+			[],
+			[{ column: 1, line: 1, message: "Suppressed.", ruleId: "x/rule", severity: 2 }],
+		);
+
+		expect(eslintFormatterAgents([{ ...result, fixableErrorCount: 5 }], DATA)).toBe("");
+	});
+
+	it("relativizes against process.cwd() when no run data is provided", () => {
+		expect.hasAssertions();
+
+		const output = eslintFormatterAgents([
+			makeResult("fallback.ts", [
+				{ column: 3, line: 7, message: "Nope.", ruleId: "n/rule", severity: 2 },
+			]),
+		]);
+
+		expect(output).toMatchInlineSnapshot(`
+			"fallback.ts:7:3: error n/rule: Nope.
+			"
+		`);
+	});
+});

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -4,7 +4,6 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import process from "node:process";
 import { describe, expect, it } from "vitest";
 
 import { computeAffectedFiles } from "../src/lint-cli/affected.ts";
@@ -13,6 +12,7 @@ import { CACHE_FILE_TYPE_AWARE } from "../src/lint-cli/constants.ts";
 import { applyTypeAwareInvalidation } from "../src/lint-cli/invalidation.ts";
 import { parseArguments } from "../src/lint-cli/options.ts";
 import { composeCommands } from "../src/lint-cli/run.ts";
+import { withoutGitEnvironment } from "./without-git.ts";
 
 const TSCONFIG = JSON.stringify({
 	compilerOptions: { module: "commonjs", strict: true, target: "es2020" },
@@ -356,26 +356,6 @@ const JSON_TSCONFIG = JSON.stringify({
 	include: ["src"],
 });
 
-function withoutGit<T>(run: () => T): T {
-	const keys = ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"];
-	const saved = keys.map((key): [string, string | undefined] => [key, process.env[key]]);
-	for (const key of keys) {
-		delete process.env[key];
-	}
-
-	try {
-		return run();
-	} finally {
-		for (const [key, value] of saved) {
-			if (value === undefined) {
-				delete process.env[key];
-			} else {
-				process.env[key] = value;
-			}
-		}
-	}
-}
-
 describe("composeCommands typed-pass skip", () => {
 	it("skips the typed pass in default mode when nothing type-relevant changed", () => {
 		expect.hasAssertions();
@@ -393,7 +373,7 @@ describe("composeCommands typed-pass skip", () => {
 				computeAffectedFiles(directory, "only");
 				seedCache(cacheFile, [fileA]);
 
-				const { commands, notice } = withoutGit(() => {
+				const { commands, notice } = withoutGitEnvironment(() => {
 					return composeCommands(parseArguments([]), {
 						cwd: directory,
 						dryRun: false,
@@ -424,7 +404,7 @@ describe("composeCommands typed-pass skip", () => {
 				computeAffectedFiles(directory, "only");
 				seedCache(cacheFile, [fileA]);
 
-				const { commands, notice } = withoutGit(() => {
+				const { commands, notice } = withoutGitEnvironment(() => {
 					return composeCommands(parseArguments(["--type-aware=only"]), {
 						cwd: directory,
 						dryRun: false,

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import { computeAffectedFiles } from "../src/lint-cli/affected.ts";
 import { normalizePath, removeCacheEntries } from "../src/lint-cli/cache.ts";
 import { CACHE_FILE_TYPE_AWARE } from "../src/lint-cli/constants.ts";
+import { writeHybridStatus } from "../src/lint-cli/hybrid-status.ts";
 import { applyTypeAwareInvalidation } from "../src/lint-cli/invalidation.ts";
 import { parseArguments } from "../src/lint-cli/options.ts";
 import { composeCommands, plan } from "../src/lint-cli/run.ts";
@@ -47,6 +48,13 @@ function withFixture(files: Record<string, string>, run: (directory: string) => 
 			fs.mkdirSync(path.dirname(absolute), { recursive: true });
 			fs.writeFileSync(absolute, content);
 		}
+
+		// Seed a fresh hybrid status so the CLI's hybrid check trusts it rather
+		// than probing a (here absent) ESLint binary. These fixtures ship no
+		// eslint config file, so the status is always fresh; the seed keeps the
+		// runner's oxlint/notice behaviour identical to a real hybrid project.
+		fs.mkdirSync(path.join(directory, "node_modules"), { recursive: true });
+		writeHybridStatus(directory, true);
 
 		run(directory);
 	} finally {

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -398,6 +398,37 @@ describe("composeCommands typed-pass skip", () => {
 		);
 	});
 
+	it("never skips the typed pass when a target resolves outside cwd", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"src/a.ts": "export function a(): number { return 1; }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, CACHE_FILE_TYPE_AWARE);
+				const fileA = path.join(directory, "src/a.ts");
+				computeAffectedFiles(directory, "only");
+				seedCache(cacheFile, [fileA]);
+
+				// "src" is in-cwd and clean, but "../elsewhere" escapes cwd, so
+				// the dirty count is unknowable: the typed pass must not
+				// auto-skip and a notice is emitted.
+				const { commands, notice } = withoutGitEnvironment(() => {
+					return composeCommands(parseArguments(["src", "../elsewhere"]), {
+						cwd: directory,
+						dryRun: false,
+						environment: {},
+					});
+				});
+
+				expect(commands.map((command) => command.label)).toContain("typed");
+				expect(notice).toMatch(/resolves outside the working directory/);
+			},
+		);
+	});
+
 	it("never skips the typed pass when --type-aware=only is explicit", () => {
 		expect.hasAssertions();
 

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -11,7 +11,7 @@ import { normalizePath, removeCacheEntries } from "../src/lint-cli/cache.ts";
 import { CACHE_FILE_TYPE_AWARE } from "../src/lint-cli/constants.ts";
 import { applyTypeAwareInvalidation } from "../src/lint-cli/invalidation.ts";
 import { parseArguments } from "../src/lint-cli/options.ts";
-import { composeCommands } from "../src/lint-cli/run.ts";
+import { composeCommands, plan } from "../src/lint-cli/run.ts";
 import { withoutGitEnvironment } from "./without-git.ts";
 
 const TSCONFIG = JSON.stringify({
@@ -414,6 +414,68 @@ describe("composeCommands typed-pass skip", () => {
 
 				expect(commands.map((command) => command.label)).toContain("typed");
 				expect(notice).toBeUndefined();
+			},
+		);
+	});
+});
+
+describe("plan mutation", () => {
+	const buildInfo = "node_modules/.cache/isentinel-lint/tsbuildinfo-typeaware";
+
+	it("performs no I/O mutation in read-only (print) mode", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"src/a.ts": "export function a(): number { return 1; }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, CACHE_FILE_TYPE_AWARE);
+				const fileA = path.join(directory, "src/a.ts");
+				seedCache(cacheFile, [fileA]);
+
+				const runPlan = withoutGitEnvironment(() => {
+					return plan(parseArguments([]), directory, {}, false);
+				});
+
+				expect(runPlan.passes.map((pass) => pass.descriptor.label)).toStrictEqual([
+					"fast",
+					"typed",
+				]);
+				// Read-only planning never runs the builder or deletes caches.
+				expect(fs.existsSync(path.join(directory, buildInfo))).toBe(false);
+				expect(fs.existsSync(cacheFile)).toBe(true);
+
+				// The mutating plan, by contrast, runs the builder.
+				withoutGitEnvironment(() => plan(parseArguments([]), directory, {}, true));
+
+				expect(fs.existsSync(path.join(directory, buildInfo))).toBe(true);
+			},
+		);
+	});
+
+	it("marks the typed pass skipped in the plan when nothing type-relevant changed", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"src/a.ts": "export function a(): number { return 1; }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, CACHE_FILE_TYPE_AWARE);
+				const fileA = path.join(directory, "src/a.ts");
+				computeAffectedFiles(directory, "only");
+				seedCache(cacheFile, [fileA]);
+
+				const runPlan = withoutGitEnvironment(() => {
+					return plan(parseArguments([]), directory, {}, true);
+				});
+				const typed = runPlan.passes.find((pass) => pass.descriptor.label === "typed");
+
+				expect(typed?.shouldRun).toBe(false);
+				expect(typed?.skipReason).toMatch(/skipping the type-aware/);
 			},
 		);
 	});

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -1,0 +1,342 @@
+// cspell:words tsbuildinfo typeaware globals
+import fileEntryCache from "file-entry-cache";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { computeAffectedFiles } from "../src/lint-cli/affected.ts";
+import { normalizePath, removeCacheEntries } from "../src/lint-cli/cache.ts";
+import { applyTypeAwareInvalidation } from "../src/lint-cli/invalidation.ts";
+
+const TSCONFIG = JSON.stringify({
+	compilerOptions: { module: "commonjs", strict: true, target: "es2020" },
+	include: ["src"],
+});
+
+const DOM_TSCONFIG = JSON.stringify({
+	compilerOptions: { lib: ["es2020", "dom"], module: "commonjs", strict: true, target: "es2020" },
+	include: ["src"],
+});
+
+function withFixture(files: Record<string, string>, run: (directory: string) => void): void {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-fx-"));
+
+	try {
+		// A sibling `node_modules/typescript` junction lets the CLI resolve the
+		// real typescript from the fixture cwd. Sources stay outside any
+		// node_modules path: TS never reports node_modules files affected.
+		const typescriptDirectory = path.dirname(
+			createRequire(import.meta.url).resolve("typescript/package.json"),
+		);
+		fs.mkdirSync(path.join(root, "node_modules"), { recursive: true });
+		fs.symlinkSync(
+			fs.realpathSync(typescriptDirectory),
+			path.join(root, "node_modules", "typescript"),
+			"junction",
+		);
+
+		const directory = path.join(root, "project");
+		for (const [relative, content] of Object.entries(files)) {
+			const absolute = path.join(directory, relative);
+			fs.mkdirSync(path.dirname(absolute), { recursive: true });
+			fs.writeFileSync(absolute, content);
+		}
+
+		run(directory);
+	} finally {
+		fs.rmSync(root, { force: true, recursive: true });
+	}
+}
+
+function seedCache(cacheFile: string, files: Array<string>): void {
+	const cache = fileEntryCache.create(path.basename(cacheFile), path.dirname(cacheFile), false);
+	for (const file of files) {
+		cache.getFileDescriptor(file);
+	}
+
+	cache.reconcile();
+}
+
+function cacheHasEntry(cacheFile: string, file: string): boolean {
+	if (!fs.existsSync(cacheFile)) {
+		return false;
+	}
+
+	const cache = fileEntryCache.createFromFile(cacheFile, false);
+	const target = normalizePath(file);
+	return cache.cache.keys().some((key) => normalizePath(key) === target);
+}
+
+function touch(file: string): void {
+	const future = Date.now() / 1000 + 60;
+	fs.utimesSync(file, future, future);
+}
+
+function invalidate(
+	cwd: string,
+	targetFiles: Array<string>,
+	alreadyDirty: ReadonlySet<string>,
+	environment: NodeJS.ProcessEnv = {},
+): ReturnType<typeof applyTypeAwareInvalidation> {
+	return applyTypeAwareInvalidation({
+		alreadyDirty,
+		cacheLocation: path.join(cwd, ".eslintcache"),
+		cwd,
+		environment,
+		mode: undefined,
+		targetFiles,
+	});
+}
+
+describe("computeAffectedFiles", () => {
+	it("reports every file on the first run, then nothing when unchanged", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"src/a.ts": "export function a(): number { return 1; }\n",
+				"src/b.ts":
+					"import { a } from './a';\nexport function b(): number { return a() + 1; }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+			(directory) => {
+				const first = computeAffectedFiles(directory, undefined);
+
+				expect(first?.firstRun).toBe(true);
+				expect(first?.affected.size).toBeGreaterThan(0);
+
+				const second = computeAffectedFiles(directory, undefined);
+
+				expect(second?.firstRun).toBe(false);
+				expect(second?.affected.size).toBe(0);
+			},
+		);
+	});
+
+	it("skips gracefully when no tsconfig is present", () => {
+		expect.hasAssertions();
+
+		withFixture({ "src/a.ts": "export const a = 1;\n" }, (directory) => {
+			expect(computeAffectedFiles(directory, undefined)).toBeUndefined();
+		});
+	});
+});
+
+describe("applyTypeAwareInvalidation", () => {
+	it("does not invalidate importers on an implementation-only edit", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"src/a.ts": "export function a(): number { return 1; }\n",
+				"src/b.ts":
+					"import { a } from './a';\nexport function b(): number { return a() + 1; }\n",
+				"src/c.ts":
+					"import { b } from './b';\nexport function c(): number { return b() + 1; }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, ".eslintcache");
+				const fileA = path.join(directory, "src/a.ts");
+				const fileB = path.join(directory, "src/b.ts");
+				const fileC = path.join(directory, "src/c.ts");
+				computeAffectedFiles(directory, undefined);
+				seedCache(cacheFile, [fileA, fileB, fileC]);
+				fs.writeFileSync(fileA, "export function a(): number { return 42; }\n");
+				touch(fileA);
+
+				const dirty = new Set([normalizePath(fileA)]);
+				const outcome = invalidate(directory, [fileA, fileB, fileC], dirty);
+
+				expect(outcome.busted).toBe(false);
+				expect(outcome.firstRun).toBe(false);
+				expect(outcome.invalidated).toStrictEqual([]);
+				expect(cacheHasEntry(cacheFile, fileB)).toBe(true);
+				expect(cacheHasEntry(cacheFile, fileC)).toBe(true);
+			},
+		);
+	});
+
+	it("invalidates transitive importers on an exported-type change", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				// Inferred return types so a's shape change propagates into c.
+				"src/a.ts": "export function a() { return 1; }\n",
+				"src/b.ts": "import { a } from './a';\nexport function b() { return a(); }\n",
+				"src/c.ts": "import { b } from './b';\nexport function c() { return b(); }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, ".eslintcache");
+				const fileA = path.join(directory, "src/a.ts");
+				const fileB = path.join(directory, "src/b.ts");
+				const fileC = path.join(directory, "src/c.ts");
+				computeAffectedFiles(directory, undefined);
+				seedCache(cacheFile, [fileA, fileB, fileC]);
+				fs.writeFileSync(fileA, "export function a() { return 'now a string'; }\n");
+				touch(fileA);
+
+				const dirty = new Set([normalizePath(fileA)]);
+				const outcome = invalidate(directory, [fileA, fileB, fileC], dirty);
+
+				expect(outcome.busted).toBe(false);
+				expect(outcome.invalidated).toContain(normalizePath(fileB));
+				expect(outcome.invalidated).toContain(normalizePath(fileC));
+				expect(cacheHasEntry(cacheFile, fileB)).toBe(false);
+				expect(cacheHasEntry(cacheFile, fileC)).toBe(false);
+			},
+		);
+	});
+
+	it("invalidates everything on a global-augmentation edit", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"src/a.ts": "export function a(): number { return 1; }\n",
+				"src/b.ts":
+					"import { a } from './a';\nexport function b(): number { return a() + 1; }\n",
+				"src/globals.ts":
+					"declare global { interface Window { foo: number; } }\nexport {};\n",
+				"tsconfig.json": DOM_TSCONFIG,
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, ".eslintcache");
+				const fileA = path.join(directory, "src/a.ts");
+				const fileB = path.join(directory, "src/b.ts");
+				const fileGlobals = path.join(directory, "src/globals.ts");
+				computeAffectedFiles(directory, undefined);
+				seedCache(cacheFile, [fileA, fileB, fileGlobals]);
+				fs.writeFileSync(
+					fileGlobals,
+					"declare global { interface Window { foo: number; bar: string; } }\nexport {};\n",
+				);
+				touch(fileGlobals);
+
+				const outcome = invalidate(
+					directory,
+					[fileA, fileB, fileGlobals],
+					new Set([normalizePath(fileGlobals)]),
+				);
+
+				expect(outcome.busted).toBe(false);
+				expect(outcome.invalidated).toContain(normalizePath(fileA));
+				expect(outcome.invalidated).toContain(normalizePath(fileB));
+				expect(cacheHasEntry(cacheFile, fileA)).toBe(false);
+				expect(cacheHasEntry(cacheFile, fileB)).toBe(false);
+			},
+		);
+	});
+
+	it("deletes the whole cache file when the affected set exceeds the threshold", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"src/a.ts": "export function a() { return 1; }\n",
+				"src/b.ts": "import { a } from './a';\nexport function b() { return a(); }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, ".eslintcache");
+				const fileA = path.join(directory, "src/a.ts");
+				const fileB = path.join(directory, "src/b.ts");
+				computeAffectedFiles(directory, undefined);
+				seedCache(cacheFile, [fileA, fileB]);
+				fs.writeFileSync(fileA, "export function a() { return 'string now'; }\n");
+				touch(fileA);
+
+				// Threshold 0: any affected file trips the escape valve.
+				const dirty = new Set([normalizePath(fileA)]);
+				const outcome = invalidate(directory, [fileA, fileB], dirty, {
+					LINT_AFFECTED_BUST_THRESHOLD: "0",
+				});
+
+				expect(outcome.busted).toBe(true);
+				expect(outcome.invalidated).toStrictEqual([]);
+				expect(fs.existsSync(cacheFile)).toBe(false);
+			},
+		);
+	});
+
+	it("persists state but invalidates nothing on the first run", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"src/a.ts": "export function a(): number { return 1; }\n",
+				"src/b.ts":
+					"import { a } from './a';\nexport function b(): number { return a() + 1; }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, ".eslintcache");
+				const fileA = path.join(directory, "src/a.ts");
+				const fileB = path.join(directory, "src/b.ts");
+				seedCache(cacheFile, [fileA, fileB]);
+
+				const outcome = invalidate(directory, [fileA, fileB], new Set());
+
+				expect(outcome.firstRun).toBe(true);
+				expect(outcome.busted).toBe(false);
+				expect(outcome.invalidated).toStrictEqual([]);
+				expect(
+					fs.existsSync(
+						path.join(directory, "node_modules/.cache/isentinel-lint/tsbuildinfo-full"),
+					),
+				).toBe(true);
+				expect(cacheHasEntry(cacheFile, fileA)).toBe(true);
+				expect(cacheHasEntry(cacheFile, fileB)).toBe(true);
+			},
+		);
+	});
+
+	it("skips when there is no tsconfig", () => {
+		expect.hasAssertions();
+
+		withFixture({ "src/a.ts": "export const a = 1;\n" }, (directory) => {
+			const cacheFile = path.join(directory, ".eslintcache");
+			const fileA = path.join(directory, "src/a.ts");
+			seedCache(cacheFile, [fileA]);
+
+			const outcome = invalidate(directory, [fileA], new Set());
+
+			expect(outcome.skipped).toBe(true);
+			expect(outcome.invalidated).toStrictEqual([]);
+			expect(cacheHasEntry(cacheFile, fileA)).toBe(true);
+		});
+	});
+});
+
+describe("removeCacheEntries", () => {
+	it("removes only the named entries and keeps the rest", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"src/a.ts": "export const a = 1;\n",
+				"src/b.ts": "export const b = 2;\n",
+				"src/c.ts": "export const c = 3;\n",
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, ".eslintcache");
+				const fileA = path.join(directory, "src/a.ts");
+				const fileB = path.join(directory, "src/b.ts");
+				const fileC = path.join(directory, "src/c.ts");
+				seedCache(cacheFile, [fileA, fileB, fileC]);
+
+				// Forward-slash path proves separator-insensitive matching.
+				const removed = removeCacheEntries(cacheFile, [fileB.split(path.sep).join("/")]);
+
+				expect(removed).toBe(1);
+				expect(cacheHasEntry(cacheFile, fileA)).toBe(true);
+				expect(cacheHasEntry(cacheFile, fileB)).toBe(false);
+				expect(cacheHasEntry(cacheFile, fileC)).toBe(true);
+			},
+		);
+	});
+});

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -4,11 +4,15 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
+import process from "node:process";
 import { describe, expect, it } from "vitest";
 
 import { computeAffectedFiles } from "../src/lint-cli/affected.ts";
 import { normalizePath, removeCacheEntries } from "../src/lint-cli/cache.ts";
+import { CACHE_FILE_TYPE_AWARE } from "../src/lint-cli/constants.ts";
 import { applyTypeAwareInvalidation } from "../src/lint-cli/invalidation.ts";
+import { parseArguments } from "../src/lint-cli/options.ts";
+import { composeCommands } from "../src/lint-cli/run.ts";
 
 const TSCONFIG = JSON.stringify({
 	compilerOptions: { module: "commonjs", strict: true, target: "es2020" },
@@ -336,6 +340,133 @@ describe("removeCacheEntries", () => {
 				expect(cacheHasEntry(cacheFile, fileA)).toBe(true);
 				expect(cacheHasEntry(cacheFile, fileB)).toBe(false);
 				expect(cacheHasEntry(cacheFile, fileC)).toBe(true);
+			},
+		);
+	});
+});
+
+const JSON_TSCONFIG = JSON.stringify({
+	compilerOptions: {
+		esModuleInterop: true,
+		module: "commonjs",
+		resolveJsonModule: true,
+		strict: true,
+		target: "es2020",
+	},
+	include: ["src"],
+});
+
+function withoutGit<T>(run: () => T): T {
+	const keys = ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"];
+	const saved = keys.map((key): [string, string | undefined] => [key, process.env[key]]);
+	for (const key of keys) {
+		delete process.env[key];
+	}
+
+	try {
+		return run();
+	} finally {
+		for (const [key, value] of saved) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
+}
+
+describe("composeCommands typed-pass skip", () => {
+	it("skips the typed pass in default mode when nothing type-relevant changed", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"src/a.ts": "export function a(): number { return 1; }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, CACHE_FILE_TYPE_AWARE);
+				const fileA = path.join(directory, "src/a.ts");
+				// Establish builder state and seed the cache so a.ts is neither
+				// mtime-dirty nor builder-affected on the next run.
+				computeAffectedFiles(directory, "only");
+				seedCache(cacheFile, [fileA]);
+
+				const { commands, notice } = withoutGit(() => {
+					return composeCommands(parseArguments([]), {
+						cwd: directory,
+						dryRun: false,
+						environment: {},
+					});
+				});
+
+				const labels = commands.map((command) => command.label);
+
+				expect(labels).toContain("fast");
+				expect(labels).not.toContain("typed");
+				expect(notice).toMatch(/skipping the type-aware/);
+			},
+		);
+	});
+
+	it("never skips the typed pass when --type-aware=only is explicit", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"src/a.ts": "export function a(): number { return 1; }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, CACHE_FILE_TYPE_AWARE);
+				const fileA = path.join(directory, "src/a.ts");
+				computeAffectedFiles(directory, "only");
+				seedCache(cacheFile, [fileA]);
+
+				const { commands, notice } = withoutGit(() => {
+					return composeCommands(parseArguments(["--type-aware=only"]), {
+						cwd: directory,
+						dryRun: false,
+						environment: {},
+					});
+				});
+
+				expect(commands.map((command) => command.label)).toContain("typed");
+				expect(notice).toBeUndefined();
+			},
+		);
+	});
+});
+
+describe("resolveJsonModule invalidation", () => {
+	it("invalidates a .ts importer when an imported .json changes shape", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"src/b.ts":
+					"import data from './data.json';\nexport function b() { return data.value; }\n",
+				"src/data.json": '{ "value": 1 }\n',
+				"tsconfig.json": JSON_TSCONFIG,
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, ".eslintcache");
+				const fileB = path.join(directory, "src/b.ts");
+				const fileData = path.join(directory, "src/data.json");
+				computeAffectedFiles(directory, undefined);
+				seedCache(cacheFile, [fileB]);
+				fs.writeFileSync(fileData, '{ "value": "now a string" }\n');
+				touch(fileData);
+
+				const outcome = invalidate(
+					directory,
+					[fileData, fileB],
+					new Set([normalizePath(fileData)]),
+				);
+
+				expect(outcome.invalidated).toContain(normalizePath(fileB));
+				expect(cacheHasEntry(cacheFile, fileB)).toBe(false);
 			},
 		);
 	});

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -1,9 +1,10 @@
-// cspell:words typeaware lintable
+// cspell:words typeaware lintable mtimes
 import fileEntryCache from "file-entry-cache";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import process from "node:process";
+import { describe, expect, it, vi } from "vitest";
 
 import { clearAllCaches, isCacheBusted, listDirtyFiles } from "../src/lint-cli/cache.ts";
 import {
@@ -23,7 +24,7 @@ import {
 	CACHE_FILE_FAST,
 	CACHE_FILE_TYPE_AWARE,
 } from "../src/lint-cli/constants.ts";
-import { collectLintableFiles } from "../src/lint-cli/files.ts";
+import { collectLintableFiles, collectRepoFiles } from "../src/lint-cli/files.ts";
 import type { RepoFiles } from "../src/lint-cli/files.ts";
 import {
 	hybridStatusPath,
@@ -34,13 +35,15 @@ import type { HybridStatus } from "../src/lint-cli/hybrid-status.ts";
 import {
 	HYBRID_UNKNOWN_WARNING,
 	NON_HYBRID_WARNING,
+	parseHybridPrintConfig,
 	resolveOxlintRun,
 } from "../src/lint-cli/hybrid.ts";
 import { parseArguments } from "../src/lint-cli/options.ts";
 import { applyPackageJsonBust, computePackageJsonHash } from "../src/lint-cli/package-hash.ts";
-import { composeCommands, plan, runConcurrent } from "../src/lint-cli/run.ts";
+import { composeCommands, plan, runConcurrent, runLint } from "../src/lint-cli/run.ts";
 import type { ChildCommand, ComposeContext, LintCliOptions } from "../src/lint-cli/types.ts";
 import { CliError } from "../src/lint-cli/types.ts";
+import { findWorkspaceRoot } from "../src/lint-cli/workspace.ts";
 import { withoutGitEnvironment } from "./without-git.ts";
 
 function baseContext(overrides: Partial<ComposeContext> = {}): ComposeContext {
@@ -86,6 +89,15 @@ function withTemporaryDirectory(run: (directory: string) => void): void {
 
 function workerCount(dirty: number, perWorker: number, max: number): "off" | number {
 	return computeWorkerCount({ dirtyCount: dirty, filesPerWorker: perWorker, maxWorkers: max });
+}
+
+function seedFileCache(cacheFile: string, files: Array<string>): void {
+	const cache = fileEntryCache.create(path.basename(cacheFile), path.dirname(cacheFile), false);
+	for (const file of files) {
+		cache.getFileDescriptor(file);
+	}
+
+	cache.reconcile();
 }
 
 function concurrencyArgument(commands: Array<ChildCommand>, label: string): string {
@@ -765,19 +777,33 @@ describe("applyPackageJsonBust", () => {
 			expect(first).toBe(second);
 		});
 	});
+
+	it("folds a workspace-root dependency bump into the sub-package hash", () => {
+		expect.hasAssertions();
+
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-ph-"));
+		try {
+			fs.writeFileSync(path.join(root, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+			writePackageJson(root, { dependencies: { shared: "1.0.0" } });
+			const app = path.join(root, "packages", "app");
+			fs.mkdirSync(app, { recursive: true });
+			writePackageJson(app, { exports: "./index.js" });
+
+			const before = computePackageJsonHash(app);
+
+			// The sub-package package.json is untouched; only the hoisted root
+			// dependency changes — the combined hash must still move.
+			writePackageJson(root, { dependencies: { shared: "2.0.0" } });
+			const after = computePackageJsonHash(app);
+
+			expect(before).not.toBe(after);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
 });
 
 describe("runConcurrent", () => {
-	function writeFakeBin(directory: string, name: string, body: string): void {
-		const packageDirectory = path.join(directory, "node_modules", name);
-		fs.mkdirSync(packageDirectory, { recursive: true });
-		fs.writeFileSync(
-			path.join(packageDirectory, "package.json"),
-			JSON.stringify({ name, bin: { [name]: "bin.js" }, version: "0.0.0" }),
-		);
-		fs.writeFileSync(path.join(packageDirectory, "bin.js"), body);
-	}
-
 	it("runs every child to completion and aggregates a non-zero exit", async () => {
 		expect.hasAssertions();
 
@@ -788,14 +814,14 @@ describe("runConcurrent", () => {
 
 			// oxlint succeeds but only after a delay; eslint fails immediately. A
 			// kill-on-failure would kill oxlint before it writes its marker.
-			writeFakeBin(
+			writeFakeToolBin(
 				directory,
 				"oxlint",
 				`const fs=require("node:fs");setTimeout(()=>{fs.writeFileSync(${JSON.stringify(
 					oxcMarker,
 				)},"ran");process.exit(0);},250);`,
 			);
-			writeFakeBin(
+			writeFakeToolBin(
 				directory,
 				"eslint",
 				`const fs=require("node:fs");fs.writeFileSync(${JSON.stringify(
@@ -821,7 +847,7 @@ describe("runConcurrent", () => {
 });
 
 function repoFiles(overrides: Partial<RepoFiles> = {}): RepoFiles {
-	return { bustFiles: [], lintable: [], typeAware: [], ...overrides };
+	return { bustFiles: [], lintable: [], targetsOutsideCwd: false, typeAware: [], ...overrides };
 }
 
 function setMtimeInPast(filePath: string): void {
@@ -850,7 +876,7 @@ describe("hybrid status file", () => {
 		});
 	});
 
-	it("skips rewriting identical content but rewrites on change", () => {
+	it("refreshes the mtime on identical content and rewrites on change", () => {
 		expect.hasAssertions();
 
 		withTemporaryDirectory((directory) => {
@@ -859,10 +885,13 @@ describe("hybrid status file", () => {
 			setMtimeInPast(hybridStatusPath(directory));
 			const before = fs.statSync(hybridStatusPath(directory)).mtimeMs;
 
-			// Identical content: the file must not be rewritten.
+			// Identical content: the file is not rewritten, but its mtime is
+			// refreshed so the CLI's freshness check keeps passing after a config
+			// touch (otherwise the ~3s probe would run on every later lint).
 			writeHybridStatus(directory, false);
 
-			expect(fs.statSync(hybridStatusPath(directory)).mtimeMs).toBe(before);
+			expect(fs.statSync(hybridStatusPath(directory)).mtimeMs).toBeGreaterThan(before);
+			expect(readHybridStatus(directory)).toStrictEqual({ oxlint: false });
 
 			// Changed content: the file is rewritten.
 			writeHybridStatus(directory, true);
@@ -1124,5 +1153,339 @@ describe("plan hybrid integration", () => {
 			expect(commands.some((command) => command.label === "oxc")).toBe(false);
 			expect(notice).toContain(NON_HYBRID_WARNING);
 		});
+	});
+});
+
+function writeFakeToolBin(directory: string, name: string, body: string): void {
+	const packageDirectory = path.join(directory, "node_modules", name);
+	fs.mkdirSync(packageDirectory, { recursive: true });
+	fs.writeFileSync(
+		path.join(packageDirectory, "package.json"),
+		JSON.stringify({ name, bin: { [name]: "bin.js" }, version: "0.0.0" }),
+	);
+	fs.writeFileSync(path.join(packageDirectory, "bin.js"), body);
+}
+
+// A no-op eslint bin so a degraded (oxlint-dropped) run completes instead of
+// failing to resolve the real binary. oxlint-tsgolint is never installed in
+// these temp dirs, so the tsgolint check sees it absent.
+const NOOP_ESLINT_BIN = "process.exit(0);";
+
+describe("runLint tsgolint check ordering", () => {
+	it("does not error without oxlint-tsgolint when the hybrid gate drops oxlint", async () => {
+		expect.hasAssertions();
+
+		const directory = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-pre-"));
+		try {
+			fs.mkdirSync(path.join(directory, "node_modules"), { recursive: true });
+			writeFakeToolBin(directory, "eslint", NOOP_ESLINT_BIN);
+			// A fresh non-hybrid status drops oxlint, so no oxlint child carries
+			// --type-aware and the check must not fire.
+			writeHybridStatus(directory, false);
+
+			const code = await withoutGitEnvironment(async () => runLint([], directory, {}));
+
+			expect(code).toBe(0);
+		} finally {
+			fs.rmSync(directory, { force: true, recursive: true });
+		}
+	});
+
+	it("still errors for an explicit --oxlint run without oxlint-tsgolint", async () => {
+		expect.hasAssertions();
+
+		const directory = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-pre-"));
+		try {
+			await expect(
+				withoutGitEnvironment(async () => runLint(["--oxlint"], directory, {})),
+			).rejects.toThrow(/oxlint-tsgolint is not installed/);
+		} finally {
+			fs.rmSync(directory, { force: true, recursive: true });
+		}
+	});
+
+	it("prints without erroring when oxlint-tsgolint is absent", async () => {
+		expect.hasAssertions();
+
+		const directory = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-pre-"));
+		const spy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+		try {
+			const code = await withoutGitEnvironment(async () => {
+				return runLint(["--print"], directory, {});
+			});
+
+			expect(code).toBe(0);
+
+			// --print returns before the check, so it never throws even though
+			// the composed oxlint child carries --type-aware.
+			const printed = spy.mock.calls.map((call) => String(call[0])).join("");
+
+			expect(printed).toContain("oxlint --type-aware");
+		} finally {
+			spy.mockRestore();
+			fs.rmSync(directory, { force: true, recursive: true });
+		}
+	});
+});
+
+describe("target normalization", () => {
+	it("relativizes an absolute target under cwd and matches its files", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			fs.mkdirSync(path.join(directory, "src"));
+			fs.writeFileSync(path.join(directory, "src", "a.ts"), "export const a = 1;\n");
+			fs.writeFileSync(path.join(directory, "b.ts"), "export const b = 2;\n");
+
+			const files = withoutGitEnvironment(() => {
+				return collectRepoFiles(directory, [path.join(directory, "src")]);
+			});
+
+			expect(files.lintable.map((file) => path.basename(file))).toStrictEqual(["a.ts"]);
+			expect(files.targetsOutsideCwd).toBe(false);
+		});
+	});
+
+	it("flags a relative target that escapes cwd", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			fs.writeFileSync(path.join(directory, "a.ts"), "export const a = 1;\n");
+
+			const files = withoutGitEnvironment(() => collectRepoFiles(directory, ["../sibling"]));
+
+			expect(files.targetsOutsideCwd).toBe(true);
+		});
+	});
+
+	it("flags an absolute target outside cwd", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const outside = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-outside-"));
+			try {
+				const files = withoutGitEnvironment(() => collectRepoFiles(directory, [outside]));
+
+				expect(files.targetsOutsideCwd).toBe(true);
+			} finally {
+				fs.rmSync(outside, { force: true, recursive: true });
+			}
+		});
+	});
+
+	it("still treats './' and trailing slashes as match-all in-cwd targets", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			fs.mkdirSync(path.join(directory, "src"));
+			fs.writeFileSync(path.join(directory, "src", "a.ts"), "export const a = 1;\n");
+
+			const dot = withoutGitEnvironment(() => collectRepoFiles(directory, ["./"]));
+			const trailing = withoutGitEnvironment(() => collectRepoFiles(directory, ["src/"]));
+
+			expect(dot.lintable).toHaveLength(1);
+			expect(dot.targetsOutsideCwd).toBe(false);
+			expect(trailing.lintable).toHaveLength(1);
+			expect(trailing.targetsOutsideCwd).toBe(false);
+		});
+	});
+});
+
+describe("workspace root", () => {
+	it("returns the nearest ancestor bearing a marker", () => {
+		expect.hasAssertions();
+
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-ws-"));
+		try {
+			fs.writeFileSync(path.join(root, "pnpm-workspace.yaml"), "packages: []\n");
+			const app = path.join(root, "packages", "app");
+			fs.mkdirSync(app, { recursive: true });
+
+			expect(findWorkspaceRoot(app)).toBe(root);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+});
+
+describe("ancestor cache-bust collection", () => {
+	it("folds workspace-root bust files into a sub-package run", () => {
+		expect.hasAssertions();
+
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-anc-"));
+		try {
+			fs.writeFileSync(path.join(root, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+			fs.writeFileSync(path.join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+			fs.writeFileSync(path.join(root, "tsconfig.json"), "{}");
+			const app = path.join(root, "packages", "app");
+			fs.mkdirSync(app, { recursive: true });
+			fs.writeFileSync(path.join(app, "a.ts"), "export const a = 1;\n");
+
+			const files = withoutGitEnvironment(() => collectRepoFiles(app, ["."]));
+
+			expect(files.bustFiles).toContain(path.join(root, "pnpm-lock.yaml"));
+			expect(files.bustFiles).toContain(path.join(root, "tsconfig.json"));
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	it("collects nothing extra when cwd is itself the workspace root", () => {
+		expect.hasAssertions();
+
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-anc-"));
+		try {
+			fs.writeFileSync(path.join(root, "pnpm-workspace.yaml"), "packages: []\n");
+			fs.writeFileSync(path.join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+
+			const files = withoutGitEnvironment(() => collectRepoFiles(root, ["."]));
+
+			// The root lockfile comes from the in-cwd scan, not doubled by the
+			// ancestor walk.
+			const lockfiles = files.bustFiles.filter(
+				(file) => path.basename(file) === "pnpm-lock.yaml",
+			);
+
+			expect(lockfiles).toHaveLength(1);
+		} finally {
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+});
+
+describe("full-pass env hygiene", () => {
+	it("explicitly clears ESLINT_TYPE_AWARE for the full pass so an inherited value cannot leak", () => {
+		expect.hasAssertions();
+
+		const command = composeEslintCommand(
+			options({ typeAware: "full" }),
+			baseContext({ eslintLabel: "eslint", typeAwareEnv: undefined }),
+		);
+
+		expect(Object.hasOwn(command.env, "ESLINT_TYPE_AWARE")).toBe(true);
+		expect(command.env["ESLINT_TYPE_AWARE"]).toBeUndefined();
+
+		// Merged over an inherited value, the undefined entry removes the key
+		// (Node drops undefined env entries at spawn time).
+		const merged: Record<string, string | undefined> = {
+			ESLINT_TYPE_AWARE: "only",
+			...command.env,
+		};
+
+		expect(merged["ESLINT_TYPE_AWARE"]).toBeUndefined();
+	});
+
+	it("keeps setting ESLINT_TYPE_AWARE for the fast and typed passes", () => {
+		expect.hasAssertions();
+
+		expect(
+			composeEslintCommand(options(), baseContext({ typeAwareEnv: "off" })).env,
+		).toStrictEqual({ ESLINT_TYPE_AWARE: "off" });
+		expect(
+			composeEslintCommand(options(), baseContext({ typeAwareEnv: "only" })).env,
+		).toStrictEqual({ ESLINT_TYPE_AWARE: "only" });
+	});
+});
+
+describe("explicit --type-aware selection in CI", () => {
+	it("keeps an explicit --type-aware=only pass in CI with the content cache strategy", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(printLines(["--type-aware=only"], directory, { CI: "true" })).toStrictEqual([
+				"oxlint --type-aware .",
+				"ESLINT_TYPE_AWARE=only eslint --cache --cache-location .eslintcache-typeaware " +
+					"--no-warn-ignored --concurrency off --cache-strategy content .",
+			]);
+		});
+	});
+
+	it("keeps an explicit --type-aware=off pass in CI", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(printLines(["--type-aware=off"], directory, { CI: "true" })).toStrictEqual([
+				"oxlint .",
+				"ESLINT_TYPE_AWARE=off eslint --cache --cache-location .eslintcache-fast " +
+					"--no-warn-ignored --concurrency off --cache-strategy content .",
+			]);
+		});
+	});
+});
+
+describe("bust-before-size ordering", () => {
+	it("clears every cache up front so an earlier pass is not under-provisioned", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const sources = ["a.ts", "b.ts", "c.ts"].map((name) => path.join(directory, name));
+			for (const source of sources) {
+				fs.writeFileSync(source, "export const x = 1;\n");
+			}
+
+			const configFile = path.join(directory, "eslint.config.ts");
+			fs.writeFileSync(configFile, "export default []");
+
+			const fastCache = path.join(directory, CACHE_FILE_FAST);
+			const typedCache = path.join(directory, CACHE_FILE_TYPE_AWARE);
+			seedFileCache(fastCache, sources);
+			seedFileCache(typedCache, sources);
+
+			// Order mtimes: typed cache oldest, config in the middle (the bust
+			// reference), fast cache newest. So the fast cache is fresh and only
+			// the typed cache is stale — yet the fix must clear BOTH before
+			// sizing so the fast pass is provisioned for all the re-linted files.
+			const now = Date.now() / 1000;
+			fs.utimesSync(typedCache, now - 120, now - 120);
+			fs.utimesSync(configFile, now - 60, now - 60);
+			fs.utimesSync(fastCache, now, now);
+
+			const { commands } = withoutGitEnvironment(() => {
+				return composeCommands(parseArguments([]), {
+					cwd: directory,
+					dryRun: false,
+					environment: { FAST_FILES_PER_WORKER: "1", LINT_MAX_WORKERS: "8" },
+				});
+			});
+
+			// Every lintable file (three sources plus eslint.config.ts) is dirty
+			// after the up-front clear => four fast workers at one file per
+			// worker. Without the fix the fast pass reads its fresh cache, sees
+			// only the uncached config file (one dirty) and sizes to "off".
+			expect(concurrencyArgument(commands, "fast")).toBe("4");
+		});
+	});
+});
+
+describe("parseHybridPrintConfig", () => {
+	it("reads the marker through leading log noise", () => {
+		expect.hasAssertions();
+
+		expect(
+			parseHybridPrintConfig('startup log\n{"settings":{"isentinel/oxlint":true}}'),
+		).toStrictEqual({ oxlint: true });
+		expect(parseHybridPrintConfig('noise {"settings":{}} trailing')).toStrictEqual({
+			oxlint: false,
+		});
+	});
+
+	it("returns undefined when there is no JSON object", () => {
+		expect.hasAssertions();
+
+		expect(parseHybridPrintConfig("not json at all")).toBeUndefined();
+		expect(parseHybridPrintConfig("")).toBeUndefined();
+	});
+});
+
+describe("buildShellCommand percent guard", () => {
+	it("refuses a % token on the Windows shell path but quotes it on POSIX", () => {
+		expect.hasAssertions();
+
+		expect(() => buildShellCommand("node", "/path/eslint.js", ["%PATH%"], "win32")).toThrow(
+			CliError,
+		);
+		expect(buildShellCommand("node", "/path/eslint.js", ["50%"], "linux")).toBe(
+			"node /path/eslint.js '50%'",
+		);
 	});
 });

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -14,11 +14,22 @@ import {
 	formatCommandLine,
 	splitArgs,
 } from "../src/lint-cli/command.ts";
-import { computeWorkerCount, resolveWorkerLimits } from "../src/lint-cli/concurrency.ts";
-import { ALL_CACHE_FILES, cacheFileForMode } from "../src/lint-cli/constants.ts";
+import {
+	computeWorkerCount,
+	resolveFastFilesPerWorker,
+	resolveWorkerLimits,
+} from "../src/lint-cli/concurrency.ts";
+import {
+	ALL_CACHE_FILES,
+	CACHE_FILE_FAST,
+	CACHE_FILE_TYPE_AWARE,
+	cacheFileForMode,
+} from "../src/lint-cli/constants.ts";
 import { collectLintableFiles } from "../src/lint-cli/files.ts";
 import { parseArguments } from "../src/lint-cli/options.ts";
-import type { ComposeContext, LintCliOptions } from "../src/lint-cli/types.ts";
+import { applyPackageJsonBust, computePackageJsonHash } from "../src/lint-cli/package-hash.ts";
+import { composeCommands, runConcurrent } from "../src/lint-cli/run.ts";
+import type { ChildCommand, ComposeContext, LintCliOptions } from "../src/lint-cli/types.ts";
 import { CliError } from "../src/lint-cli/types.ts";
 
 function baseContext(overrides: Partial<ComposeContext> = {}): ComposeContext {
@@ -27,8 +38,10 @@ function baseContext(overrides: Partial<ComposeContext> = {}): ComposeContext {
 		cacheLocation: ".eslintcache",
 		ci: false,
 		concurrency: "off",
+		eslintLabel: "eslint",
 		oxlintTypeAware: false,
 		paths: ["."],
+		typeAwareEnv: undefined,
 		...overrides,
 	};
 }
@@ -83,6 +96,12 @@ function withTemporaryDirectory(run: (directory: string) => void): void {
 
 function workerCount(dirty: number, perWorker: number, max: number): "off" | number {
 	return computeWorkerCount({ dirtyCount: dirty, filesPerWorker: perWorker, maxWorkers: max });
+}
+
+function concurrencyArgument(commands: Array<ChildCommand>, label: string): string {
+	const command = commands.find((entry) => entry.label === label);
+	const index = command?.args.indexOf("--concurrency") ?? -1;
+	return command?.args[index + 1] ?? "";
 }
 
 describe("parseArguments", () => {
@@ -403,8 +422,14 @@ describe("command composition", () => {
 		expect.hasAssertions();
 
 		const command = composeEslintCommand(
-			options({ typeAware: "off" }),
-			baseContext({ cacheLocation: ".eslintcache-fast", concurrency: 4, paths: ["src"] }),
+			options(),
+			baseContext({
+				cacheLocation: ".eslintcache-fast",
+				concurrency: 4,
+				eslintLabel: "fast",
+				paths: ["src"],
+				typeAwareEnv: "off",
+			}),
 		);
 
 		expect(command.args).toStrictEqual([
@@ -417,6 +442,7 @@ describe("command composition", () => {
 			"src",
 		]);
 		expect(command.env).toStrictEqual({ ESLINT_TYPE_AWARE: "off" });
+		expect(command.label).toBe("fast");
 	});
 
 	it("adds the content cache strategy in CI", () => {
@@ -456,8 +482,13 @@ describe("formatCommandLine", () => {
 		expect.hasAssertions();
 
 		const command = composeEslintCommand(
-			options({ typeAware: "off" }),
-			baseContext({ cacheLocation: ".eslintcache-fast", ci: true, concurrency: 4 }),
+			options(),
+			baseContext({
+				cacheLocation: ".eslintcache-fast",
+				ci: true,
+				concurrency: 4,
+				typeAwareEnv: "off",
+			}),
 		);
 
 		expect(formatCommandLine(command)).toBe(
@@ -489,4 +520,270 @@ describe("buildShellCommand", () => {
 			'node "C:/a b/eslint.js" .',
 		);
 	});
+});
+
+function printLines(
+	argv: Array<string>,
+	directory: string,
+	environment: NodeJS.ProcessEnv = {},
+): Array<string> {
+	return withoutGitEnvironment(() => {
+		const { commands } = composeCommands(parseArguments(argv), {
+			cwd: directory,
+			dryRun: true,
+			environment,
+		});
+		return commands.map((command) => formatCommandLine(command));
+	});
+}
+
+describe("composeCommands --print", () => {
+	it("composes the default concurrent two-pass mode plus oxlint", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(printLines([], directory)).toStrictEqual([
+				"oxlint --type-aware .",
+				"ESLINT_TYPE_AWARE=off eslint --cache --cache-location .eslintcache-fast " +
+					"--no-warn-ignored --concurrency off .",
+				"ESLINT_TYPE_AWARE=only eslint --cache --cache-location .eslintcache-typeaware " +
+					"--no-warn-ignored --concurrency off .",
+			]);
+		});
+	});
+
+	it("composes only the fast pass for --type-aware=off", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(printLines(["--type-aware=off"], directory)).toStrictEqual([
+				"oxlint .",
+				"ESLINT_TYPE_AWARE=off eslint --cache --cache-location .eslintcache-fast " +
+					"--no-warn-ignored --concurrency off .",
+			]);
+		});
+	});
+
+	it("composes only the typed pass for --type-aware=only", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(printLines(["--type-aware=only"], directory)).toStrictEqual([
+				"oxlint --type-aware .",
+				"ESLINT_TYPE_AWARE=only eslint --cache --cache-location .eslintcache-typeaware " +
+					"--no-warn-ignored --concurrency off .",
+			]);
+		});
+	});
+
+	it("composes the full config for the --type-aware=full escape hatch", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(printLines(["--type-aware=full"], directory)).toStrictEqual([
+				"oxlint --type-aware .",
+				"eslint --cache --cache-location .eslintcache --no-warn-ignored --concurrency off .",
+			]);
+		});
+	});
+
+	it("composes a single full pass with the content cache strategy in CI", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(printLines([], directory, { CI: "true" })).toStrictEqual([
+				"oxlint --type-aware .",
+				"eslint --cache --cache-location .eslintcache --no-warn-ignored --concurrency off " +
+					"--cache-strategy content .",
+			]);
+		});
+	});
+
+	it("composes the sequential full-config fix pass", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(printLines(["--fix"], directory)).toStrictEqual([
+				"oxlint --type-aware --fix .",
+				"eslint --cache --cache-location .eslintcache --no-warn-ignored --concurrency off " +
+					"--fix .",
+			]);
+		});
+	});
+});
+
+describe("fast pass sizing", () => {
+	it("sizes the fast pass from FAST_FILES_PER_WORKER and the typed pass from 350", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			for (const name of ["a.ts", "b.ts", "c.ts"]) {
+				fs.writeFileSync(path.join(directory, name), "export const x = 1;\n");
+			}
+
+			const { commands } = withoutGitEnvironment(() => {
+				return composeCommands(parseArguments([]), {
+					cwd: directory,
+					dryRun: true,
+					environment: { FAST_FILES_PER_WORKER: "1", LINT_MAX_WORKERS: "8" },
+				});
+			});
+
+			// Three dirty files: FAST_FILES_PER_WORKER=1 => 3 fast workers; the
+			// typed pass keeps the 350-file default => a single worker (off).
+			expect(concurrencyArgument(commands, "fast")).toBe("3");
+			expect(concurrencyArgument(commands, "typed")).toBe("off");
+		});
+	});
+});
+
+describe("resolveFastFilesPerWorker", () => {
+	it("defaults to 800 and honours FAST_FILES_PER_WORKER", () => {
+		expect.hasAssertions();
+
+		expect(resolveFastFilesPerWorker({})).toBe(800);
+		expect(resolveFastFilesPerWorker({ FAST_FILES_PER_WORKER: "200" })).toBe(200);
+		expect(resolveFastFilesPerWorker({ FAST_FILES_PER_WORKER: "0" })).toBe(800);
+	});
+});
+
+describe("applyPackageJsonBust", () => {
+	function writePackageJson(directory: string, value: Record<string, unknown>): void {
+		fs.writeFileSync(path.join(directory, "package.json"), JSON.stringify(value));
+	}
+
+	function seedCaches(directory: string): void {
+		for (const name of ALL_CACHE_FILES) {
+			fs.writeFileSync(path.join(directory, name), "{}");
+		}
+	}
+
+	it("stores the hash without busting on the first run", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			writePackageJson(directory, { exports: "./index.js" });
+			seedCaches(directory);
+
+			const outcome = applyPackageJsonBust(directory);
+
+			expect(outcome).toStrictEqual({ busted: false, firstRun: true });
+
+			for (const name of ALL_CACHE_FILES) {
+				expect(fs.existsSync(path.join(directory, name))).toBe(true);
+			}
+		});
+	});
+
+	it("deletes the type-aware caches but keeps the fast cache when exports change", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			writePackageJson(directory, { exports: "./index.js" });
+			applyPackageJsonBust(directory);
+			seedCaches(directory);
+
+			writePackageJson(directory, { exports: "./other.js" });
+			const outcome = applyPackageJsonBust(directory);
+
+			expect(outcome).toStrictEqual({ busted: true, firstRun: false });
+			expect(fs.existsSync(path.join(directory, CACHE_FILE_TYPE_AWARE))).toBe(false);
+			expect(fs.existsSync(path.join(directory, ".eslintcache"))).toBe(false);
+			expect(fs.existsSync(path.join(directory, CACHE_FILE_FAST))).toBe(true);
+		});
+	});
+
+	it("does not bust when only unrelated fields change", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			writePackageJson(directory, { exports: "./index.js", scripts: { build: "tsc" } });
+			applyPackageJsonBust(directory);
+			seedCaches(directory);
+
+			writePackageJson(directory, {
+				exports: "./index.js",
+				scripts: { build: "tsc --noEmit" },
+				version: "9.9.9",
+			});
+			const outcome = applyPackageJsonBust(directory);
+
+			expect(outcome).toStrictEqual({ busted: false, firstRun: false });
+
+			for (const name of ALL_CACHE_FILES) {
+				expect(fs.existsSync(path.join(directory, name))).toBe(true);
+			}
+		});
+	});
+
+	it("hashes resolution fields independent of key order", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const dependencies = { a: "1", b: "2" };
+			writePackageJson(directory, { dependencies, exports: "./index.js" });
+			const first = computePackageJsonHash(directory);
+
+			// Reverse the insertion order programmatically so the hash, not the
+			// literal, is what proves order-independence.
+			const reversed = Object.fromEntries(Object.entries(dependencies).reverse());
+			writePackageJson(directory, { dependencies: reversed, exports: "./index.js" });
+			const second = computePackageJsonHash(directory);
+
+			expect(first).toBe(second);
+		});
+	});
+});
+
+describe("runConcurrent", () => {
+	function writeFakeBin(directory: string, name: string, body: string): void {
+		const packageDirectory = path.join(directory, "node_modules", name);
+		fs.mkdirSync(packageDirectory, { recursive: true });
+		fs.writeFileSync(
+			path.join(packageDirectory, "package.json"),
+			JSON.stringify({ name, bin: { [name]: "bin.js" }, version: "0.0.0" }),
+		);
+		fs.writeFileSync(path.join(packageDirectory, "bin.js"), body);
+	}
+
+	it("runs every child to completion and aggregates a non-zero exit", async () => {
+		expect.hasAssertions();
+
+		const directory = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-run-"));
+		try {
+			const oxcMarker = path.join(directory, "oxc-ran");
+			const eslintMarker = path.join(directory, "eslint-ran");
+
+			// oxlint succeeds but only after a delay; eslint fails immediately. A
+			// kill-on-failure would kill oxlint before it writes its marker.
+			writeFakeBin(
+				directory,
+				"oxlint",
+				`const fs=require("node:fs");setTimeout(()=>{fs.writeFileSync(${JSON.stringify(
+					oxcMarker,
+				)},"ran");process.exit(0);},250);`,
+			);
+			writeFakeBin(
+				directory,
+				"eslint",
+				`const fs=require("node:fs");fs.writeFileSync(${JSON.stringify(
+					eslintMarker,
+				)},"ran");process.exit(1);`,
+			);
+
+			const code = await runConcurrent(
+				[
+					{ args: [], bin: "oxlint", env: {}, label: "oxc" },
+					{ args: [], bin: "eslint", env: {}, label: "eslint" },
+				],
+				directory,
+			);
+
+			expect(code).toBe(1);
+			expect(fs.existsSync(eslintMarker)).toBe(true);
+			expect(fs.existsSync(oxcMarker)).toBe(true);
+		} finally {
+			fs.rmSync(directory, { force: true, recursive: true });
+		}
+	}, 15_000);
 });

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -3,10 +3,9 @@ import fileEntryCache from "file-entry-cache";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import process from "node:process";
 import { describe, expect, it } from "vitest";
 
-import { clearAllCaches, countDirtyFiles, isCacheBusted } from "../src/lint-cli/cache.ts";
+import { clearAllCaches, isCacheBusted, listDirtyFiles } from "../src/lint-cli/cache.ts";
 import {
 	buildShellCommand,
 	composeEslintCommand,
@@ -23,7 +22,6 @@ import {
 	ALL_CACHE_FILES,
 	CACHE_FILE_FAST,
 	CACHE_FILE_TYPE_AWARE,
-	cacheFileForMode,
 } from "../src/lint-cli/constants.ts";
 import { collectLintableFiles } from "../src/lint-cli/files.ts";
 import { parseArguments } from "../src/lint-cli/options.ts";
@@ -31,6 +29,7 @@ import { applyPackageJsonBust, computePackageJsonHash } from "../src/lint-cli/pa
 import { composeCommands, runConcurrent } from "../src/lint-cli/run.ts";
 import type { ChildCommand, ComposeContext, LintCliOptions } from "../src/lint-cli/types.ts";
 import { CliError } from "../src/lint-cli/types.ts";
+import { withoutGitEnvironment } from "./without-git.ts";
 
 function baseContext(overrides: Partial<ComposeContext> = {}): ComposeContext {
 	return {
@@ -62,26 +61,6 @@ function options(overrides: Partial<LintCliOptions> = {}): LintCliOptions {
 		typeAware: undefined,
 		...overrides,
 	};
-}
-
-function withoutGitEnvironment<T>(run: () => T): T {
-	const keys = ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"];
-	const saved = keys.map((key): [string, string | undefined] => [key, process.env[key]]);
-	for (const key of keys) {
-		delete process.env[key];
-	}
-
-	try {
-		return run();
-	} finally {
-		for (const [key, value] of saved) {
-			if (value === undefined) {
-				delete process.env[key];
-			} else {
-				process.env[key] = value;
-			}
-		}
-	}
 }
 
 function withTemporaryDirectory(run: (directory: string) => void): void {
@@ -246,16 +225,6 @@ describe("resolveWorkerLimits", () => {
 	});
 });
 
-describe("cacheFileForMode", () => {
-	it("maps type-aware modes to cache files", () => {
-		expect.hasAssertions();
-
-		expect(cacheFileForMode(undefined)).toBe(".eslintcache");
-		expect(cacheFileForMode("off")).toBe(".eslintcache-fast");
-		expect(cacheFileForMode("only")).toBe(".eslintcache-typeaware");
-	});
-});
-
 describe("cache helpers", () => {
 	it("detects a bust file newer than the cache", () => {
 		expect.hasAssertions();
@@ -320,7 +289,9 @@ describe("cache helpers", () => {
 			fs.writeFileSync(fileA, "const a = 1;");
 			fs.writeFileSync(fileB, "const b = 2;");
 
-			expect(countDirtyFiles(path.join(directory, "missing"), [fileA, fileB], false)).toBe(2);
+			expect(
+				listDirtyFiles(path.join(directory, "missing"), [fileA, fileB], false),
+			).toHaveLength(2);
 		});
 	});
 
@@ -342,13 +313,13 @@ describe("cache helpers", () => {
 			cache.reconcile();
 
 			// fileA is cached and unchanged; fileB was never seen.
-			expect(countDirtyFiles(cacheFile, [fileA, fileB], false)).toBe(1);
+			expect(listDirtyFiles(cacheFile, [fileA, fileB], false)).toHaveLength(1);
 
 			fs.writeFileSync(fileA, "const a = 42;");
 			const future = Date.now() / 1000 + 60;
 			fs.utimesSync(fileA, future, future);
 
-			expect(countDirtyFiles(cacheFile, [fileA, fileB], false)).toBe(2);
+			expect(listDirtyFiles(cacheFile, [fileA, fileB], false)).toHaveLength(2);
 		});
 	});
 });

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -24,6 +24,18 @@ import {
 	CACHE_FILE_TYPE_AWARE,
 } from "../src/lint-cli/constants.ts";
 import { collectLintableFiles } from "../src/lint-cli/files.ts";
+import type { RepoFiles } from "../src/lint-cli/files.ts";
+import {
+	hybridStatusPath,
+	readHybridStatus,
+	writeHybridStatus,
+} from "../src/lint-cli/hybrid-status.ts";
+import type { HybridStatus } from "../src/lint-cli/hybrid-status.ts";
+import {
+	HYBRID_UNKNOWN_WARNING,
+	NON_HYBRID_WARNING,
+	resolveOxlintRun,
+} from "../src/lint-cli/hybrid.ts";
 import { parseArguments } from "../src/lint-cli/options.ts";
 import { applyPackageJsonBust, computePackageJsonHash } from "../src/lint-cli/package-hash.ts";
 import { composeCommands, plan, runConcurrent } from "../src/lint-cli/run.ts";
@@ -806,4 +818,311 @@ describe("runConcurrent", () => {
 			fs.rmSync(directory, { force: true, recursive: true });
 		}
 	}, 15_000);
+});
+
+function repoFiles(overrides: Partial<RepoFiles> = {}): RepoFiles {
+	return { bustFiles: [], lintable: [], typeAware: [], ...overrides };
+}
+
+function setMtimeInPast(filePath: string): void {
+	const past = Date.now() / 1000 - 60;
+	fs.utimesSync(filePath, past, past);
+}
+
+function setMtimeInFuture(filePath: string): void {
+	const future = Date.now() / 1000 + 60;
+	fs.utimesSync(filePath, future, future);
+}
+
+describe("hybrid status file", () => {
+	it("only writes when node_modules exists", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			writeHybridStatus(directory, true);
+
+			expect(fs.existsSync(hybridStatusPath(directory))).toBe(false);
+
+			fs.mkdirSync(path.join(directory, "node_modules"));
+			writeHybridStatus(directory, true);
+
+			expect(readHybridStatus(directory)).toStrictEqual({ oxlint: true });
+		});
+	});
+
+	it("skips rewriting identical content but rewrites on change", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			fs.mkdirSync(path.join(directory, "node_modules"));
+			writeHybridStatus(directory, false);
+			setMtimeInPast(hybridStatusPath(directory));
+			const before = fs.statSync(hybridStatusPath(directory)).mtimeMs;
+
+			// Identical content: the file must not be rewritten.
+			writeHybridStatus(directory, false);
+
+			expect(fs.statSync(hybridStatusPath(directory)).mtimeMs).toBe(before);
+
+			// Changed content: the file is rewritten.
+			writeHybridStatus(directory, true);
+
+			expect(readHybridStatus(directory)).toStrictEqual({ oxlint: true });
+		});
+	});
+
+	it("swallows write failures", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			fs.mkdirSync(path.join(directory, "node_modules"));
+			// `.cache` as a file makes creating the isentinel-lint subdir throw.
+			fs.writeFileSync(path.join(directory, "node_modules", ".cache"), "");
+
+			expect(() => {
+				writeHybridStatus(directory, true);
+			}).not.toThrow();
+			expect(readHybridStatus(directory)).toBeUndefined();
+		});
+	});
+
+	it("returns undefined for malformed status content", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const statusPath = hybridStatusPath(directory);
+			fs.mkdirSync(path.dirname(statusPath), { recursive: true });
+			fs.writeFileSync(statusPath, "not json");
+
+			expect(readHybridStatus(directory)).toBeUndefined();
+		});
+	});
+});
+
+describe("resolveOxlintRun", () => {
+	function freshConfig(directory: string): string {
+		const config = path.join(directory, "eslint.config.ts");
+		fs.writeFileSync(config, "export default []");
+		setMtimeInPast(config);
+		return config;
+	}
+
+	it("drops oxlint with a warning when a fresh status is non-hybrid", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			fs.mkdirSync(path.join(directory, "node_modules"));
+			const config = freshConfig(directory);
+			writeHybridStatus(directory, false);
+
+			let probeCalls = 0;
+			function probe(): HybridStatus {
+				probeCalls += 1;
+				return { oxlint: false };
+			}
+
+			const decision = resolveOxlintRun(
+				{
+					cwd: directory,
+					files: repoFiles({ bustFiles: [config] }),
+					mutate: true,
+					runEslint: true,
+					runOxlint: true,
+				},
+				probe,
+			);
+
+			expect(decision).toStrictEqual({ reason: NON_HYBRID_WARNING, run: false });
+			expect(probeCalls).toBe(0);
+		});
+	});
+
+	it("runs both engines when a fresh status is hybrid, without probing", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			fs.mkdirSync(path.join(directory, "node_modules"));
+			const config = freshConfig(directory);
+			writeHybridStatus(directory, true);
+
+			let probeCalls = 0;
+			function probe(): HybridStatus {
+				probeCalls += 1;
+				return { oxlint: false };
+			}
+
+			const decision = resolveOxlintRun(
+				{
+					cwd: directory,
+					files: repoFiles({ bustFiles: [config] }),
+					mutate: true,
+					runEslint: true,
+					runOxlint: true,
+				},
+				probe,
+			);
+
+			expect(decision).toStrictEqual({ reason: undefined, run: true });
+			expect(probeCalls).toBe(0);
+		});
+	});
+
+	it("probes when the status is stale and persists the probe result", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			fs.mkdirSync(path.join(directory, "node_modules"));
+			// Status first (older), then a newer config makes it stale.
+			writeHybridStatus(directory, true);
+			const config = path.join(directory, "eslint.config.ts");
+			fs.writeFileSync(config, "export default []");
+			setMtimeInFuture(config);
+
+			let probeCalls = 0;
+			function probe(): HybridStatus {
+				probeCalls += 1;
+				return { oxlint: false };
+			}
+
+			const decision = resolveOxlintRun(
+				{
+					cwd: directory,
+					files: repoFiles({
+						bustFiles: [config],
+						typeAware: [path.join(directory, "a.ts")],
+					}),
+					mutate: true,
+					runEslint: true,
+					runOxlint: true,
+				},
+				probe,
+			);
+
+			expect(probeCalls).toBe(1);
+			expect(decision).toStrictEqual({ reason: NON_HYBRID_WARNING, run: false });
+			expect(readHybridStatus(directory)).toStrictEqual({ oxlint: false });
+		});
+	});
+
+	it("fails open when the probe cannot determine the status", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			fs.mkdirSync(path.join(directory, "node_modules"));
+
+			const decision = resolveOxlintRun(
+				{
+					cwd: directory,
+					files: repoFiles({ typeAware: [path.join(directory, "a.ts")] }),
+					mutate: true,
+					runEslint: true,
+					runOxlint: true,
+				},
+				() => {},
+			);
+
+			expect(decision).toStrictEqual({ reason: HYBRID_UNKNOWN_WARNING, run: true });
+		});
+	});
+
+	it("skips the check for explicit single-tool runs", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			let probeCalls = 0;
+			function probe(): HybridStatus {
+				probeCalls += 1;
+				return { oxlint: false };
+			}
+
+			// --oxlint leaves runEslint false; --eslint leaves runOxlint false.
+			const oxlintOnly = resolveOxlintRun(
+				{
+					cwd: directory,
+					files: repoFiles(),
+					mutate: true,
+					runEslint: false,
+					runOxlint: true,
+				},
+				probe,
+			);
+			const eslintOnly = resolveOxlintRun(
+				{
+					cwd: directory,
+					files: repoFiles(),
+					mutate: true,
+					runEslint: true,
+					runOxlint: false,
+				},
+				probe,
+			);
+
+			expect(oxlintOnly).toStrictEqual({ reason: undefined, run: true });
+			expect(eslintOnly).toStrictEqual({ reason: undefined, run: false });
+			expect(probeCalls).toBe(0);
+		});
+	});
+
+	it("never probes or writes for a read-only (--print) plan", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			fs.mkdirSync(path.join(directory, "node_modules"));
+			const config = path.join(directory, "eslint.config.ts");
+			fs.writeFileSync(config, "export default []");
+			setMtimeInFuture(config);
+
+			let probeCalls = 0;
+			function probe(): HybridStatus {
+				probeCalls += 1;
+				return { oxlint: false };
+			}
+
+			const decision = resolveOxlintRun(
+				{
+					cwd: directory,
+					files: repoFiles({
+						bustFiles: [config],
+						typeAware: [path.join(directory, "a.ts")],
+					}),
+					mutate: false,
+					runEslint: true,
+					runOxlint: true,
+				},
+				probe,
+			);
+
+			// Stale status, but --print never probes: assume hybrid, print
+			// unchanged.
+			expect(decision).toStrictEqual({ reason: undefined, run: true });
+			expect(probeCalls).toBe(0);
+			expect(fs.existsSync(hybridStatusPath(directory))).toBe(false);
+		});
+	});
+});
+
+describe("plan hybrid integration", () => {
+	it("drops the oxlint child for a fresh non-hybrid status", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			fs.mkdirSync(path.join(directory, "node_modules"));
+			const config = path.join(directory, "eslint.config.ts");
+			fs.writeFileSync(config, "export default []");
+			fs.writeFileSync(path.join(directory, "a.ts"), "export const x = 1;\n");
+			setMtimeInPast(config);
+			writeHybridStatus(directory, false);
+
+			const { commands, notice } = withoutGitEnvironment(() => {
+				return composeCommands(parseArguments([]), {
+					cwd: directory,
+					dryRun: false,
+					environment: {},
+				});
+			});
+
+			expect(commands.some((command) => command.label === "oxc")).toBe(false);
+			expect(notice).toContain(NON_HYBRID_WARNING);
+		});
+	});
 });

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -1,8 +1,9 @@
-// cspell:words typeaware
+// cspell:words typeaware lintable
 import fileEntryCache from "file-entry-cache";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import process from "node:process";
 import { describe, expect, it } from "vitest";
 
 import { clearAllCaches, countDirtyFiles, isCacheBusted } from "../src/lint-cli/cache.ts";
@@ -15,6 +16,7 @@ import {
 } from "../src/lint-cli/command.ts";
 import { computeWorkerCount, resolveWorkerLimits } from "../src/lint-cli/concurrency.ts";
 import { ALL_CACHE_FILES, cacheFileForMode } from "../src/lint-cli/constants.ts";
+import { collectLintableFiles } from "../src/lint-cli/files.ts";
 import { parseArguments } from "../src/lint-cli/options.ts";
 import type { ComposeContext, LintCliOptions } from "../src/lint-cli/types.ts";
 import { CliError } from "../src/lint-cli/types.ts";
@@ -47,6 +49,26 @@ function options(overrides: Partial<LintCliOptions> = {}): LintCliOptions {
 		typeAware: undefined,
 		...overrides,
 	};
+}
+
+function withoutGitEnvironment<T>(run: () => T): T {
+	const keys = ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"];
+	const saved = keys.map((key): [string, string | undefined] => [key, process.env[key]]);
+	for (const key of keys) {
+		delete process.env[key];
+	}
+
+	try {
+		return run();
+	} finally {
+		for (const [key, value] of saved) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
 }
 
 function withTemporaryDirectory(run: (directory: string) => void): void {
@@ -308,6 +330,37 @@ describe("cache helpers", () => {
 			fs.utimesSync(fileA, future, future);
 
 			expect(countDirtyFiles(cacheFile, [fileA, fileB], false)).toBe(2);
+		});
+	});
+});
+
+describe("collectLintableFiles", () => {
+	it("collects the TS/JS family plus JSONC, YAML, TOML, Markdown and Lua", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const lintable = [
+				"a.ts",
+				"b.tsx",
+				"c.js",
+				"config.json",
+				"tsconfig.jsonc",
+				"data.json5",
+				"ci.yaml",
+				"pnpm-workspace.yml",
+				"Cargo.toml",
+				"README.md",
+				"init.lua",
+			];
+			const excluded = ["notes.txt", "styles.css"];
+			for (const name of [...lintable, ...excluded]) {
+				fs.writeFileSync(path.join(directory, name), "");
+			}
+
+			const files = withoutGitEnvironment(() => collectLintableFiles(directory, ["."]));
+			const collected = files.map((file) => path.basename(file));
+
+			expect(collected.toSorted()).toStrictEqual(lintable.toSorted());
 		});
 	});
 });

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -26,7 +26,7 @@ import {
 import { collectLintableFiles } from "../src/lint-cli/files.ts";
 import { parseArguments } from "../src/lint-cli/options.ts";
 import { applyPackageJsonBust, computePackageJsonHash } from "../src/lint-cli/package-hash.ts";
-import { composeCommands, runConcurrent } from "../src/lint-cli/run.ts";
+import { composeCommands, plan, runConcurrent } from "../src/lint-cli/run.ts";
 import type { ChildCommand, ComposeContext, LintCliOptions } from "../src/lint-cli/types.ts";
 import { CliError } from "../src/lint-cli/types.ts";
 import { withoutGitEnvironment } from "./without-git.ts";
@@ -38,7 +38,6 @@ function baseContext(overrides: Partial<ComposeContext> = {}): ComposeContext {
 		ci: false,
 		concurrency: "off",
 		eslintLabel: "eslint",
-		oxlintTypeAware: false,
 		paths: ["."],
 		typeAwareEnv: undefined,
 		...overrides,
@@ -372,10 +371,10 @@ describe("command composition", () => {
 	it("composes the oxlint command with type-aware, agents and fix", () => {
 		expect.hasAssertions();
 
-		const command = composeOxlintCommand(
-			options({ agents: true, fix: true }),
-			baseContext({ oxlintTypeAware: true, paths: ["src"] }),
-		);
+		const command = composeOxlintCommand(options({ agents: true, fix: true }), {
+			oxlintTypeAware: true,
+			paths: ["src"],
+		});
 
 		expect(command.args).toStrictEqual(["--format", "agent", "--type-aware", "--fix", "src"]);
 		expect(command.env).toStrictEqual({});
@@ -384,7 +383,7 @@ describe("command composition", () => {
 	it("omits --type-aware from oxlint when disabled", () => {
 		expect.hasAssertions();
 
-		const command = composeOxlintCommand(options(), baseContext({ oxlintTypeAware: false }));
+		const command = composeOxlintCommand(options(), { oxlintTypeAware: false, paths: ["."] });
 
 		expect(command.args).not.toContain("--type-aware");
 	});
@@ -471,7 +470,7 @@ describe("formatCommandLine", () => {
 	it("renders oxlint without an env prefix", () => {
 		expect.hasAssertions();
 
-		const command = composeOxlintCommand(options(), baseContext({ oxlintTypeAware: true }));
+		const command = composeOxlintCommand(options(), { oxlintTypeAware: true, paths: ["."] });
 
 		expect(formatCommandLine(command)).toBe("oxlint --type-aware .");
 	});
@@ -579,6 +578,56 @@ describe("composeCommands --print", () => {
 				"eslint --cache --cache-location .eslintcache --no-warn-ignored --concurrency off " +
 					"--fix .",
 			]);
+		});
+	});
+});
+
+describe("plan", () => {
+	it("returns the default fast + typed passes as data", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const runPlan = withoutGitEnvironment(() => {
+				return plan(parseArguments([]), directory, {}, false);
+			});
+
+			expect(runPlan.oxlint).toBe(true);
+			expect(runPlan.oxlintTypeAware).toBe(true);
+			expect(runPlan.passes.map((pass) => pass.descriptor.label)).toStrictEqual([
+				"fast",
+				"typed",
+			]);
+			// A read-only plan never auto-skips the typed pass.
+			expect(runPlan.passes.every((pass) => pass.shouldRun)).toBe(true);
+		});
+	});
+
+	it("plans no ESLint passes for an oxlint-only run", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const runPlan = withoutGitEnvironment(() => {
+				return plan(parseArguments(["--oxlint"]), directory, {}, false);
+			});
+
+			expect(runPlan.oxlint).toBe(true);
+			expect(runPlan.passes).toStrictEqual([]);
+		});
+	});
+
+	it("collapses to a single pass for the explicit modes", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const fast = withoutGitEnvironment(() => {
+				return plan(parseArguments(["--type-aware=off"]), directory, {}, false);
+			});
+			const full = withoutGitEnvironment(() => {
+				return plan(parseArguments([]), directory, { CI: "true" }, false);
+			});
+
+			expect(fast.passes.map((pass) => pass.descriptor.label)).toStrictEqual(["fast"]);
+			expect(full.passes.map((pass) => pass.descriptor.label)).toStrictEqual(["eslint"]);
 		});
 	});
 });

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -1,0 +1,439 @@
+// cspell:words typeaware
+import fileEntryCache from "file-entry-cache";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { clearAllCaches, countDirtyFiles, isCacheBusted } from "../src/lint-cli/cache.ts";
+import {
+	buildShellCommand,
+	composeEslintCommand,
+	composeOxlintCommand,
+	formatCommandLine,
+	splitArgs,
+} from "../src/lint-cli/command.ts";
+import { computeWorkerCount, resolveWorkerLimits } from "../src/lint-cli/concurrency.ts";
+import { ALL_CACHE_FILES, cacheFileForMode } from "../src/lint-cli/constants.ts";
+import { parseArguments } from "../src/lint-cli/options.ts";
+import type { ComposeContext, LintCliOptions } from "../src/lint-cli/types.ts";
+import { CliError } from "../src/lint-cli/types.ts";
+
+function baseContext(overrides: Partial<ComposeContext> = {}): ComposeContext {
+	return {
+		agentsFormatterPath: "/dist/formatter-agents.mjs",
+		cacheLocation: ".eslintcache",
+		ci: false,
+		concurrency: "off",
+		oxlintTypeAware: false,
+		paths: ["."],
+		...overrides,
+	};
+}
+
+function options(overrides: Partial<LintCliOptions> = {}): LintCliOptions {
+	return {
+		agents: false,
+		cache: true,
+		concurrency: undefined,
+		eslint: false,
+		eslintArgs: [],
+		fix: false,
+		oxlint: false,
+		oxlintArgs: [],
+		oxlintTypeAware: true,
+		paths: ["."],
+		print: false,
+		typeAware: undefined,
+		...overrides,
+	};
+}
+
+function withTemporaryDirectory(run: (directory: string) => void): void {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-"));
+
+	try {
+		run(directory);
+	} finally {
+		fs.rmSync(directory, { force: true, recursive: true });
+	}
+}
+
+function workerCount(dirty: number, perWorker: number, max: number): "off" | number {
+	return computeWorkerCount({ dirtyCount: dirty, filesPerWorker: perWorker, maxWorkers: max });
+}
+
+describe("parseArguments", () => {
+	it("defaults paths to '.'", () => {
+		expect.hasAssertions();
+
+		expect(parseArguments([]).paths).toStrictEqual(["."]);
+	});
+
+	it("keeps explicit paths", () => {
+		expect.hasAssertions();
+
+		expect(parseArguments(["src", "test"]).paths).toStrictEqual(["src", "test"]);
+	});
+
+	it("errors when --eslint and --oxlint are combined", () => {
+		expect.hasAssertions();
+
+		expect(() => parseArguments(["--eslint", "--oxlint"])).toThrow(CliError);
+	});
+
+	it("errors when --fix is combined with --type-aware", () => {
+		expect.hasAssertions();
+
+		expect(() => parseArguments(["--fix", "--type-aware=only"])).toThrow(
+			/Cannot combine --fix with --type-aware/,
+		);
+	});
+
+	it("errors on unknown flags", () => {
+		expect.hasAssertions();
+
+		expect(() => parseArguments(["--nope"])).toThrow(CliError);
+	});
+
+	it("errors on invalid --concurrency", () => {
+		expect.hasAssertions();
+
+		expect(() => parseArguments(["--concurrency", "banana"])).toThrow(/Invalid --concurrency/);
+	});
+
+	it("accepts numeric and off concurrency overrides", () => {
+		expect.hasAssertions();
+
+		expect(parseArguments(["--concurrency", "6"]).concurrency).toBe(6);
+		expect(parseArguments(["--concurrency", "off"]).concurrency).toBe("off");
+	});
+
+	it("errors when bare -- passthrough is used without a single tool", () => {
+		expect.hasAssertions();
+
+		expect(() => parseArguments(["--", "--foo"])).toThrow(/single tool/);
+		expect(() => parseArguments(["--eslint", "--oxlint", "--", "--foo"])).toThrow(CliError);
+	});
+
+	it("forwards -- passthrough to the selected tool", () => {
+		expect.hasAssertions();
+
+		expect(parseArguments(["--oxlint", "--", "--deny", "all"]).oxlintArgs).toStrictEqual([
+			"--deny",
+			"all",
+		]);
+		expect(parseArguments(["--eslint", "--", "--max-warnings", "0"]).eslintArgs).toStrictEqual([
+			"--max-warnings",
+			"0",
+		]);
+	});
+
+	it("splits dash-prefixed per-tool extra args", () => {
+		expect.hasAssertions();
+
+		const parsed = parseArguments([
+			"--eslint-args",
+			"--max-warnings 0",
+			"--oxlint-args=--quiet",
+		]);
+
+		expect(parsed.eslintArgs).toStrictEqual(["--max-warnings", "0"]);
+		expect(parsed.oxlintArgs).toStrictEqual(["--quiet"]);
+	});
+
+	it("parses cache and type-aware toggles", () => {
+		expect.hasAssertions();
+
+		const parsed = parseArguments(["--no-cache", "--no-oxlint-type-aware", "--type-aware=off"]);
+
+		expect(parsed.cache).toBe(false);
+		expect(parsed.oxlintTypeAware).toBe(false);
+		expect(parsed.typeAware).toBe("off");
+	});
+});
+
+describe("computeWorkerCount", () => {
+	it("returns off for zero or single-worker workloads", () => {
+		expect.hasAssertions();
+
+		expect(workerCount(0, 350, 8)).toBe("off");
+		expect(workerCount(350, 350, 8)).toBe("off");
+	});
+
+	it("scales with the dirty count", () => {
+		expect.hasAssertions();
+
+		expect(workerCount(400, 350, 8)).toBe(2);
+		expect(workerCount(1400, 350, 8)).toBe(4);
+	});
+
+	it("caps at maxWorkers", () => {
+		expect.hasAssertions();
+
+		expect(workerCount(100_000, 350, 3)).toBe(3);
+	});
+
+	it("returns off when the cap is below two", () => {
+		expect.hasAssertions();
+
+		expect(workerCount(100_000, 350, 1)).toBe("off");
+	});
+});
+
+describe("resolveWorkerLimits", () => {
+	it("defaults to 350 files per worker and a quarter of the CPUs", () => {
+		expect.hasAssertions();
+
+		expect(resolveWorkerLimits({}, 16)).toStrictEqual({ filesPerWorker: 350, maxWorkers: 4 });
+	});
+
+	it("honours env overrides", () => {
+		expect.hasAssertions();
+
+		const limits = resolveWorkerLimits({ FILES_PER_WORKER: "200", LINT_MAX_WORKERS: "6" }, 16);
+
+		expect(limits).toStrictEqual({ filesPerWorker: 200, maxWorkers: 6 });
+	});
+
+	it("ignores invalid env overrides", () => {
+		expect.hasAssertions();
+
+		const limits = resolveWorkerLimits({ FILES_PER_WORKER: "0", LINT_MAX_WORKERS: "x" }, 16);
+
+		expect(limits).toStrictEqual({ filesPerWorker: 350, maxWorkers: 4 });
+	});
+});
+
+describe("cacheFileForMode", () => {
+	it("maps type-aware modes to cache files", () => {
+		expect.hasAssertions();
+
+		expect(cacheFileForMode(undefined)).toBe(".eslintcache");
+		expect(cacheFileForMode("off")).toBe(".eslintcache-fast");
+		expect(cacheFileForMode("only")).toBe(".eslintcache-typeaware");
+	});
+});
+
+describe("cache helpers", () => {
+	it("detects a bust file newer than the cache", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const cacheFile = path.join(directory, ".eslintcache");
+			const configFile = path.join(directory, "eslint.config.ts");
+			fs.writeFileSync(cacheFile, "{}");
+			fs.writeFileSync(configFile, "export default []");
+			const future = Date.now() / 1000 + 60;
+			fs.utimesSync(configFile, future, future);
+
+			expect(isCacheBusted(cacheFile, [configFile])).toBe(true);
+		});
+	});
+
+	it("returns false when the cache is newer than every bust file", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const cacheFile = path.join(directory, ".eslintcache");
+			const configFile = path.join(directory, "eslint.config.ts");
+			fs.writeFileSync(configFile, "export default []");
+			const past = Date.now() / 1000 - 60;
+			fs.utimesSync(configFile, past, past);
+			fs.writeFileSync(cacheFile, "{}");
+
+			expect(isCacheBusted(cacheFile, [configFile])).toBe(false);
+		});
+	});
+
+	it("returns false when the cache file is missing", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(isCacheBusted(path.join(directory, "missing"), [])).toBe(false);
+		});
+	});
+
+	it("clears every managed cache file", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			for (const name of ALL_CACHE_FILES) {
+				fs.writeFileSync(path.join(directory, name), "{}");
+			}
+
+			clearAllCaches(directory);
+
+			for (const name of ALL_CACHE_FILES) {
+				expect(fs.existsSync(path.join(directory, name))).toBe(false);
+			}
+		});
+	});
+
+	it("counts all files when the cache is missing", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const fileA = path.join(directory, "a.ts");
+			const fileB = path.join(directory, "b.ts");
+			fs.writeFileSync(fileA, "const a = 1;");
+			fs.writeFileSync(fileB, "const b = 2;");
+
+			expect(countDirtyFiles(path.join(directory, "missing"), [fileA, fileB], false)).toBe(2);
+		});
+	});
+
+	it("counts only changed and uncached files", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const cacheFile = path.join(directory, ".eslintcache");
+			const fileA = path.join(directory, "a.ts");
+			const fileB = path.join(directory, "b.ts");
+			fs.writeFileSync(fileA, "const a = 1;");
+			fs.writeFileSync(fileB, "const b = 2;");
+
+			const cache = fileEntryCache.createFromFile(cacheFile, false) as unknown as {
+				getFileDescriptor: (file: string) => unknown;
+				reconcile: () => void;
+			};
+			cache.getFileDescriptor(fileA);
+			cache.reconcile();
+
+			// fileA is cached and unchanged; fileB was never seen.
+			expect(countDirtyFiles(cacheFile, [fileA, fileB], false)).toBe(1);
+
+			fs.writeFileSync(fileA, "const a = 42;");
+			const future = Date.now() / 1000 + 60;
+			fs.utimesSync(fileA, future, future);
+
+			expect(countDirtyFiles(cacheFile, [fileA, fileB], false)).toBe(2);
+		});
+	});
+});
+
+describe("splitArgs", () => {
+	it("splits on whitespace and respects quotes", () => {
+		expect.hasAssertions();
+
+		expect(splitArgs("--max-warnings 0")).toStrictEqual(["--max-warnings", "0"]);
+		expect(splitArgs("--rule 'no-console: error'")).toStrictEqual([
+			"--rule",
+			"no-console: error",
+		]);
+		expect(splitArgs("  ")).toStrictEqual([]);
+	});
+});
+
+describe("command composition", () => {
+	it("composes the oxlint command with type-aware, agents and fix", () => {
+		expect.hasAssertions();
+
+		const command = composeOxlintCommand(
+			options({ agents: true, fix: true }),
+			baseContext({ oxlintTypeAware: true, paths: ["src"] }),
+		);
+
+		expect(command.args).toStrictEqual(["--format", "agent", "--type-aware", "--fix", "src"]);
+		expect(command.env).toStrictEqual({});
+	});
+
+	it("omits --type-aware from oxlint when disabled", () => {
+		expect.hasAssertions();
+
+		const command = composeOxlintCommand(options(), baseContext({ oxlintTypeAware: false }));
+
+		expect(command.args).not.toContain("--type-aware");
+	});
+
+	it("composes the ESLint command with cache location and concurrency", () => {
+		expect.hasAssertions();
+
+		const command = composeEslintCommand(
+			options({ typeAware: "off" }),
+			baseContext({ cacheLocation: ".eslintcache-fast", concurrency: 4, paths: ["src"] }),
+		);
+
+		expect(command.args).toStrictEqual([
+			"--cache",
+			"--cache-location",
+			".eslintcache-fast",
+			"--no-warn-ignored",
+			"--concurrency",
+			"4",
+			"src",
+		]);
+		expect(command.env).toStrictEqual({ ESLINT_TYPE_AWARE: "off" });
+	});
+
+	it("adds the content cache strategy in CI", () => {
+		expect.hasAssertions();
+
+		const command = composeEslintCommand(options(), baseContext({ ci: true, concurrency: 2 }));
+		const strategyIndex = command.args.indexOf("--cache-strategy");
+
+		expect(strategyIndex).toBeGreaterThan(-1);
+		expect(command.args[strategyIndex + 1]).toBe("content");
+	});
+
+	it("drops cache flags when caching is disabled", () => {
+		expect.hasAssertions();
+
+		const command = composeEslintCommand(options({ cache: false }), baseContext({ ci: true }));
+
+		expect(command.args).not.toContain("--cache");
+		expect(command.args).not.toContain("--cache-strategy");
+	});
+
+	it("points ESLint at the agents formatter", () => {
+		expect.hasAssertions();
+
+		const command = composeEslintCommand(
+			options({ agents: true }),
+			baseContext({ agentsFormatterPath: "/dist/formatter-agents.mjs" }),
+		);
+		const formatIndex = command.args.indexOf("--format");
+
+		expect(command.args[formatIndex + 1]).toBe("/dist/formatter-agents.mjs");
+	});
+});
+
+describe("formatCommandLine", () => {
+	it("renders a shell-equivalent line with an env prefix", () => {
+		expect.hasAssertions();
+
+		const command = composeEslintCommand(
+			options({ typeAware: "off" }),
+			baseContext({ cacheLocation: ".eslintcache-fast", ci: true, concurrency: 4 }),
+		);
+
+		expect(formatCommandLine(command)).toBe(
+			"ESLINT_TYPE_AWARE=off eslint --cache --cache-location .eslintcache-fast " +
+				"--no-warn-ignored --concurrency 4 --cache-strategy content .",
+		);
+	});
+
+	it("renders oxlint without an env prefix", () => {
+		expect.hasAssertions();
+
+		const command = composeOxlintCommand(options(), baseContext({ oxlintTypeAware: true }));
+
+		expect(formatCommandLine(command)).toBe("oxlint --type-aware .");
+	});
+});
+
+describe("buildShellCommand", () => {
+	it("quotes tokens with spaces per platform", () => {
+		expect.hasAssertions();
+
+		expect(buildShellCommand("node", "/path/eslint.js", ["."], "linux")).toBe(
+			"node /path/eslint.js .",
+		);
+		expect(buildShellCommand("node", "/a b/eslint.js", ["."], "linux")).toBe(
+			"node '/a b/eslint.js' .",
+		);
+		expect(buildShellCommand("node", "C:/a b/eslint.js", ["."], "win32")).toBe(
+			'node "C:/a b/eslint.js" .',
+		);
+	});
+});

--- a/test/oxlint.spec.ts
+++ b/test/oxlint.spec.ts
@@ -287,6 +287,33 @@ describe("oxlint hybrid coverage", () => {
 	});
 });
 
+/**
+ * Whether any resolved config carries the hybrid marker the lint CLI probes
+ * for.
+ *
+ * @param configs - The resolved flat config items.
+ * @returns Whether `settings["isentinel/oxlint"]` is stamped anywhere.
+ */
+function hasOxlintMarker(configs: Array<TypedFlatConfigItem>): boolean {
+	return configs.some((config) => config.settings?.["isentinel/oxlint"] === true);
+}
+
+describe("hybrid marker", () => {
+	it("stamps the oxlint marker only when hybrid mode is enabled", async ({ expect }) => {
+		expect.hasAssertions();
+
+		const hybrid = await isentinel({
+			name: "test/marker-hybrid",
+			...baseOptions,
+			oxlint: true,
+		});
+		const plain = await isentinel({ name: "test/marker-plain", ...baseOptions });
+
+		expect(hasOxlintMarker([...hybrid])).toBe(true);
+		expect(hasOxlintMarker([...plain])).toBe(false);
+	});
+});
+
 describe("oxlint config snapshots", () => {
 	it("should match the default roblox game config", ({ expect }) => {
 		expect.hasAssertions();

--- a/test/type-aware-split.spec.ts
+++ b/test/type-aware-split.spec.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { describe, it } from "vitest";
 
 import { isentinel } from "../src";
@@ -310,4 +311,94 @@ describe("type-aware split", () => {
 			}),
 		).rejects.toThrow('typeAware: "only"');
 	});
+});
+
+type SplitOutcome = "full" | "off" | "only";
+
+interface EnvironmentCase {
+	env: string | undefined;
+	expected: SplitOutcome;
+	option: "only" | boolean | undefined;
+}
+
+/**
+ * Classify a resolved config by which type-aware split (if any) was applied.
+ * The split appends a `type-aware-split/disables` config, and the `"only"` pass
+ * additionally appends a `type-aware-split/ignores` config.
+ *
+ * @param configs - The resolved flat config items.
+ * @returns The observed split outcome.
+ */
+function classifySplit(configs: Array<TypedFlatConfigItem>): SplitOutcome {
+	const names = new Set(configs.map((config) => config.name));
+	if (!names.has("isentinel/type-aware-split/disables")) {
+		return "full";
+	}
+
+	return names.has("isentinel/type-aware-split/ignores") ? "only" : "off";
+}
+
+/**
+ * Build a config with `ESLINT_TYPE_AWARE` set to the given value (restoring it
+ * afterwards) and report which split it produced.
+ *
+ * @param environmentValue - The value to assign the env var, or `undefined` to
+ *   leave it unset.
+ * @param option - The `typeAware` factory option, or `undefined` to omit it.
+ * @returns The observed split outcome.
+ */
+async function resolveSplitOutcome(
+	environmentValue: string | undefined,
+	option: "only" | boolean | undefined,
+): Promise<SplitOutcome> {
+	const previous = process.env["ESLINT_TYPE_AWARE"];
+	if (environmentValue === undefined) {
+		delete process.env["ESLINT_TYPE_AWARE"];
+	} else {
+		process.env["ESLINT_TYPE_AWARE"] = environmentValue;
+	}
+
+	const optionOverride = option === undefined ? {} : { typeAware: option };
+
+	try {
+		const config = await isentinel({
+			name: "test/env-type-aware",
+			...baseOptions,
+			...optionOverride,
+		});
+		return classifySplit([...config]);
+	} finally {
+		if (previous === undefined) {
+			delete process.env["ESLINT_TYPE_AWARE"];
+		} else {
+			process.env["ESLINT_TYPE_AWARE"] = previous;
+		}
+	}
+}
+
+// Precedence matrix: env off/false/only/garbage/unset crossed with the
+// `typeAware` option undefined/false/"only"/true. An explicit option always
+// wins; the env var only applies when the option is undefined.
+const environmentCases: Array<EnvironmentCase> = [
+	{ env: "off", expected: "off", option: undefined },
+	{ env: "false", expected: "off", option: undefined },
+	{ env: "only", expected: "only", option: undefined },
+	{ env: "garbage", expected: "full", option: undefined },
+	{ env: undefined, expected: "full", option: undefined },
+	{ env: "only", expected: "off", option: false },
+	{ env: "off", expected: "only", option: "only" },
+	{ env: "garbage", expected: "off", option: false },
+	{ env: undefined, expected: "only", option: "only" },
+	{ env: "off", expected: "full", option: true },
+];
+
+describe("eslint_type_aware environment variable", () => {
+	it.for(environmentCases)(
+		"env=$env option=$option -> $expected",
+		async ({ env, expected, option }, { expect }) => {
+			expect.hasAssertions();
+
+			expect(await resolveSplitOutcome(env, option)).toBe(expected);
+		},
+	);
 });

--- a/test/update-package-json.spec.ts
+++ b/test/update-package-json.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ConfirmOverwrite } from "../src/cli/stages/update-package-json.ts";
+import { LINT_SCRIPTS, mergeLintScripts } from "../src/cli/stages/update-package-json.ts";
+
+describe("mergeLintScripts", () => {
+	it("adds both lint scripts when absent", async () => {
+		expect.hasAssertions();
+
+		const scripts: Record<string, string> = {};
+
+		const result = await mergeLintScripts(scripts, { skipPrompt: false });
+
+		expect(scripts).toStrictEqual(LINT_SCRIPTS);
+		expect(result.added).toStrictEqual(["lint", "lint:fix"]);
+		expect(result.overwritten).toStrictEqual([]);
+	});
+
+	it("adds only the missing script alongside unrelated scripts", async () => {
+		expect.hasAssertions();
+
+		const scripts: Record<string, string> = { build: "tsc" };
+
+		const result = await mergeLintScripts(scripts, { skipPrompt: false });
+
+		expect(scripts).toStrictEqual({
+			"build": "tsc",
+			"lint": "isentinel-lint",
+			"lint:fix": "isentinel-lint --fix",
+		});
+		expect(result.added).toStrictEqual(["lint", "lint:fix"]);
+	});
+
+	it("leaves identical existing scripts untouched without prompting", async () => {
+		expect.hasAssertions();
+
+		const scripts: Record<string, string> = { ...LINT_SCRIPTS };
+		const confirmOverwrite = vi.fn<ConfirmOverwrite>();
+
+		const result = await mergeLintScripts(scripts, {
+			confirmOverwrite,
+			skipPrompt: false,
+		});
+
+		expect(scripts).toStrictEqual(LINT_SCRIPTS);
+		expect(result.added).toStrictEqual([]);
+		expect(result.overwritten).toStrictEqual([]);
+		expect(confirmOverwrite).not.toHaveBeenCalled();
+	});
+
+	it("preserves differing scripts in skip-prompt mode and never prompts", async () => {
+		expect.hasAssertions();
+
+		const scripts: Record<string, string> = {
+			"lint": "eslint",
+			"lint:fix": "eslint --fix",
+		};
+		const confirmOverwrite = vi.fn<ConfirmOverwrite>();
+
+		const result = await mergeLintScripts(scripts, {
+			confirmOverwrite,
+			skipPrompt: true,
+		});
+
+		expect(scripts).toStrictEqual({ "lint": "eslint", "lint:fix": "eslint --fix" });
+		expect(result.added).toStrictEqual([]);
+		expect(result.overwritten).toStrictEqual([]);
+		expect(confirmOverwrite).not.toHaveBeenCalled();
+	});
+
+	it("adds missing scripts but preserves differing ones in skip-prompt mode", async () => {
+		expect.hasAssertions();
+
+		const scripts: Record<string, string> = { lint: "eslint" };
+
+		const result = await mergeLintScripts(scripts, { skipPrompt: true });
+
+		expect(scripts).toStrictEqual({ "lint": "eslint", "lint:fix": "isentinel-lint --fix" });
+		expect(result.added).toStrictEqual(["lint:fix"]);
+		expect(result.overwritten).toStrictEqual([]);
+	});
+
+	it("overwrites a differing script when the user confirms", async () => {
+		expect.hasAssertions();
+
+		const scripts: Record<string, string> = { "lint": "eslint", "lint:fix": "eslint --fix" };
+		const confirmOverwrite = vi.fn<ConfirmOverwrite>().mockResolvedValue(true);
+
+		const result = await mergeLintScripts(scripts, {
+			confirmOverwrite,
+			skipPrompt: false,
+		});
+
+		expect(scripts).toStrictEqual(LINT_SCRIPTS);
+		expect(result.overwritten).toStrictEqual(["lint", "lint:fix"]);
+		expect(confirmOverwrite).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps a differing script when the user declines", async () => {
+		expect.hasAssertions();
+
+		const scripts: Record<string, string> = { lint: "eslint" };
+		const confirmOverwrite = vi.fn<ConfirmOverwrite>().mockResolvedValue(false);
+
+		const result = await mergeLintScripts(scripts, {
+			confirmOverwrite,
+			skipPrompt: false,
+		});
+
+		expect(scripts).toStrictEqual({ "lint": "eslint", "lint:fix": "isentinel-lint --fix" });
+		expect(result.overwritten).toStrictEqual([]);
+		expect(result.added).toStrictEqual(["lint:fix"]);
+		expect(confirmOverwrite).toHaveBeenCalledOnce();
+	});
+});

--- a/test/without-git.ts
+++ b/test/without-git.ts
@@ -1,0 +1,30 @@
+import process from "node:process";
+
+/**
+ * Run `run` with the git worktree environment variables unset so
+ * `git ls-files` resolves against the temporary fixture directory rather than
+ * the repository the tests themselves live in.
+ *
+ * @template T - The callback's return type.
+ * @param run - The callback to run without git environment overrides.
+ * @returns The callback's return value.
+ */
+export function withoutGitEnvironment<T>(run: () => T): T {
+	const keys = ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"];
+	const saved = keys.map((key): [string, string | undefined] => [key, process.env[key]]);
+	for (const key of keys) {
+		delete process.env[key];
+	}
+
+	try {
+		return run();
+	} finally {
+		for (const [key, value] of saved) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -51,13 +51,19 @@ export default defineConfig([
 		entry: ["src/index.ts"],
 		unused: {
 			// Required for cli
-			ignore: ["ansis", "yargs"],
+			ignore: ["ansis", "yargs", "concurrently", "file-entry-cache"],
 			level: "warning",
 		},
 	},
 	{
 		...sharedOptions,
 		entry: ["src/cli.ts"],
+	},
+	{
+		...sharedOptions,
+		// The lint runner shells out to the consumer's local eslint/oxlint and
+		// resolves them at runtime, so its runtime deps stay external.
+		entry: { "lint-cli": "src/lint-cli/index.ts" },
 	},
 	{
 		...sharedOptions,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -61,6 +61,12 @@ export default defineConfig([
 	},
 	{
 		...sharedOptions,
+		// Shipped at dist/formatter-agents.mjs; the isentinel-lint CLI resolves
+		// this exact path to pass it to `eslint --format`.
+		entry: { "formatter-agents": "src/formatter-agents.ts" },
+	},
+	{
+		...sharedOptions,
 		deps: {
 			neverBundle: [
 				/^@typescript-eslint\//,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -57,7 +57,11 @@ export default defineConfig([
 	},
 	{
 		...sharedOptions,
-		entry: ["src/cli.ts"],
+		// Source the CLI entry directly from the file that runs the yargs
+		// instance. A barrel (`src/cli.ts`) would tree-shake the top-level
+		// `void instance.argv` side effect away, emitting an empty
+		// `dist/cli.mjs`.
+		entry: { cli: "src/cli/index.ts" },
 	},
 	{
 		...sharedOptions,


### PR DESCRIPTION
## Summary

New `isentinel-lint` bin: one command for hybrid oxlint+ESLint linting. Consumers write `"lint": "isentinel-lint"` (the setup wizard now scaffolds it). Replaces per-project lint.sh scripts.

### Runner
- Default local mode: 3-way concurrent — oxlint ∥ fast pass (`ESLINT_TYPE_AWARE=off`, all file types, `.eslintcache-fast`) ∥ typed pass (`ESLINT_TYPE_AWARE=only`, TS-only, `.eslintcache-typeaware`). Split verified rule-for-rule equal to the full config.
- Typed pass auto-skipped when nothing type-relevant is dirty (computed after cache invalidation).
- `--type-aware=off|only|full`, `--fix` (sequential, full config), `--agents` (ships an agent-friendly formatter, also exported as `./formatter-agents`), `--eslint`/`--oxlint`, `--no-cache`, `--concurrency`, `--print`, per-tool `--eslint-args`/`--oxlint-args`.
- CI: single full pass + `--cache-strategy content`. oxlint `--type-aware` on by default; hard error if `oxlint-tsgolint` missing (`--no-oxlint-type-aware` to bypass).

### Concurrency heuristic
ESLint workers sized from the dirty-file count, not repo size: typed pass `ceil(dirty/350)`, fast pass `ceil(dirty/800)`, cap `cores/4`, `<2 → off`. Env-tunable (`FILES_PER_WORKER`, `FAST_FILES_PER_WORKER`, `LINT_MAX_WORKERS`). Constants from empirical type-aware curve (cost ≈ filesPerWorker^1.46, ~6.5s TS program per worker).

### Trustworthy caching
ESLint `--cache` is unsafe with type-aware rules (editing a file can change results in importers without touching their cache entries). Fixes:
- TS incremental-builder affected-set invalidation (shape-hash BFS over emitted .d.ts; `declaration: true` required — `noEmit` degrades the shape hash to full source text). Hub edits with unchanged public surface invalidate nothing. ~1.65s warm overhead.
- Whole-cache bust on config/tsconfig/lockfile changes; package.json resolution-field hash bust (typed caches only; scripts edits don't bust).
- resolveJsonModule .json edits propagate to importers (fixture-tested).

### Also
- Factory reads `ESLINT_TYPE_AWARE` env (`off`/`false`/`only`; explicit option wins).
- Fixed shipped wizard bin: `src/cli.ts` barrel let rolldown tree-shake the yargs side effect, emitting an empty `dist/cli.mjs`.
- concurrently no longer kills siblings on ordinary lint failures; exit codes aggregated.

### Known trade-off
Default 2-pass mode doesn't report unused disable directives (a directive naming a rule from the other pass would false-positive); `--fix` and CI use the full config and still report them. Directive-report merging deferred. Related: #587.

## Test plan
- 230 vitest tests (flag matrix, --print snapshots, heuristic sizing, cache busts, builder invalidation against real TS fixture projects, concurrent exit aggregation)
- `pnpm typecheck`, `pnpm lint`, `pnpm build` green; both bins smoke-tested
- Next: pilot on anime-rush (2600+ TS files) to calibrate the files-per-worker constants

https://claude.ai/code/session_01EHzXxDGP4ApTZ8BPtmcA6U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `isentinel-lint` command (oxlint + ESLint), including command preview, configurable type-aware mode, concurrency, and cache handling.
  * Added `formatter-agents` output formatting for more readable, deterministic diagnostics.
  * Added incremental type-aware invalidation to reduce unnecessary work while keeping results accurate.
  * Automatically adds/updates `lint` and `lint:fix` scripts during setup (with optional confirmation).
* **Documentation**
  * Expanded `isentinel-lint` setup/config docs: supported flags, environment variables, CI behavior, and type-aware requirements.
* **Bug Fixes**
  * Improved hybrid-mode detection/handling and cache invalidation behavior when type-relevant changes occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->