### PR TITLE
fix: resolve prettier settings identically in both factories

### DIFF
--- a/src/eslint/factory.ts
+++ b/src/eslint/factory.ts
@@ -3,6 +3,7 @@ import { findUpSync } from "find-up-simple";
 import { isPackageExists } from "local-pkg";
 
 import { GLOB_MARKDOWN, GLOB_ROOT } from "../globs.ts";
+import { resolvePrettierSettings } from "../prettier-config.ts";
 import type { RuleOptions } from "../typegen.d.ts";
 import {
 	getOverrides,
@@ -12,7 +13,6 @@ import {
 	overrideRuleSeverity,
 	resolveNodeMajor,
 	resolveOxfmtConfigOptions,
-	resolvePrettierConfigOptions,
 	resolveSubOptions,
 	shouldEnableFeature,
 } from "../utils.ts";
@@ -326,23 +326,13 @@ export async function isentinel(
 
 	const formatterOptions = typeof formatters === "object" ? formatters : {};
 
-	const prettierOptions = formatterOptions.prettierOptions ?? {};
-	const editorConfigOptions = await resolvePrettierConfigOptions();
 	const oxfmtConfigOptions = formatters !== false ? await resolveOxfmtConfigOptions() : {};
 
-	const prettierSettings: PrettierOptions = Object.assign(
-		{
-			arrowParens: "always",
-			printWidth: 100,
-			quoteProps: "consistent",
-			semi: true,
-			singleQuote: false,
-			tabWidth: 4,
-			trailingComma: "all",
-			useTabs: true,
-		} satisfies PrettierOptions,
-		editorConfigOptions,
-		prettierOptions,
+	// Shared with the oxlint factory: these settings feed rule options (for
+	// example `flawless/arrow-return-style`'s `maxLen`), so both engines must
+	// resolve them identically or their fixes disagree.
+	const prettierSettings: PrettierOptions = resolvePrettierSettings(
+		formatterOptions.prettierOptions,
 	);
 
 	const configs: Array<Awaitable<Array<TypedFlatConfigItem>>> = [];

--- a/src/oxlint/factory.ts
+++ b/src/oxlint/factory.ts
@@ -9,6 +9,7 @@ import type {
 import { defineConfig } from "oxlint";
 
 import { GLOB_EXCLUDE, GLOB_ROOT, GLOB_SRC } from "../globs.ts";
+import { resolvePrettierSettings } from "../prettier-config.ts";
 import { buildOxfmtOptions } from "../rules/oxfmt.ts";
 import type { Rules } from "../types.ts";
 import {
@@ -169,17 +170,12 @@ export function isentinel(
 	}
 
 	const formatterOptions = typeof formatters === "object" ? formatters : {};
-	const prettierSettings: Record<string, unknown> = {
-		arrowParens: "always",
-		printWidth: 100,
-		quoteProps: "consistent",
-		semi: true,
-		singleQuote: false,
-		tabWidth: 4,
-		trailingComma: "all",
-		useTabs: true,
-		...formatterOptions.prettierOptions,
-	};
+	// Shared with the ESLint factory: these settings feed rule options (for
+	// example `flawless/arrow-return-style`'s `maxLen`), so both engines must
+	// resolve them identically or their fixes disagree.
+	const prettierSettings: Record<string, unknown> = resolvePrettierSettings(
+		formatterOptions.prettierOptions,
+	);
 
 	const configs: Array<Array<TypedOxlintConfigItem>> = [
 		oxlintJavascript({

--- a/src/prettier-config.ts
+++ b/src/prettier-config.ts
@@ -1,0 +1,391 @@
+/**
+ * Synchronous resolution of the effective Prettier-shaped formatting settings
+ * (`printWidth`, `tabWidth`, `useTabs`, ...) shared by both factories.
+ *
+ * These settings do not only drive formatting: `printWidth` and `tabWidth`
+ * feed rule options such as `flawless/arrow-return-style`'s `maxLen`,
+ * `tabWidth` and `useOxfmt.printWidth`. The ESLint and oxlint factories must
+ * therefore resolve them identically, or the same rule reaches opposite
+ * conclusions in each engine and `--fix` ping-pongs the code between both
+ * forms.
+ *
+ * Prettier's own `resolveConfig` is async-only since v3, and the oxlint
+ * factory is synchronous, so resolution is reimplemented here against the
+ * config formats that can be read synchronously. TypeScript config files
+ * (`prettier.config.ts` and friends) need a loader and are skipped.
+ */
+
+import { getStaticJSONValue, parseJSON } from "jsonc-eslint-parser";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+import type { Options as PrettierOptions } from "prettier";
+import { getStaticYAMLValue, parseYAML } from "yaml-eslint-parser";
+
+/** Preset defaults, overridden by any project-level configuration. */
+export const PRETTIER_DEFAULTS = {
+	arrowParens: "always",
+	printWidth: 100,
+	quoteProps: "consistent",
+	semi: true,
+	singleQuote: false,
+	tabWidth: 4,
+	trailingComma: "all",
+	useTabs: true,
+} as const satisfies PrettierOptions;
+
+/**
+ * Config file names searched in each directory, in Prettier's own precedence
+ * order. `package.json` is handled separately (it only counts when it carries
+ * a `prettier` key).
+ */
+const CONFIG_FILES = [
+	".prettierrc",
+	".prettierrc.json",
+	".prettierrc.jsonc",
+	".prettierrc.json5",
+	".prettierrc.yaml",
+	".prettierrc.yml",
+	".prettierrc.js",
+	".prettierrc.cjs",
+	".prettierrc.mjs",
+	"prettier.config.js",
+	"prettier.config.cjs",
+	"prettier.config.mjs",
+] as const;
+
+/**
+ * EditorConfig section matched against a representative source file rather
+ * than `package.json`: the settings feed JS/TS rule options, so per-extension
+ * sections must resolve the way they do for the files those rules lint.
+ */
+const EDITORCONFIG_PROBE_FILE = "index.ts";
+
+const LINE_BREAK = /\r?\n/;
+const LEADING_SLASH = /^\//;
+const REGEXP_SPECIAL = /[$()*+.?[\\\]^{|}]/g;
+/**
+ * Glob constructs expanded by {@link expandGlobToken}; anything else is
+ * escaped.
+ */
+const GLOB_TOKEN = /\*\*\/?|\{[^{}]*\}|[$()*+.?[\\\]^{|}]/g;
+
+interface EditorConfigSection {
+	pattern: string;
+	properties: Record<string, string>;
+}
+
+interface ParsedEditorConfig {
+	isRoot: boolean;
+	sections: Array<EditorConfigSection>;
+}
+
+/**
+ * Resolve the project's Prettier configuration, EditorConfig included, without
+ * awaiting.
+ *
+ * @param cwd - Directory to start the upward search from.
+ * @returns The resolved options, or an empty object when none are found.
+ */
+export function resolveProjectPrettierConfig(cwd: string = process.cwd()): PrettierOptions {
+	return {
+		...resolveEditorConfigOptions(cwd),
+		...resolvePrettierRcOptions(cwd),
+	};
+}
+
+/**
+ * Resolve the effective formatting settings: preset defaults, overridden by
+ * the project's EditorConfig and Prettier configuration, overridden by the
+ * options passed to the factory.
+ *
+ * @param prettierOptions - Explicit `formatters.prettierOptions`.
+ * @param cwd - Directory to resolve project configuration from.
+ * @returns The merged settings.
+ */
+export function resolvePrettierSettings(
+	prettierOptions: PrettierOptions = {},
+	cwd: string = process.cwd(),
+): PrettierOptions {
+	return {
+		...PRETTIER_DEFAULTS,
+		...resolveProjectPrettierConfig(cwd),
+		...prettierOptions,
+	};
+}
+
+function readFileOrUndefined(filePath: string): string | undefined {
+	try {
+		return fs.readFileSync(filePath, "utf-8");
+	} catch {
+		return undefined;
+	}
+}
+
+function parseJsonLike(contents: string): unknown {
+	try {
+		return getStaticJSONValue(parseJSON(contents, { jsonSyntax: "json5" }));
+	} catch {
+		return undefined;
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readPackageJsonPrettierKey(filePath: string): PrettierOptions | undefined {
+	const contents = readFileOrUndefined(filePath);
+	if (contents === undefined) {
+		return undefined;
+	}
+
+	const parsed = parseJsonLike(contents);
+	const prettierKey = isRecord(parsed) ? parsed["prettier"] : undefined;
+	// A string value points at a shareable config, which needs module
+	// resolution Prettier performs itself; treat it as absent.
+	return isRecord(prettierKey) ? prettierKey : undefined;
+}
+
+/**
+ * Load a JS Prettier config. Node's `require` handles ESM entry points
+ * synchronously on the versions this package supports, so both module systems
+ * work; a config that cannot be loaded is treated as absent rather than fatal.
+ *
+ * @param filePath - Absolute path of the config module.
+ * @returns The exported options, or `undefined`.
+ */
+function requireConfigModule(filePath: string): PrettierOptions | undefined {
+	try {
+		const require = createRequire(filePath);
+		const loaded: unknown = require(filePath);
+		const value = isRecord(loaded) && "default" in loaded ? loaded["default"] : loaded;
+		return isRecord(value) ? value : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function parseYamlLike(contents: string): unknown {
+	try {
+		return getStaticYAMLValue(parseYAML(contents));
+	} catch {
+		return undefined;
+	}
+}
+
+function readConfigFile(filePath: string): PrettierOptions | undefined {
+	const extension = path.extname(filePath);
+	if (extension === ".js" || extension === ".cjs" || extension === ".mjs") {
+		return fs.existsSync(filePath) ? requireConfigModule(filePath) : undefined;
+	}
+
+	const contents = readFileOrUndefined(filePath);
+	if (contents === undefined) {
+		return undefined;
+	}
+
+	// `.prettierrc` accepts both JSON and YAML; YAML is a superset in practice,
+	// but JSON(C) is tried first so trailing commas and comments still parse.
+	const parsed = parseJsonLike(contents) ?? parseYamlLike(contents);
+	return isRecord(parsed) ? parsed : undefined;
+}
+
+function ancestorDirectories(cwd: string): Array<string> {
+	const directories: Array<string> = [];
+	let current = path.resolve(cwd);
+
+	while (true) {
+		directories.push(current);
+		const parent = path.dirname(current);
+		if (parent === current) {
+			return directories;
+		}
+
+		current = parent;
+	}
+}
+
+/**
+ * Walk up from `cwd` looking for a Prettier configuration file.
+ *
+ * @param cwd - Directory to start the upward search from.
+ * @returns The first configuration found, or an empty object.
+ */
+function resolvePrettierRcOptions(cwd: string): PrettierOptions {
+	for (const directory of ancestorDirectories(cwd)) {
+		const fromPackageJson = readPackageJsonPrettierKey(path.join(directory, "package.json"));
+		if (fromPackageJson !== undefined) {
+			return fromPackageJson;
+		}
+
+		for (const filename of CONFIG_FILES) {
+			const config = readConfigFile(path.join(directory, filename));
+			if (config !== undefined) {
+				return config;
+			}
+		}
+	}
+
+	return {};
+}
+
+function editorConfigToPrettier(properties: Record<string, string>): PrettierOptions {
+	const options: PrettierOptions = {};
+
+	const indentStyle = properties["indent_style"];
+	if (indentStyle === "tab" || indentStyle === "space") {
+		options.useTabs = indentStyle === "tab";
+	}
+
+	// `indent_size = tab` defers to `tab_width`, matching EditorConfig itself.
+	const indentSize = properties["indent_size"];
+	const width =
+		indentSize === undefined || indentSize === "tab" ? properties["tab_width"] : indentSize;
+	const tabWidth = Number.parseInt(width ?? "", 10);
+	if (Number.isFinite(tabWidth)) {
+		options.tabWidth = tabWidth;
+	}
+
+	const printWidth = Number.parseInt(properties["max_line_length"] ?? "", 10);
+	if (Number.isFinite(printWidth)) {
+		options.printWidth = printWidth;
+	}
+
+	const endOfLine = properties["end_of_line"];
+	if (endOfLine === "cr" || endOfLine === "crlf" || endOfLine === "lf") {
+		options.endOfLine = endOfLine;
+	}
+
+	return options;
+}
+
+function parseEditorConfig(contents: string): ParsedEditorConfig {
+	const sections: Array<EditorConfigSection> = [];
+	let current: EditorConfigSection | undefined;
+	let isRoot = false;
+
+	for (const rawLine of contents.split(LINE_BREAK)) {
+		const line = rawLine.trim();
+		if (line === "" || line.startsWith("#") || line.startsWith(";")) {
+			continue;
+		}
+
+		if (line.startsWith("[") && line.endsWith("]")) {
+			current = { pattern: line.slice(1, -1), properties: {} };
+			sections.push(current);
+			continue;
+		}
+
+		const separator = line.indexOf("=");
+		if (separator === -1) {
+			continue;
+		}
+
+		const key = line.slice(0, separator).trim().toLowerCase();
+		const value = line.slice(separator + 1).trim();
+
+		if (current === undefined) {
+			isRoot ||= key === "root" && value.toLowerCase() === "true";
+			continue;
+		}
+
+		current.properties[key] = value;
+	}
+
+	return { isRoot, sections };
+}
+
+function escapeRegExp(value: string): string {
+	return value.replaceAll(REGEXP_SPECIAL, (character) => `\\${character}`);
+}
+
+/**
+ * Expand one glob token into its regular-expression equivalent.
+ *
+ * @param token - A token matched by {@link GLOB_TOKEN}.
+ * @returns The regular-expression source for the token.
+ */
+function expandGlobToken(token: string): string {
+	if (token.startsWith("**")) {
+		// The trailing separator is part of the token, so `**\/x` also matches a
+		// bare `x`.
+		return "(?:.*)";
+	}
+
+	if (token === "*") {
+		return "[^/]*";
+	}
+
+	if (token === "?") {
+		return "[^/]";
+	}
+
+	if (token.startsWith("{")) {
+		const alternatives = token.slice(1, -1).split(",");
+		return `(?:${alternatives.map((alternative) => escapeRegExp(alternative)).join("|")})`;
+	}
+
+	return `\\${token}`;
+}
+
+/**
+ * Match an EditorConfig section pattern against a path relative to the
+ * `.editorconfig` file. Supports the `*`, `**`, `?` and `{a,b}` constructs;
+ * numeric ranges and character classes are rare enough in formatting sections
+ * to fall through as non-matches.
+ *
+ * @param pattern - The section pattern.
+ * @param relativePath - Path relative to the `.editorconfig` directory.
+ * @returns Whether the section applies.
+ */
+function matchesEditorConfigPattern(pattern: string, relativePath: string): boolean {
+	// A pattern without a slash applies at any depth.
+	const normalized = pattern.includes("/") ? pattern.replace(LEADING_SLASH, "") : `**/${pattern}`;
+	const subject = relativePath.split(path.sep).join("/");
+
+	const source = normalized.replaceAll(GLOB_TOKEN, (token) => expandGlobToken(token));
+	const matcher = new RegExp(`^${source}$`);
+	return matcher.test(subject);
+}
+
+/**
+ * Resolve EditorConfig settings for a representative source file and translate
+ * them into their Prettier equivalents.
+ *
+ * @param cwd - Directory to start the upward search from.
+ * @returns The translated options.
+ */
+function resolveEditorConfigOptions(cwd: string): PrettierOptions {
+	const properties: Record<string, string> = {};
+
+	// Nearest file wins, so collect from the root down: `Object.assign` lets
+	// closer directories overwrite what farther ones set.
+	for (const directory of ancestorDirectories(cwd).toReversed()) {
+		const contents = readFileOrUndefined(path.join(directory, ".editorconfig"));
+		if (contents === undefined) {
+			continue;
+		}
+
+		const { isRoot, sections } = parseEditorConfig(contents);
+		const relative = path.relative(directory, path.join(cwd, EDITORCONFIG_PROBE_FILE));
+		const forProbe = sections
+			.filter(({ pattern }) => matchesEditorConfigPattern(pattern, relative))
+			.reduce<Record<string, string>>(
+				(accumulator, section) => Object.assign(accumulator, section.properties),
+				{},
+			);
+
+		if (isRoot) {
+			// Everything collected from farther ancestors is out of scope.
+			for (const key of Object.keys(properties)) {
+				delete properties[key];
+			}
+		}
+
+		Object.assign(properties, forProbe);
+	}
+
+	return editorConfigToPrettier(properties);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,10 +8,8 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import process from "node:process";
 import type { FormatConfig, JsdocConfig } from "oxfmt";
-import prettier from "prettier";
 import { minVersion } from "semver";
 
-import type { PrettierOptions } from "./eslint/configs/index.ts";
 import type { OptionsConfig } from "./eslint/types.ts";
 import { GLOB_SRC_EXT } from "./globs.ts";
 import type { Awaitable, TypedFlatConfigItem } from "./types.ts";
@@ -485,26 +483,6 @@ export function renamePluginInConfigs(
 
 		return clone;
 	});
-}
-
-/**
- * Resolve Prettier configuration options for the project.
- *
- * @returns The Prettier configuration options, or an empty object if none
- *   found.
- */
-export async function resolvePrettierConfigOptions(): Promise<PrettierOptions> {
-	try {
-		// Use package.json as file path since it exists in all projects and
-		// allows prettier to resolve project-wide configuration (prettierrc,
-		// EditorConfig, etc.)
-		const config = await prettier.resolveConfig("package.json", {
-			editorconfig: true,
-		});
-		return config ?? {};
-	} catch {
-		return {};
-	}
 }
 
 const OXFMT_CONFIG_FILES = [".oxfmtrc.json", ".oxfmtrc.jsonc"];

--- a/test/__snapshots__/oxlint.spec.ts.snap
+++ b/test/__snapshots__/oxlint.spec.ts.snap
@@ -3379,6 +3379,7 @@ exports[`oxlint config snapshots > should match the default roblox game config 1
           "error",
           {
             "arrowParens": "always",
+            "endOfLine": "lf",
             "printWidth": 100,
             "quoteProps": "consistent",
             "semi": true,
@@ -3544,6 +3545,7 @@ exports[`oxlint config snapshots > should match the default roblox game config 1
           "error",
           {
             "arrowParens": "always",
+            "endOfLine": "lf",
             "printWidth": 100,
             "quoteProps": "consistent",
             "semi": true,
@@ -7266,6 +7268,7 @@ exports[`oxlint config snapshots > should match the package config 1`] = `
           "error",
           {
             "arrowParens": "always",
+            "endOfLine": "lf",
             "printWidth": 100,
             "quoteProps": "consistent",
             "semi": true,
@@ -7431,6 +7434,7 @@ exports[`oxlint config snapshots > should match the package config 1`] = `
           "error",
           {
             "arrowParens": "always",
+            "endOfLine": "lf",
             "printWidth": 100,
             "quoteProps": "consistent",
             "semi": true,

--- a/test/prettier-config.spec.ts
+++ b/test/prettier-config.spec.ts
@@ -1,0 +1,168 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { isentinel } from "../src";
+import { isentinel as oxlint } from "../src/oxlint";
+import { PRETTIER_DEFAULTS, resolvePrettierSettings } from "../src/prettier-config";
+
+/**
+ * Resolve settings against a throwaway project directory containing the given
+ * files.
+ *
+ * @param files - File names mapped to their contents.
+ * @param prettierOptions - Explicit factory options to merge on top.
+ * @returns The resolved settings.
+ */
+function settingsFor(
+	files: Record<string, string>,
+	prettierOptions: Record<string, unknown> = {},
+): Record<string, unknown> {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), "isentinel-prettier-"));
+
+	try {
+		for (const [name, contents] of Object.entries(files)) {
+			fs.writeFileSync(path.join(directory, name), contents, "utf-8");
+		}
+
+		return resolvePrettierSettings(prettierOptions, directory);
+	} finally {
+		fs.rmSync(directory, { force: true, recursive: true });
+	}
+}
+
+describe("resolvePrettierSettings", () => {
+	it("falls back to the preset defaults", () => {
+		expect.hasAssertions();
+
+		expect(settingsFor({})).toStrictEqual({ ...PRETTIER_DEFAULTS });
+	});
+
+	it("reads .prettierrc as JSON", () => {
+		expect.hasAssertions();
+
+		expect(settingsFor({ ".prettierrc": '{"printWidth": 80}' })["printWidth"]).toBe(80);
+	});
+
+	it("reads .prettierrc.yaml", () => {
+		expect.hasAssertions();
+
+		const settings = settingsFor({ ".prettierrc.yaml": "printWidth: 70\ntabWidth: 2\n" });
+
+		expect(settings).toMatchObject({ printWidth: 70, tabWidth: 2 });
+	});
+
+	it("reads the package.json prettier key", () => {
+		expect.hasAssertions();
+
+		const settings = settingsFor({
+			"package.json": '{"name": "x", "prettier": {"printWidth": 60}}',
+		});
+
+		expect(settings["printWidth"]).toBe(60);
+	});
+
+	it("ignores a package.json prettier key naming a shareable config", () => {
+		expect.hasAssertions();
+
+		const settings = settingsFor({
+			"package.json": '{"name": "x", "prettier": "@company/prettier-config"}',
+		});
+
+		expect(settings["printWidth"]).toBe(PRETTIER_DEFAULTS.printWidth);
+	});
+
+	it("translates EditorConfig properties", () => {
+		expect.hasAssertions();
+
+		const settings = settingsFor({
+			".editorconfig": [
+				"root = true",
+				"",
+				"[*]",
+				"end_of_line = lf",
+				"indent_style = space",
+				"indent_size = 2",
+				"max_line_length = 90",
+			].join("\n"),
+		});
+
+		expect(settings).toMatchObject({
+			endOfLine: "lf",
+			printWidth: 90,
+			tabWidth: 2,
+			useTabs: false,
+		});
+	});
+
+	it("applies EditorConfig sections matching source files", () => {
+		expect.hasAssertions();
+
+		const settings = settingsFor({
+			".editorconfig": [
+				"root = true",
+				"",
+				"[*]",
+				"indent_size = 8",
+				"",
+				"[*.{ts,tsx}]",
+				"indent_size = 3",
+			].join("\n"),
+		});
+
+		expect(settings["tabWidth"]).toBe(3);
+	});
+
+	it("lets a Prettier config win over EditorConfig", () => {
+		expect.hasAssertions();
+
+		const settings = settingsFor({
+			".editorconfig": "root = true\n\n[*]\nmax_line_length = 90\n",
+			".prettierrc": '{"printWidth": 80}',
+		});
+
+		expect(settings["printWidth"]).toBe(80);
+	});
+
+	it("lets explicit factory options win over everything", () => {
+		expect.hasAssertions();
+
+		const settings = settingsFor({ ".prettierrc": '{"printWidth": 80}' }, { printWidth: 55 });
+
+		expect(settings["printWidth"]).toBe(55);
+	});
+});
+
+/**
+ * Read the options of the arrow rule out of a rule map.
+ *
+ * @param rules - The rule map to read from.
+ * @returns The rule's options object, if the rule is present.
+ */
+function arrowOptions(rules: Record<string, unknown> | undefined): unknown {
+	const entry = rules?.["flawless/arrow-return-style"];
+	return Array.isArray(entry) ? entry[1] : undefined;
+}
+
+describe("factory parity", () => {
+	it("gives both engines the same arrow-return-style options", async () => {
+		expect.hasAssertions();
+
+		const eslintConfigs = await isentinel({ roblox: false, type: "package" });
+		const eslintRules = eslintConfigs.find(
+			(config) => config.name === "isentinel/flawless/rules",
+		)?.rules;
+
+		// Emitted overrides carry no name, so the rule itself is the anchor.
+		const oxlintConfig = oxlint({ name: "test/parity", roblox: false, type: "package" });
+		const oxlintRules = oxlintConfig.overrides?.find(
+			(override) => override.rules?.["flawless/arrow-return-style"] !== undefined,
+		)?.rules;
+
+		const fromEslint = arrowOptions(eslintRules);
+
+		expect(fromEslint).toBeDefined();
+		expect(arrowOptions(oxlintRules as Record<string, unknown>)).toStrictEqual(fromEslint);
+	});
+});


### PR DESCRIPTION
Refs #587.

## Problem

The ESLint factory merged prettier + EditorConfig resolution into its `prettierSettings`; the oxlint factory used only the hardcoded defaults plus explicit `formatters.prettierOptions`.

Those settings are not formatting-only — they feed rule options, notably `flawless/arrow-return-style`'s `maxLen`, `tabWidth` and `useOxfmt.printWidth`. So in any project with a `printWidth`/`tabWidth` outside the defaults, the two engines ran the same rule with different options, reached opposite conclusions, and `--fix` ping-ponged the code between both forms. That is a better explanation for #587 than an oxlint jsPlugin AST/scope difference.

## Fix

New `src/prettier-config.ts` exposing `resolvePrettierSettings(prettierOptions, cwd)`: preset defaults ← EditorConfig ← prettier config ← explicit options. Both factories now call it, so their inputs cannot drift. The async `resolvePrettierConfigOptions` in `src/utils.ts` is removed.

Prettier's `resolveConfig` is async-only since v3 and the oxlint factory is synchronous, so resolution is reimplemented synchronously. It covers `package.json#prettier`, `.prettierrc(.json|.jsonc|.json5|.yaml|.yml|.js|.cjs|.mjs)`, `prettier.config.{js,cjs,mjs}` and `.editorconfig`.

## Deliberate deltas from prettier's own resolution

- `prettier.config.ts` / `.prettierrc.ts` are skipped — they need a loader. The ESLint side previously honored them.
- EditorConfig sections are matched against a representative `index.ts` instead of `package.json`, so `[*.{ts,tsx}]` sections now apply. These settings drive JS/TS rule options, so matching the files those rules lint is the intent.

## Verification

- `test/prettier-config.spec.ts`: 9 resolution cases plus a parity test asserting both factories emit identical `flawless/arrow-return-style` options.
- Full suite 153 passed, typecheck clean, `pnpm lint` (oxlint + eslint) clean.
- One snapshot change, which is the fix in evidence: the oxlint config now picks up `endOfLine: "lf"` from this repo's own `.editorconfig`, which it previously ignored.

## Not addressed

Nothing verifies that a consumer's `eslint.config.ts` actually sets `oxlint: true` before `isentinel-lint` runs both engines. Without it, every mapped rule runs twice — the other half of #587. Left out of scope here (no `isentinel-lint` changes); worth its own issue.

https://claude.ai/code/session_01VF32MLxnjVissiFJDo6xy9