### PR TITLE
fix(lint-cli): give each config variant its own ESLint cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           key: eslint-cache-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml', 'eslint.config.*', '.eslintignore') }}-${{ github.run_id }}
-          path: .eslintcache
+          path: .eslintcache*
           restore-keys: |
             eslint-cache-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml', 'eslint.config.*', '.eslintignore') }}-
             eslint-cache-${{ runner.os }}-

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ typings/
 .npm
 
 # Optional eslint cache
-.eslintcache
+.eslintcache*
 
 # Optional REPL history
 .node_repl_history

--- a/README.md
+++ b/README.md
@@ -244,13 +244,33 @@ Other behaviours:
   CPU. The fast pass is cheap per file, so it packs far more files per worker
   (see `FAST_FILES_PER_WORKER`) than the type-aware pass.
 - Keeps a separate ESLint cache per pass so they never invalidate one another:
-  `.eslintcache-fast` (fast pass), `.eslintcache-typeaware` (type-aware pass),
-  and `.eslintcache` (the full single-pass config used by `--fix`, CI and
-  `--type-aware=full`). A change to an ESLint/oxlint/Prettier/tsconfig file or a
-  lockfile clears all three; a change to the root `package.json` resolution
-  surface (`exports`, `imports`, `main`, `module`, `types`, `typesVersions`,
-  `dependencies`, `devDependencies`, `peerDependencies`) clears only the
-  type-aware caches (a syntactic lint cannot be affected by resolution).
+  `.eslintcache-fast-<key>` (fast pass), `.eslintcache-typeaware-<key>`
+  (type-aware pass), and `.eslintcache-<key>` (the full single-pass config used
+  by `--fix`, CI and `--type-aware=full`). A change to an
+  ESLint/oxlint/Prettier/tsconfig file or a lockfile clears each cache that is
+  actually older than that change; a change to the root `package.json`
+  resolution surface (`exports`, `imports`, `main`, `module`, `types`,
+  `typesVersions`, `dependencies`, `devDependencies`, `peerDependencies`) clears
+  only the type-aware caches (a syntactic lint cannot be affected by
+  resolution). Add `.eslintcache*` to `.gitignore` — a bare `.eslintcache` entry
+  does not match the suffixed names.
+- Splits every cache by **config variant**. ESLint stores a config hash per
+  cache entry, so two runs that resolve even slightly different configs wipe
+  each other's entries when they share one cache file — an agent session and a
+  human session alternating against one cache re-lint the whole project in both
+  directions, every time. The `<key>` above is an 8-character hash of the inputs
+  that make this preset resolve a different config: agent session, editor
+  session and CI. Each variant gets its own cache (and its own builder /
+  `package.json`-hash state), so nothing is invalidated; the variants simply
+  stop overwriting each other. Git-hook runs deliberately share the plain
+  no-agent variant.
+
+  If your own `eslint.config.*` branches on something the runner cannot see —
+  your own agent/editor check, a feature flag, or an explicit `isAgent`,
+  `isInEditor` or `defaultSeverity` option — set `ISENTINEL_LINT_CACHE_KEY` to a
+  value naming that branch. It is folded into the key, giving those configs
+  separate caches too.
+
 - Runs `--fix` sequentially (`oxlint --fix`, then `eslint --fix`) so two writers
   never race on the same files.
 - Lets every child run to completion and returns non-zero if any failed — an

--- a/hk.pkl
+++ b/hk.pkl
@@ -12,11 +12,26 @@ local sharedGuards = new Mapping<String, Step> {
     }
 }
 
+// `isentinel-lint` shims to `dist/lint-cli.mjs`, so the bin does not exist
+// until something builds it — a fresh clone would otherwise fail the lint step.
+// Skips `nr gen`: the typegen files it writes are tracked, so they are already
+// present, and regenerating them here would rewrite tracked files mid-commit.
+// `tsdown.config.ts` sets `clean: true`, so `dist` is emptied at build start
+// and is briefly absent — the lint step's `depends` is what keeps that window
+// from being observable, not the omitted `--clean` flag.
+local build = new Step {
+    check = "pnpm exec tsdown --dts"
+    shell = bash
+}
+
 // The hybrid CLI sequences oxlint then ESLint itself, dropping the
 // oxlint-covered rules from the ESLint pass, so a separate oxlint step would
 // only double-lint. GIT_HOOK pins hook runs to the no-agent cache variant.
+// `depends` is load-bearing: hk runs steps concurrently by default, so without
+// it the build could still be writing `dist` as this step loads it.
 local lint = new Step {
     glob = List("*.ts", "*.tsx", "*.js", "*.mjs", "*.cjs", "*.json", "*.jsonc", "*.md", "*.toml", "*.yaml", "*.yml")
+    depends = List("build")
     check = "isentinel-lint {{files}}"
     fix = "isentinel-lint --fix {{files}}"
     shell = bash
@@ -50,6 +65,7 @@ hooks {
         steps {
             ...sharedGuards
             ["renovate-config"] = renovateConfig
+            ["build"] = build
             ["lint"] = lint
             ["typecheck"] = typecheck
             ["test"] = test
@@ -58,6 +74,7 @@ hooks {
     ["pre-push"] {
         steps {
             ...sharedGuards
+            ["build"] = build
             ["lint"] = lint
             ["typecheck"] = typecheck
         }
@@ -80,6 +97,7 @@ hooks {
         steps {
             ...sharedGuards
             ["renovate-config"] = renovateConfig
+            ["build"] = build
             ["lint"] = lint
             ["typecheck"] = typecheck
         }

--- a/hk.pkl
+++ b/hk.pkl
@@ -12,18 +12,13 @@ local sharedGuards = new Mapping<String, Step> {
     }
 }
 
-local oxlint = new Step {
-    glob = List("*.ts", "*.tsx", "*.js", "*.mjs", "*.cjs")
-    check = "pnpm exec oxlint {{files}}"
-    fix = "pnpm exec oxlint --fix {{files}}"
-    shell = bash
-    env = new Mapping<String, String> { ["GIT_HOOK"] = "1" }
-}
-
+// The hybrid CLI sequences oxlint then ESLint itself, dropping the
+// oxlint-covered rules from the ESLint pass, so a separate oxlint step would
+// only double-lint. GIT_HOOK pins hook runs to the no-agent cache variant.
 local lint = new Step {
     glob = List("*.ts", "*.tsx", "*.js", "*.mjs", "*.cjs", "*.json", "*.jsonc", "*.md", "*.toml", "*.yaml", "*.yml")
-    check = "eslint --cache --no-warn-ignored {{files}}"
-    fix = "eslint --cache --fix --no-warn-ignored {{files}}"
+    check = "isentinel-lint {{files}}"
+    fix = "isentinel-lint --fix {{files}}"
     shell = bash
     env = new Mapping<String, String> { ["GIT_HOOK"] = "1" }
 }
@@ -55,7 +50,6 @@ hooks {
         steps {
             ...sharedGuards
             ["renovate-config"] = renovateConfig
-            ["oxlint"] = oxlint
             ["lint"] = lint
             ["typecheck"] = typecheck
             ["test"] = test
@@ -64,7 +58,6 @@ hooks {
     ["pre-push"] {
         steps {
             ...sharedGuards
-            ["oxlint"] = oxlint
             ["lint"] = lint
             ["typecheck"] = typecheck
         }
@@ -87,7 +80,6 @@ hooks {
         steps {
             ...sharedGuards
             ["renovate-config"] = renovateConfig
-            ["oxlint"] = oxlint
             ["lint"] = lint
             ["typecheck"] = typecheck
         }

--- a/src/lint-cli/affected.ts
+++ b/src/lint-cli/affected.ts
@@ -1,4 +1,4 @@
-// cspell:words tsbuildinfo typeaware buildinfo normalised stabilise
+// cspell:words tsbuildinfo typeaware buildinfo mtimes normalised stabilise
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -25,17 +25,39 @@ export interface AffectedResult {
 let warned = false;
 
 /**
- * Resolve the builder incremental-state (`.tsbuildinfo`) file for a mode.
- * Stored under `node_modules/.cache/isentinel-lint/` so it never pollutes the
- * consumer's source tree and is cleaned with `node_modules`.
+ * Resolve the builder incremental-state (`.tsbuildinfo`) file for a mode and
+ * config variant. Stored under `node_modules/.cache/isentinel-lint/` so it
+ * never pollutes the consumer's source tree and is cleaned with
+ * `node_modules`.
+ *
+ * The variant key is part of the path because this state is drained
+ * destructively: {@link computeAffectedFiles} consumes the affected set and
+ * advances the buildinfo, and the caller removes those files from *one* cache.
+ * Sharing one buildinfo across variants would let an agent run advance the
+ * state while only its own cache was invalidated; the next human run would
+ * then see an empty affected set with stale entries still in its own warm
+ * cache — and since those files' mtimes never changed, the typed pass would
+ * auto-skip and report stale diagnostics that ESLint's `hashOfConfig` cannot
+ * catch.
  *
  * @param cwd - The consumer project root.
  * @param mode - The active ESLint type-aware mode (never `"off"` here).
+ * @param key - The config-variant key from `resolveCacheKey`.
  * @returns The absolute path to the mode's buildinfo file.
  */
-export function builderStatePath(cwd: string, mode: TypeAwareMode | undefined): string {
+export function builderStatePath(
+	cwd: string,
+	mode: TypeAwareMode | undefined,
+	key: string,
+): string {
 	const suffix = mode === "only" ? "typeaware" : "full";
-	return path.join(cwd, "node_modules", ".cache", "isentinel-lint", `tsbuildinfo-${suffix}`);
+	return path.join(
+		cwd,
+		"node_modules",
+		".cache",
+		"isentinel-lint",
+		`tsbuildinfo-${suffix}-${key}`,
+	);
 }
 
 /**
@@ -52,11 +74,13 @@ export function builderStatePath(cwd: string, mode: TypeAwareMode | undefined): 
  *
  * @param cwd - The consumer project root.
  * @param mode - The active ESLint type-aware mode.
+ * @param key - The config-variant key from `resolveCacheKey`.
  * @returns The affected result, or `undefined` when skipped.
  */
 export function computeAffectedFiles(
 	cwd: string,
 	mode: TypeAwareMode | undefined,
+	key: string,
 ): AffectedResult | undefined {
 	const ts = loadTypescript(cwd);
 	if (ts === undefined) {
@@ -71,7 +95,7 @@ export function computeAffectedFiles(
 	}
 
 	try {
-		return runBuilder(ts, cwd, configPath, mode);
+		return runBuilder(ts, configPath, builderStatePath(cwd, mode, key));
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		warnOnce(`type-aware cache invalidation failed: ${message}`);
@@ -154,16 +178,14 @@ function collectAffected(
  * without reporting diagnostics, then persist updated state.
  *
  * @param ts - The resolved TypeScript module.
- * @param cwd - The consumer project root.
  * @param configPath - The resolved tsconfig path.
- * @param mode - The active ESLint type-aware mode.
+ * @param buildInfoPath - The variant's buildinfo file (see {@link builderStatePath}).
  * @returns The affected result.
  */
 function runBuilder(
 	ts: typeof TypeScript,
-	cwd: string,
 	configPath: string,
-	mode: TypeAwareMode | undefined,
+	buildInfoPath: string,
 ): AffectedResult | undefined {
 	const configFile = ts.readConfigFile(configPath, (file) => ts.sys.readFile(file));
 	if (configFile.error !== undefined) {
@@ -182,7 +204,6 @@ function runBuilder(
 		return { affected: new Set(), firstRun: false };
 	}
 
-	const buildInfoPath = builderStatePath(cwd, mode);
 	fs.mkdirSync(path.dirname(buildInfoPath), { recursive: true });
 	const firstRun = !fs.existsSync(buildInfoPath);
 

--- a/src/lint-cli/cache-key.ts
+++ b/src/lint-cli/cache-key.ts
@@ -1,0 +1,51 @@
+import crypto from "node:crypto";
+
+import { isCi, isInAgentSession, isInEditorEnvironment } from "../utils.ts";
+
+/** Length of the hex digest slice used to suffix cache and state files. */
+const CACHE_KEY_LENGTH = 8;
+
+/**
+ * Environment variable a consumer sets to fold its own config branches into the
+ * cache key. The env-derived key only sees the branches this preset owns, so a
+ * consumer whose `eslint.config.*` varies on anything else — its own
+ * `isInAgentSession()` check, a feature flag, an explicit `isAgent` /
+ * `isInEditor` / `defaultSeverity` option — must name that branch here or its
+ * variants will keep sharing (and overwriting) one cache.
+ */
+const CACHE_KEY_OVERRIDE = "ISENTINEL_LINT_CACHE_KEY";
+
+/**
+ * Resolve the cache-variant key for this run. Every input that makes the preset
+ * resolve a *different* ESLint config gets its own key, and therefore its own
+ * cache file and its own per-cache state.
+ *
+ * This exists because ESLint stores a `hashOfConfig` per cache entry: two runs
+ * whose resolved configs differ by even one rule severity invalidate each
+ * other's entries wholesale when they share a cache file. An agent run and a
+ * human run alternating against one cache re-lint the whole project in both
+ * directions, forever. Splitting the file by variant means nothing is
+ * invalidated — the variants simply stop overwriting each other.
+ *
+ * The key is derived from the environment rather than from the resolved config
+ * because hashing the real config costs a full `eslint --print-config`
+ * (~4.6s/run), and the key stored in an existing cache describes the *previous*
+ * run, which cannot predict this one.
+ *
+ * @param environment - The process environment to derive the key from.
+ * @returns An 8-character hex key identifying the config variant.
+ */
+export function resolveCacheKey(environment: NodeJS.ProcessEnv): string {
+	const parts = [
+		isInAgentSession(environment),
+		isInEditorEnvironment(environment),
+		isCi(environment),
+		environment[CACHE_KEY_OVERRIDE] ?? "",
+	];
+
+	return crypto
+		.createHash("sha256")
+		.update(parts.join("|"))
+		.digest("hex")
+		.slice(0, CACHE_KEY_LENGTH);
+}

--- a/src/lint-cli/cache.ts
+++ b/src/lint-cli/cache.ts
@@ -2,7 +2,7 @@ import fileEntryCache from "file-entry-cache";
 import fs from "node:fs";
 import path from "node:path";
 
-import { ALL_CACHE_FILES } from "./constants.ts";
+import { CACHE_FILE_PREFIX } from "./constants.ts";
 import { toPosix } from "./paths.ts";
 
 /**
@@ -86,18 +86,68 @@ export function isCacheBusted(cacheFilePath: string, bustFiles: Array<string>): 
 }
 
 /**
- * Delete every ESLint cache file the runner manages.
+ * List every ESLint cache file present in the working directory, matched by
+ * prefix rather than by exact name: each pass's cache carries a config-variant
+ * key suffix, so the set on disk is open-ended and an exact-name list would
+ * miss (and therefore leak) every variant but the current run's.
+ *
+ * @param cwd - The working directory containing the cache files.
+ * @returns Absolute paths to the cache files found.
+ */
+export function listCacheFiles(cwd: string): Array<string> {
+	let entries: Array<string>;
+	try {
+		entries = fs.readdirSync(cwd);
+	} catch {
+		return [];
+	}
+
+	return entries
+		.filter((entry) => entry.startsWith(CACHE_FILE_PREFIX))
+		.map((entry) => path.resolve(cwd, entry));
+}
+
+/**
+ * Delete every ESLint cache file the runner manages, across all variants.
  *
  * @param cwd - The working directory containing the cache files.
  */
 export function clearAllCaches(cwd: string): void {
-	for (const name of ALL_CACHE_FILES) {
-		try {
-			fs.rmSync(path.resolve(cwd, name), { force: true });
-		} catch {
-			// Best effort; ESLint will rebuild the cache regardless.
-		}
+	for (const cacheFilePath of listCacheFiles(cwd)) {
+		removeCacheFile(cacheFilePath);
 	}
+}
+
+/**
+ * Delete the individually stale cache files in the working directory.
+ *
+ * Deliberately per-file rather than all-or-nothing: variants this run did not
+ * select still sit on disk, and {@link isCacheStale} reports a missing file as
+ * fresh. An all-or-nothing gate over only the selected passes therefore lets an
+ * unselected-but-stale variant survive a config edit, then wipes every fresh
+ * variant the next time that stale one is selected — the same mutual
+ * invalidation the variant split exists to remove, relocated to the config-edit
+ * path.
+ *
+ * @param cwd - The working directory containing the cache files.
+ * @param newestBustMtimeMs - The newest bust-file mtime (see {@link maxMtimeMs}).
+ * @returns The absolute paths deleted.
+ */
+export function sweepStaleCaches(
+	cwd: string,
+	newestBustMtimeMs: number | undefined,
+): Array<string> {
+	const removed: Array<string> = [];
+	for (const cacheFilePath of listCacheFiles(cwd)) {
+		if (!isCacheStale(cacheFilePath, newestBustMtimeMs)) {
+			continue;
+		}
+
+		removeCacheFile(cacheFilePath);
+		removed.push(cacheFilePath);
+	}
+
+	return removed;
 }
 
 /**
@@ -180,6 +230,14 @@ function safeMtimeMs(filePath: string): number | undefined {
 		return fs.statSync(filePath).mtimeMs;
 	} catch {
 		return undefined;
+	}
+}
+
+function removeCacheFile(cacheFilePath: string): void {
+	try {
+		fs.rmSync(cacheFilePath, { force: true });
+	} catch {
+		// Best effort; ESLint will rebuild the cache regardless.
 	}
 }
 

--- a/src/lint-cli/constants.ts
+++ b/src/lint-cli/constants.ts
@@ -20,21 +20,42 @@ export const DEFAULT_FAST_FILES_PER_WORKER = 800;
  */
 export const AFFECTED_BUST_THRESHOLD = 1000;
 
-/** ESLint cache file used when no type-aware mode is selected. */
-export const CACHE_FILE_DEFAULT = ".eslintcache";
+/**
+ * Base name of every ESLint cache file the runner manages. Each real file adds
+ * a pass suffix and a config-variant key (see {@link cacheFileFor}), so this
+ * doubles as the prefix the whole-cache sweep matches on.
+ */
+export const CACHE_FILE_PREFIX = ".eslintcache";
 
-/** ESLint cache file used for `--type-aware=off` (syntactic-only) runs. */
-export const CACHE_FILE_FAST = ".eslintcache-fast";
+/** ESLint cache base name used when no type-aware mode is selected. */
+export const CACHE_FILE_DEFAULT = CACHE_FILE_PREFIX;
 
-/** ESLint cache file used for `--type-aware=only` runs. */
-export const CACHE_FILE_TYPE_AWARE = ".eslintcache-typeaware";
+/** ESLint cache base name used for `--type-aware=off` (syntactic-only) runs. */
+export const CACHE_FILE_FAST = `${CACHE_FILE_PREFIX}-fast`;
 
-/** Every ESLint cache file the runner manages, cleared on a config change. */
+/** ESLint cache base name used for `--type-aware=only` runs. */
+export const CACHE_FILE_TYPE_AWARE = `${CACHE_FILE_PREFIX}-typeaware`;
+
+/** Every ESLint cache base name the runner manages. */
 export const ALL_CACHE_FILES = [
 	CACHE_FILE_DEFAULT,
 	CACHE_FILE_FAST,
 	CACHE_FILE_TYPE_AWARE,
 ] as const;
+
+/**
+ * Suffix a cache base name with the run's config-variant key. Two runs whose
+ * resolved ESLint configs differ get different keys and therefore different
+ * files, so neither can invalidate the other's entries via ESLint's per-entry
+ * `hashOfConfig`.
+ *
+ * @param baseName - The pass's cache base name (see {@link ALL_CACHE_FILES}).
+ * @param key - The variant key from `resolveCacheKey`.
+ * @returns The keyed cache file name, relative to the working directory.
+ */
+export function cacheFileFor(baseName: string, key: string): string {
+	return `${baseName}-${key}`;
+}
 
 // The extension arrays live in `src/globs.ts` next to the glob patterns they
 // mirror, and are re-exported here under the names the lint CLI uses:

--- a/src/lint-cli/invalidation.ts
+++ b/src/lint-cli/invalidation.ts
@@ -9,6 +9,10 @@ import type { TypeAwareMode } from "./types.ts";
 
 /** Inputs to one type-aware invalidation pass. */
 export interface InvalidationRequest {
+	/**
+	 * The config-variant key from `resolveCacheKey`; keys the builder state.
+	 */
+	key: string;
 	/** Normalised paths already dirty by mtime/checksum. */
 	alreadyDirty: ReadonlySet<string>;
 	/**
@@ -60,6 +64,7 @@ export interface InvalidationOutcome {
  * @returns The invalidation outcome.
  */
 export function applyTypeAwareInvalidation({
+	key,
 	alreadyDirty,
 	cache,
 	cacheLocation,
@@ -68,7 +73,7 @@ export function applyTypeAwareInvalidation({
 	mode,
 	targetFiles,
 }: InvalidationRequest): InvalidationOutcome {
-	const result = computeAffectedFiles(cwd, mode);
+	const result = computeAffectedFiles(cwd, mode, key);
 	if (result === undefined) {
 		return { busted: false, firstRun: false, invalidated: [], skipped: true };
 	}
@@ -87,9 +92,9 @@ export function applyTypeAwareInvalidation({
 	// in-project affected set (which counts files this run will never touch).
 	const affectedTargets: Array<string> = [];
 	for (const affected of result.affected) {
-		const key = normalizePath(affected);
-		if (targets.has(key)) {
-			affectedTargets.push(key);
+		const normalized = normalizePath(affected);
+		if (targets.has(normalized)) {
+			affectedTargets.push(normalized);
 		}
 	}
 
@@ -99,7 +104,7 @@ export function applyTypeAwareInvalidation({
 		return { busted: true, firstRun: false, invalidated: [], skipped: false };
 	}
 
-	const invalidated = affectedTargets.filter((key) => !alreadyDirty.has(key));
+	const invalidated = affectedTargets.filter((target) => !alreadyDirty.has(target));
 	if (cache !== undefined) {
 		cache.removeEntries(invalidated);
 	} else {

--- a/src/lint-cli/package-hash.ts
+++ b/src/lint-cli/package-hash.ts
@@ -3,7 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
-import { CACHE_FILE_DEFAULT, CACHE_FILE_TYPE_AWARE } from "./constants.ts";
+import { CACHE_FILE_DEFAULT, CACHE_FILE_TYPE_AWARE, cacheFileFor } from "./constants.ts";
 import { findWorkspaceRoot } from "./workspace.ts";
 
 /**
@@ -36,14 +36,21 @@ export interface PackageJsonBustOutcome {
 }
 
 /**
- * Resolve the persisted package.json resolution-hash file. Stored alongside the
- * builder state so it is cleaned with `node_modules`.
+ * Resolve the persisted package.json resolution-hash file for a config variant.
+ * Stored alongside the builder state so it is cleaned with `node_modules`.
+ *
+ * The variant key is part of the path because the stored hash is consumed once:
+ * after the first run that sees a new hash, every later run finds
+ * `stored === hash` and returns early. A shared state file would let the first
+ * variant to run absorb the dependency bump on behalf of all of them, leaving
+ * every cache it did not delete permanently stale with respect to that bump.
  *
  * @param cwd - The consumer project root.
+ * @param key - The config-variant key from `resolveCacheKey`.
  * @returns The absolute path to the stored-hash file.
  */
-export function packageHashStatePath(cwd: string): string {
-	return path.join(cwd, "node_modules", ".cache", "isentinel-lint", "package-json-hash");
+export function packageHashStatePath(cwd: string, key: string): string {
+	return path.join(cwd, "node_modules", ".cache", "isentinel-lint", `package-json-hash-${key}`);
 }
 
 /**
@@ -77,22 +84,28 @@ export function computePackageJsonHash(cwd: string): string | undefined {
 }
 
 /**
- * Bust the type-aware caches when the root `package.json` resolution surface
- * changed since the last run. Deletes `.eslintcache-typeaware` and
- * `.eslintcache` (both type-aware configs) while leaving `.eslintcache-fast`
- * (syntactic-only) intact, since resolution changes cannot alter a syntactic
- * lint. The first run only stores the hash.
+ * Bust this variant's type-aware caches when the root `package.json`
+ * resolution surface changed since the last run. Deletes
+ * `.eslintcache-typeaware-<key>` and `.eslintcache-<key>` (both type-aware
+ * configs) while leaving `.eslintcache-fast-<key>` (syntactic-only) intact,
+ * since resolution changes cannot alter a syntactic lint. The first run only
+ * stores the hash.
+ *
+ * Only this variant's files are touched, which is why the stored hash is keyed
+ * too: each variant observes the bump independently on its own first run after
+ * it (see {@link packageHashStatePath}).
  *
  * @param cwd - The consumer project root.
+ * @param key - The config-variant key from `resolveCacheKey`.
  * @returns The bust outcome.
  */
-export function applyPackageJsonBust(cwd: string): PackageJsonBustOutcome {
+export function applyPackageJsonBust(cwd: string, key: string): PackageJsonBustOutcome {
 	const hash = computePackageJsonHash(cwd);
 	if (hash === undefined) {
 		return { busted: false, firstRun: false };
 	}
 
-	const statePath = packageHashStatePath(cwd);
+	const statePath = packageHashStatePath(cwd, key);
 	const stored = safeRead(statePath);
 	if (stored === hash) {
 		return { busted: false, firstRun: false };
@@ -103,8 +116,8 @@ export function applyPackageJsonBust(cwd: string): PackageJsonBustOutcome {
 		return { busted: false, firstRun: true };
 	}
 
-	fs.rmSync(path.resolve(cwd, CACHE_FILE_TYPE_AWARE), { force: true });
-	fs.rmSync(path.resolve(cwd, CACHE_FILE_DEFAULT), { force: true });
+	fs.rmSync(path.resolve(cwd, cacheFileFor(CACHE_FILE_TYPE_AWARE, key)), { force: true });
+	fs.rmSync(path.resolve(cwd, cacheFileFor(CACHE_FILE_DEFAULT, key)), { force: true });
 	return { busted: true, firstRun: false };
 }
 

--- a/src/lint-cli/passes.ts
+++ b/src/lint-cli/passes.ts
@@ -12,8 +12,11 @@ import type { LintCliOptions, ToolLabel, TypeAwareMode } from "./types.ts";
  * mode branches just pick descriptors.
  */
 export interface PassDescriptor {
-	/** ESLint cache file this pass reads and writes. */
-	cacheFile: string;
+	/**
+	 * Base name of the ESLint cache this pass reads and writes. The real file
+	 * name adds the run's config-variant key; see `cacheFileFor`.
+	 */
+	cacheFileBase: string;
 	/**
 	 * Resolve the files-per-worker for this pass from the shared limits and the
 	 * environment. The fast pass uses its own higher break-even.
@@ -43,7 +46,7 @@ export interface PassDescriptor {
  * The syntactic-only fast pass (`ESLINT_TYPE_AWARE=off`, `.eslintcache-fast`).
  */
 export const FAST_PASS: PassDescriptor = {
-	cacheFile: CACHE_FILE_FAST,
+	cacheFileBase: CACHE_FILE_FAST,
 	filesPerWorker: (_limits, environment) => resolveFastFilesPerWorker(environment),
 	invalidation: "none",
 	label: "fast",
@@ -53,7 +56,7 @@ export const FAST_PASS: PassDescriptor = {
 
 /** The type-aware pass (`ESLINT_TYPE_AWARE=only`, `.eslintcache-typeaware`). */
 export const TYPED_PASS: PassDescriptor = {
-	cacheFile: CACHE_FILE_TYPE_AWARE,
+	cacheFileBase: CACHE_FILE_TYPE_AWARE,
 	filesPerWorker: (limits) => limits.filesPerWorker,
 	invalidation: "only",
 	label: "typed",
@@ -63,7 +66,7 @@ export const TYPED_PASS: PassDescriptor = {
 
 /** The full-config pass (env unset, `.eslintcache`): CI, `--fix`, `=full`. */
 export const FULL_PASS: PassDescriptor = {
-	cacheFile: CACHE_FILE_DEFAULT,
+	cacheFileBase: CACHE_FILE_DEFAULT,
 	filesPerWorker: (limits) => limits.filesPerWorker,
 	invalidation: "full",
 	label: "eslint",

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -7,8 +7,9 @@ import path from "node:path";
 import process from "node:process";
 
 import { isCi } from "../utils.ts";
+import { resolveCacheKey } from "./cache-key.ts";
 import type { DirtyCache } from "./cache.ts";
-import { clearAllCaches, isCacheStale, maxMtimeMs, normalizePath, openCache } from "./cache.ts";
+import { isCacheStale, maxMtimeMs, normalizePath, openCache, sweepStaleCaches } from "./cache.ts";
 import {
 	buildShellCommand,
 	composeEslintCommand,
@@ -16,6 +17,7 @@ import {
 	formatCommandLine,
 } from "./command.ts";
 import { computeWorkerCount, resolveWorkerLimits } from "./concurrency.ts";
+import { cacheFileFor } from "./constants.ts";
 import { collectRepoFiles } from "./files.ts";
 import type { RepoFiles } from "./files.ts";
 import { resolveOxlintRun } from "./hybrid.ts";
@@ -58,9 +60,14 @@ export interface SizingContext {
 
 /** One planned ESLint pass: its descriptor, sizing and run/skip decision. */
 export interface PassPlan {
+	/**
+	 * The pass's resolved cache file name for this run: its base name plus the
+	 * config-variant key.
+	 */
+	cacheFile: string;
 	/** The concurrency resolved for the pass. */
 	concurrency: "off" | number;
-	/** The pass descriptor (cache file, label, type-aware env, sizing). */
+	/** The pass descriptor (cache base name, label, type-aware env, sizing). */
 	descriptor: PassDescriptor;
 	/** Whether the pass runs; false when auto-skipped. */
 	shouldRun: boolean;
@@ -111,12 +118,14 @@ export interface CommandPlan {
 
 /** Shared inputs threaded into {@link sizePass}. */
 interface SizePassContext {
+	/** The config-variant key for this run. */
+	key: string;
 	/**
-	 * Whether every ESLint cache was already cleared up front (an mtime bust
-	 * affecting some selected pass). When true, every file counts as dirty and
-	 * the builder is skipped — everything re-lints regardless.
+	 * The cache files the up-front stale sweep deleted (absolute paths). A pass
+	 * whose cache is in here counts every file as dirty and skips the builder —
+	 * everything re-lints regardless.
 	 */
-	cachesCleared: boolean;
+	clearedCaches: ReadonlySet<string>;
 	cwd: string;
 	environment: NodeJS.ProcessEnv;
 	files: RepoFiles;
@@ -148,6 +157,7 @@ export function plan(
 	mutate: boolean,
 ): RunPlan {
 	const ci = isCi(environment);
+	const key = resolveCacheKey(environment);
 	const runOxlint = !options.eslint;
 	const runEslint = !options.oxlint;
 	const oxlintTypeAware = resolveOxlintTypeAware(options);
@@ -183,24 +193,24 @@ export function plan(
 	// `--no-cache` never touches cache state, and `--print` (mutate=false) never
 	// mutates.
 	//
-	// The package.json bust runs first and deletes only the type-aware caches (a
-	// syntactic lint is immune to resolution changes), so it does NOT set
-	// `cachesCleared` — the fast cache survives it. The mtime bust below is the
-	// wholesale one.
+	// The package.json bust runs first and deletes only this variant's type-aware
+	// caches (a syntactic lint is immune to resolution changes), so it does NOT
+	// feed `clearedCaches` — the fast cache survives it. The mtime sweep below is
+	// the wholesale one, and it covers every variant on disk, not just the ones
+	// this run selected.
 	const canMutateCaches = mutate && options.cache;
 	const hasTypeAwarePass = descriptors.some((descriptor) => descriptor.invalidation !== "none");
 	if (canMutateCaches && hasTypeAwarePass) {
-		applyPackageJsonBust(cwd);
+		applyPackageJsonBust(cwd, key);
 	}
 
-	const cachesCleared = canMutateCaches
-		? clearStaleCaches(descriptors, cwd, newestBustMtime)
-		: false;
+	const clearedCaches = new Set(canMutateCaches ? sweepStaleCaches(cwd, newestBustMtime) : []);
 
 	const multiPass = descriptors.length > 1;
 	const passes = descriptors.map((descriptor) => {
 		return sizePass(descriptor, {
-			cachesCleared,
+			key,
+			clearedCaches,
 			cwd,
 			environment,
 			files,
@@ -264,7 +274,7 @@ export function compose(runPlan: RunPlan, options: LintCliOptions): CommandPlan 
 		commands.push(
 			composeEslintCommand(options, {
 				agentsFormatterPath: runPlan.agentsFormatterPath,
-				cacheLocation: pass.descriptor.cacheFile,
+				cacheLocation: pass.cacheFile,
 				ci: runPlan.ci,
 				concurrency: pass.concurrency,
 				eslintLabel: pass.descriptor.label,
@@ -399,40 +409,16 @@ function resolveOxlintTypeAware(options: LintCliOptions): boolean {
  * @param context - The shared sizing inputs.
  * @returns The number of dirty files.
  */
-/**
- * Evaluate the mtime bust for every selected pass's cache file and, if any is
- * stale, clear all managed caches exactly once. Returns whether the wholesale
- * clear happened so sizing can treat every file as dirty without re-checking.
- *
- * @param descriptors - The selected pass descriptors.
- * @param cwd - The working directory.
- * @param newestBustMtime - The newest cache-bust mtime (see {@link maxMtimeMs}).
- * @returns True when the caches were cleared.
- */
-function clearStaleCaches(
-	descriptors: Array<PassDescriptor>,
-	cwd: string,
-	newestBustMtime: number | undefined,
-): boolean {
-	const stale = descriptors.some((descriptor) => {
-		return isCacheStale(path.resolve(cwd, descriptor.cacheFile), newestBustMtime);
-	});
-	if (stale) {
-		clearAllCaches(cwd);
-	}
-
-	return stale;
-}
-
 function mutatingDirtyCount(
 	descriptor: PassDescriptor,
 	cacheLocation: string,
 	targetFiles: Array<string>,
-	{ cachesCleared, cwd, environment }: SizePassContext,
+	{ key, clearedCaches, cwd, environment }: SizePassContext,
 ): number {
-	if (cachesCleared) {
-		// A bust already cleared every cache up front (see `plan`), so every file
-		// is dirty and the builder would be pure waste — everything re-lints.
+	if (clearedCaches.has(cacheLocation)) {
+		// The up-front sweep already deleted this pass's cache (see `plan`), so
+		// every file is dirty and the builder would be pure waste — everything
+		// re-lints.
 		return targetFiles.length;
 	}
 
@@ -443,6 +429,7 @@ function mutatingDirtyCount(
 
 	if (descriptor.invalidation !== "none") {
 		const outcome = applyTypeAwareInvalidation({
+			key,
 			alreadyDirty: dirty,
 			cache,
 			cacheLocation,
@@ -492,16 +479,21 @@ function readOnlyDirtyCount(
  * path only reports the mtime/checksum-dirty files.
  *
  * @param descriptor - The pass being sized.
+ * @param cacheFile - The pass's keyed cache file name.
  * @param context - The shared sizing inputs.
  * @returns The number of dirty files.
  */
-function passDirtyCount(descriptor: PassDescriptor, context: SizePassContext): number {
+function passDirtyCount(
+	descriptor: PassDescriptor,
+	cacheFile: string,
+	context: SizePassContext,
+): number {
 	const targetFiles = descriptor.typeAwareOnly ? context.files.typeAware : context.files.lintable;
 	if (!context.options.cache) {
 		return targetFiles.length;
 	}
 
-	const cacheLocation = path.resolve(context.cwd, descriptor.cacheFile);
+	const cacheLocation = path.resolve(context.cwd, cacheFile);
 	return context.mutate
 		? mutatingDirtyCount(descriptor, cacheLocation, targetFiles, context)
 		: readOnlyDirtyCount(cacheLocation, targetFiles, context);
@@ -517,7 +509,8 @@ function passDirtyCount(descriptor: PassDescriptor, context: SizePassContext): n
  * @returns The planned pass.
  */
 function sizePass(descriptor: PassDescriptor, context: SizePassContext): PassPlan {
-	const dirtyCount = passDirtyCount(descriptor, context);
+	const cacheFile = cacheFileFor(descriptor.cacheFileBase, context.key);
+	const dirtyCount = passDirtyCount(descriptor, cacheFile, context);
 	const conservative = context.files.targetsOutsideCwd;
 	const filesPerWorker = descriptor.filesPerWorker(context.limits, context.environment);
 
@@ -544,10 +537,16 @@ function sizePass(descriptor: PassDescriptor, context: SizePassContext): PassPla
 	const canSkip =
 		context.mutate && context.multiPass && descriptor === TYPED_PASS && !conservative;
 	if (canSkip && dirtyCount === 0) {
-		return { concurrency, descriptor, shouldRun: false, skipReason: TYPED_SKIP_NOTICE };
+		return {
+			cacheFile,
+			concurrency,
+			descriptor,
+			shouldRun: false,
+			skipReason: TYPED_SKIP_NOTICE,
+		};
 	}
 
-	return { concurrency, descriptor, shouldRun: true, skipReason: undefined };
+	return { cacheFile, concurrency, descriptor, shouldRun: true, skipReason: undefined };
 }
 
 async function spawnChild(command: ChildCommand, cwd: string): Promise<number> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+// cspell:words CLAUDECODE NVIM
 import type { ParserOptions } from "@typescript-eslint/parser";
 
 import type { Linter } from "eslint";
@@ -326,51 +327,51 @@ export async function interopDefault<T>(dynamicImport: ModuleImport<T>): Promise
 	return resolved;
 }
 
-export function isInGitHooksOrLintStaged(): boolean {
+export function isInGitHooksOrLintStaged(environment: NodeJS.ProcessEnv = process.env): boolean {
 	return [
-		process.env["GIT_HOOK"],
-		process.env["GIT_PARAMS"],
-		process.env["VSCODE_GIT_COMMAND"],
-		process.env["npm_lifecycle_script"]?.startsWith("lint-staged"),
+		environment["GIT_HOOK"],
+		environment["GIT_PARAMS"],
+		environment["VSCODE_GIT_COMMAND"],
+		environment["npm_lifecycle_script"]?.startsWith("lint-staged"),
 	].some(Boolean);
 }
 
-export function isInAgentSession(): boolean {
-	if (isInGitHooksOrLintStaged()) {
+export function isInAgentSession(environment: NodeJS.ProcessEnv = process.env): boolean {
+	if (isInGitHooksOrLintStaged(environment)) {
 		return false;
 	}
 
 	return [
-		process.env["CLAUDECODE"],
-		process.env["CLAUDE_CODE_ENTRYPOINT"],
-		process.env["CODEX_THREAD_ID"],
-		process.env["CURSOR_AGENT"],
-		process.env["GEMINI_CLI"],
-		process.env["OPENCODE"],
+		environment["CLAUDECODE"],
+		environment["CLAUDE_CODE_ENTRYPOINT"],
+		environment["CODEX_THREAD_ID"],
+		environment["CURSOR_AGENT"],
+		environment["GEMINI_CLI"],
+		environment["OPENCODE"],
 	].some(Boolean);
 }
 
-export function isInEditorEnvironment(): boolean {
+export function isInEditorEnvironment(environment: NodeJS.ProcessEnv = process.env): boolean {
 	// Allow explicit override via environment variable
-	const explicitValue = process.env["ESLINT_IN_EDITOR"];
+	const explicitValue = environment["ESLINT_IN_EDITOR"];
 	if (explicitValue !== undefined) {
 		return explicitValue === "true" || explicitValue === "1";
 	}
 
-	if (isCi()) {
+	if (isCi(environment)) {
 		return false;
 	}
 
-	if (isInGitHooksOrLintStaged()) {
+	if (isInGitHooksOrLintStaged(environment)) {
 		return false;
 	}
 
 	return [
-		process.env["VSCODE_PID"],
-		process.env["VSCODE_CWD"],
-		process.env["JETBRAINS_IDE"],
-		process.env["VIM"],
-		process.env["NVIM"],
+		environment["VSCODE_PID"],
+		environment["VSCODE_CWD"],
+		environment["JETBRAINS_IDE"],
+		environment["VIM"],
+		environment["NVIM"],
 	].some(Boolean);
 }
 

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -1,4 +1,4 @@
-// cspell:words tsbuildinfo typeaware globals
+// cspell:words tsbuildinfo typeaware globals CLAUDECODE
 import fileEntryCache from "file-entry-cache";
 import fs from "node:fs";
 import { createRequire } from "node:module";
@@ -7,18 +7,41 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { computeAffectedFiles } from "../src/lint-cli/affected.ts";
+import { resolveCacheKey } from "../src/lint-cli/cache-key.ts";
 import { normalizePath, removeCacheEntries } from "../src/lint-cli/cache.ts";
-import { CACHE_FILE_TYPE_AWARE } from "../src/lint-cli/constants.ts";
+import { CACHE_FILE_TYPE_AWARE, cacheFileFor } from "../src/lint-cli/constants.ts";
 import { writeHybridStatus } from "../src/lint-cli/hybrid-status.ts";
 import { applyTypeAwareInvalidation } from "../src/lint-cli/invalidation.ts";
 import { parseArguments } from "../src/lint-cli/options.ts";
 import { composeCommands, plan } from "../src/lint-cli/run.ts";
 import { withoutGitEnvironment } from "./without-git.ts";
 
+/**
+ * The config-variant key every fixture here runs under. All of these drive the
+ * runner with an empty environment, so the key they resolve is fixed.
+ */
+const TEST_KEY = resolveCacheKey({});
+
+/** The keyed type-aware cache file the runner reads and writes in a fixture. */
+const TYPE_AWARE_CACHE = cacheFileFor(CACHE_FILE_TYPE_AWARE, TEST_KEY);
+
+/** An environment that resolves to the agent config variant. */
+const AGENT_ENVIRONMENT = { CLAUDECODE: "1" };
+
+/** The agent variant's config-variant key. */
+const AGENT_KEY = resolveCacheKey(AGENT_ENVIRONMENT);
+
 const TSCONFIG = JSON.stringify({
 	compilerOptions: { module: "commonjs", strict: true, target: "es2020" },
 	include: ["src"],
 });
+
+/** The fixture the per-variant cache isolation tests share. */
+const VARIANT_FIXTURE = {
+	"eslint.config.ts": "export default [];\n",
+	"src/a.ts": "export function a(): number { return 1; }\n",
+	"tsconfig.json": TSCONFIG,
+};
 
 const DOM_TSCONFIG = JSON.stringify({
 	compilerOptions: { lib: ["es2020", "dom"], module: "commonjs", strict: true, target: "es2020" },
@@ -93,6 +116,7 @@ function invalidate(
 	environment: NodeJS.ProcessEnv = {},
 ): ReturnType<typeof applyTypeAwareInvalidation> {
 	return applyTypeAwareInvalidation({
+		key: TEST_KEY,
 		alreadyDirty,
 		cacheLocation: path.join(cwd, ".eslintcache"),
 		cwd,
@@ -114,12 +138,12 @@ describe("computeAffectedFiles", () => {
 				"tsconfig.json": TSCONFIG,
 			},
 			(directory) => {
-				const first = computeAffectedFiles(directory, undefined);
+				const first = computeAffectedFiles(directory, undefined, TEST_KEY);
 
 				expect(first?.firstRun).toBe(true);
 				expect(first?.affected.size).toBeGreaterThan(0);
 
-				const second = computeAffectedFiles(directory, undefined);
+				const second = computeAffectedFiles(directory, undefined, TEST_KEY);
 
 				expect(second?.firstRun).toBe(false);
 				expect(second?.affected.size).toBe(0);
@@ -131,7 +155,7 @@ describe("computeAffectedFiles", () => {
 		expect.hasAssertions();
 
 		withFixture({ "src/a.ts": "export const a = 1;\n" }, (directory) => {
-			expect(computeAffectedFiles(directory, undefined)).toBeUndefined();
+			expect(computeAffectedFiles(directory, undefined, TEST_KEY)).toBeUndefined();
 		});
 	});
 });
@@ -154,7 +178,7 @@ describe("applyTypeAwareInvalidation", () => {
 				const fileA = path.join(directory, "src/a.ts");
 				const fileB = path.join(directory, "src/b.ts");
 				const fileC = path.join(directory, "src/c.ts");
-				computeAffectedFiles(directory, undefined);
+				computeAffectedFiles(directory, undefined, TEST_KEY);
 				seedCache(cacheFile, [fileA, fileB, fileC]);
 				fs.writeFileSync(fileA, "export function a(): number { return 42; }\n");
 				touch(fileA);
@@ -187,7 +211,7 @@ describe("applyTypeAwareInvalidation", () => {
 				const fileA = path.join(directory, "src/a.ts");
 				const fileB = path.join(directory, "src/b.ts");
 				const fileC = path.join(directory, "src/c.ts");
-				computeAffectedFiles(directory, undefined);
+				computeAffectedFiles(directory, undefined, TEST_KEY);
 				seedCache(cacheFile, [fileA, fileB, fileC]);
 				fs.writeFileSync(fileA, "export function a() { return 'now a string'; }\n");
 				touch(fileA);
@@ -221,7 +245,7 @@ describe("applyTypeAwareInvalidation", () => {
 				const fileA = path.join(directory, "src/a.ts");
 				const fileB = path.join(directory, "src/b.ts");
 				const fileGlobals = path.join(directory, "src/globals.ts");
-				computeAffectedFiles(directory, undefined);
+				computeAffectedFiles(directory, undefined, TEST_KEY);
 				seedCache(cacheFile, [fileA, fileB, fileGlobals]);
 				fs.writeFileSync(
 					fileGlobals,
@@ -257,7 +281,7 @@ describe("applyTypeAwareInvalidation", () => {
 				const cacheFile = path.join(directory, ".eslintcache");
 				const fileA = path.join(directory, "src/a.ts");
 				const fileB = path.join(directory, "src/b.ts");
-				computeAffectedFiles(directory, undefined);
+				computeAffectedFiles(directory, undefined, TEST_KEY);
 				seedCache(cacheFile, [fileA, fileB]);
 				fs.writeFileSync(fileA, "export function a() { return 'string now'; }\n");
 				touch(fileA);
@@ -298,7 +322,10 @@ describe("applyTypeAwareInvalidation", () => {
 				expect(outcome.invalidated).toStrictEqual([]);
 				expect(
 					fs.existsSync(
-						path.join(directory, "node_modules/.cache/isentinel-lint/tsbuildinfo-full"),
+						path.join(
+							directory,
+							`node_modules/.cache/isentinel-lint/tsbuildinfo-full-${TEST_KEY}`,
+						),
 					),
 				).toBe(true);
 				expect(cacheHasEntry(cacheFile, fileA)).toBe(true);
@@ -374,11 +401,11 @@ describe("composeCommands typed-pass skip", () => {
 				"tsconfig.json": TSCONFIG,
 			},
 			(directory) => {
-				const cacheFile = path.join(directory, CACHE_FILE_TYPE_AWARE);
+				const cacheFile = path.join(directory, TYPE_AWARE_CACHE);
 				const fileA = path.join(directory, "src/a.ts");
 				// Establish builder state and seed the cache so a.ts is neither
 				// mtime-dirty nor builder-affected on the next run.
-				computeAffectedFiles(directory, "only");
+				computeAffectedFiles(directory, "only", TEST_KEY);
 				seedCache(cacheFile, [fileA]);
 
 				const { commands, notice } = withoutGitEnvironment(() => {
@@ -407,9 +434,9 @@ describe("composeCommands typed-pass skip", () => {
 				"tsconfig.json": TSCONFIG,
 			},
 			(directory) => {
-				const cacheFile = path.join(directory, CACHE_FILE_TYPE_AWARE);
+				const cacheFile = path.join(directory, TYPE_AWARE_CACHE);
 				const fileA = path.join(directory, "src/a.ts");
-				computeAffectedFiles(directory, "only");
+				computeAffectedFiles(directory, "only", TEST_KEY);
 				seedCache(cacheFile, [fileA]);
 
 				// "src" is in-cwd and clean, but "../elsewhere" escapes cwd, so
@@ -438,9 +465,9 @@ describe("composeCommands typed-pass skip", () => {
 				"tsconfig.json": TSCONFIG,
 			},
 			(directory) => {
-				const cacheFile = path.join(directory, CACHE_FILE_TYPE_AWARE);
+				const cacheFile = path.join(directory, TYPE_AWARE_CACHE);
 				const fileA = path.join(directory, "src/a.ts");
-				computeAffectedFiles(directory, "only");
+				computeAffectedFiles(directory, "only", TEST_KEY);
 				seedCache(cacheFile, [fileA]);
 
 				const { commands, notice } = withoutGitEnvironment(() => {
@@ -459,7 +486,7 @@ describe("composeCommands typed-pass skip", () => {
 });
 
 describe("plan mutation", () => {
-	const buildInfo = "node_modules/.cache/isentinel-lint/tsbuildinfo-typeaware";
+	const buildInfo = `node_modules/.cache/isentinel-lint/tsbuildinfo-typeaware-${TEST_KEY}`;
 
 	it("performs no I/O mutation in read-only (print) mode", () => {
 		expect.hasAssertions();
@@ -470,7 +497,7 @@ describe("plan mutation", () => {
 				"tsconfig.json": TSCONFIG,
 			},
 			(directory) => {
-				const cacheFile = path.join(directory, CACHE_FILE_TYPE_AWARE);
+				const cacheFile = path.join(directory, TYPE_AWARE_CACHE);
 				const fileA = path.join(directory, "src/a.ts");
 				seedCache(cacheFile, [fileA]);
 
@@ -503,9 +530,9 @@ describe("plan mutation", () => {
 				"tsconfig.json": TSCONFIG,
 			},
 			(directory) => {
-				const cacheFile = path.join(directory, CACHE_FILE_TYPE_AWARE);
+				const cacheFile = path.join(directory, TYPE_AWARE_CACHE);
 				const fileA = path.join(directory, "src/a.ts");
-				computeAffectedFiles(directory, "only");
+				computeAffectedFiles(directory, "only", TEST_KEY);
 				seedCache(cacheFile, [fileA]);
 
 				const runPlan = withoutGitEnvironment(() => {
@@ -517,6 +544,95 @@ describe("plan mutation", () => {
 				expect(typed?.skipReason).toMatch(/skipping the type-aware/);
 			},
 		);
+	});
+});
+
+describe("per-variant cache isolation", () => {
+	/**
+	 * Seed a warm type-aware cache for one variant: establish its builder state
+	 * so nothing is affected, then record `src/a.ts` as already linted.
+	 *
+	 * @param directory - The fixture root.
+	 * @param environment - The environment identifying the variant.
+	 * @returns The absolute path to the variant's seeded cache file.
+	 */
+	function seedVariant(directory: string, environment: NodeJS.ProcessEnv): string {
+		const key = resolveCacheKey(environment);
+		const cacheFile = path.join(directory, cacheFileFor(CACHE_FILE_TYPE_AWARE, key));
+		computeAffectedFiles(directory, "only", key);
+		seedCache(cacheFile, [path.join(directory, "src/a.ts")]);
+		return cacheFile;
+	}
+
+	it("keeps both caches warm when agent and non-agent runs alternate", () => {
+		expect.hasAssertions();
+
+		withFixture(VARIANT_FIXTURE, (directory) => {
+			const humanCache = seedVariant(directory, {});
+			const agentCache = seedVariant(directory, AGENT_ENVIRONMENT);
+
+			withoutGitEnvironment(() => {
+				plan(parseArguments([]), directory, AGENT_ENVIRONMENT, true);
+				plan(parseArguments([]), directory, {}, true);
+				plan(parseArguments([]), directory, AGENT_ENVIRONMENT, true);
+			});
+
+			// Before the split, each run rewrote the single cache with its own
+			// resolved config, so the other variant re-linted everything.
+			expect(fs.existsSync(humanCache)).toBe(true);
+			expect(fs.existsSync(agentCache)).toBe(true);
+		});
+	});
+
+	it("busts only the stale variant when the config changes", () => {
+		expect.hasAssertions();
+
+		withFixture(VARIANT_FIXTURE, (directory) => {
+			const humanCache = seedVariant(directory, {});
+			const agentCache = seedVariant(directory, AGENT_ENVIRONMENT);
+
+			// The config now post-dates the agent cache but not the human one.
+			const configSeconds = Date.now() / 1000 + 60;
+			fs.utimesSync(path.join(directory, "eslint.config.ts"), configSeconds, configSeconds);
+			fs.utimesSync(humanCache, configSeconds + 60, configSeconds + 60);
+
+			withoutGitEnvironment(() => plan(parseArguments([]), directory, {}, true));
+
+			expect(fs.existsSync(agentCache)).toBe(false);
+			expect(fs.existsSync(humanCache)).toBe(true);
+		});
+	});
+
+	it("never deletes a stale cache in read-only (print) mode", () => {
+		expect.hasAssertions();
+
+		withFixture(VARIANT_FIXTURE, (directory) => {
+			const agentCache = seedVariant(directory, AGENT_ENVIRONMENT);
+			const configSeconds = Date.now() / 1000 + 60;
+			fs.utimesSync(path.join(directory, "eslint.config.ts"), configSeconds, configSeconds);
+
+			withoutGitEnvironment(() => plan(parseArguments([]), directory, {}, false));
+
+			expect(fs.existsSync(agentCache)).toBe(true);
+		});
+	});
+
+	it("keys the builder state per variant", () => {
+		expect.hasAssertions();
+
+		withFixture(VARIANT_FIXTURE, (directory) => {
+			computeAffectedFiles(directory, "only", TEST_KEY);
+			computeAffectedFiles(directory, "only", AGENT_KEY);
+
+			const stateDirectory = path.join(directory, "node_modules", ".cache", "isentinel-lint");
+
+			expect(
+				fs.existsSync(path.join(stateDirectory, `tsbuildinfo-typeaware-${TEST_KEY}`)),
+			).toBe(true);
+			expect(
+				fs.existsSync(path.join(stateDirectory, `tsbuildinfo-typeaware-${AGENT_KEY}`)),
+			).toBe(true);
+		});
 	});
 });
 
@@ -535,7 +651,7 @@ describe("resolveJsonModule invalidation", () => {
 				const cacheFile = path.join(directory, ".eslintcache");
 				const fileB = path.join(directory, "src/b.ts");
 				const fileData = path.join(directory, "src/data.json");
-				computeAffectedFiles(directory, undefined);
+				computeAffectedFiles(directory, undefined, TEST_KEY);
 				seedCache(cacheFile, [fileB]);
 				fs.writeFileSync(fileData, '{ "value": "now a string" }\n');
 				touch(fileData);

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -1,4 +1,4 @@
-// cspell:words typeaware lintable mtimes
+// cspell:words typeaware lintable mtimes CLAUDECODE
 import fileEntryCache from "file-entry-cache";
 import fs from "node:fs";
 import os from "node:os";
@@ -6,7 +6,13 @@ import path from "node:path";
 import process from "node:process";
 import { describe, expect, it, vi } from "vitest";
 
-import { clearAllCaches, isCacheBusted, listDirtyFiles } from "../src/lint-cli/cache.ts";
+import { resolveCacheKey } from "../src/lint-cli/cache-key.ts";
+import {
+	clearAllCaches,
+	isCacheBusted,
+	listDirtyFiles,
+	sweepStaleCaches,
+} from "../src/lint-cli/cache.ts";
 import {
 	buildShellCommand,
 	composeEslintCommand,
@@ -21,8 +27,10 @@ import {
 } from "../src/lint-cli/concurrency.ts";
 import {
 	ALL_CACHE_FILES,
+	CACHE_FILE_DEFAULT,
 	CACHE_FILE_FAST,
 	CACHE_FILE_TYPE_AWARE,
+	cacheFileFor,
 } from "../src/lint-cli/constants.ts";
 import { collectLintableFiles, collectRepoFiles } from "../src/lint-cli/files.ts";
 import type { RepoFiles } from "../src/lint-cli/files.ts";
@@ -39,7 +47,11 @@ import {
 	resolveOxlintRun,
 } from "../src/lint-cli/hybrid.ts";
 import { parseArguments } from "../src/lint-cli/options.ts";
-import { applyPackageJsonBust, computePackageJsonHash } from "../src/lint-cli/package-hash.ts";
+import {
+	applyPackageJsonBust,
+	computePackageJsonHash,
+	packageHashStatePath,
+} from "../src/lint-cli/package-hash.ts";
 import { composeCommands, plan, runConcurrent, runLint } from "../src/lint-cli/run.ts";
 import type { ChildCommand, ComposeContext, LintCliOptions } from "../src/lint-cli/types.ts";
 import { CliError } from "../src/lint-cli/types.ts";
@@ -89,6 +101,19 @@ function withTemporaryDirectory(run: (directory: string) => void): void {
 
 function workerCount(dirty: number, perWorker: number, max: number): "off" | number {
 	return computeWorkerCount({ dirtyCount: dirty, filesPerWorker: perWorker, maxWorkers: max });
+}
+
+/**
+ * The keyed cache file name a run under `environment` writes for a pass. Cache
+ * files carry a config-variant key, so assertions derive the name rather than
+ * hardcoding it.
+ *
+ * @param baseName - The pass's cache base name.
+ * @param environment - The environment the run resolves its key from.
+ * @returns The keyed cache file name.
+ */
+function keyedCacheFile(baseName: string, environment: NodeJS.ProcessEnv = {}): string {
+	return cacheFileFor(baseName, resolveCacheKey(environment));
 }
 
 function seedFileCache(cacheFile: string, files: Array<string>): void {
@@ -300,6 +325,112 @@ describe("cache helpers", () => {
 			for (const name of ALL_CACHE_FILES) {
 				expect(fs.existsSync(path.join(directory, name))).toBe(false);
 			}
+		});
+	});
+
+	it("clears keyed cache variants, not just the base names", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const variants = ALL_CACHE_FILES.flatMap((name) => [
+				cacheFileFor(name, "aaaa1111"),
+				cacheFileFor(name, "bbbb2222"),
+			]);
+			for (const name of variants) {
+				fs.writeFileSync(path.join(directory, name), "{}");
+			}
+
+			clearAllCaches(directory);
+
+			for (const name of variants) {
+				expect(fs.existsSync(path.join(directory, name))).toBe(false);
+			}
+		});
+	});
+
+	describe("sweepStaleCaches", () => {
+		/**
+		 * Write a cache file whose mtime sits a fixed offset from the bust
+		 * file's, so staleness never depends on filesystem timestamp
+		 * resolution.
+		 *
+		 * @param filePath - The cache file to write.
+		 * @param mtimeSeconds - The mtime to stamp it with, in seconds.
+		 */
+		function writeCacheAt(filePath: string, mtimeSeconds: number): void {
+			fs.writeFileSync(filePath, "{}");
+			fs.utimesSync(filePath, mtimeSeconds, mtimeSeconds);
+		}
+
+		it("deletes only the individually stale variants", () => {
+			expect.hasAssertions();
+
+			withTemporaryDirectory((directory) => {
+				const configFile = path.join(directory, "eslint.config.ts");
+				const bustSeconds = Date.now() / 1000;
+				fs.writeFileSync(configFile, "export default [];");
+				fs.utimesSync(configFile, bustSeconds, bustSeconds);
+
+				const stale = path.join(directory, cacheFileFor(CACHE_FILE_FAST, "aaaa1111"));
+				const fresh = path.join(directory, cacheFileFor(CACHE_FILE_FAST, "bbbb2222"));
+				writeCacheAt(stale, bustSeconds - 60);
+				writeCacheAt(fresh, bustSeconds + 60);
+
+				const removed = sweepStaleCaches(directory, bustSeconds * 1000);
+
+				expect(removed).toStrictEqual([stale]);
+				expect(fs.existsSync(stale)).toBe(false);
+				expect(fs.existsSync(fresh)).toBe(true);
+			});
+		});
+
+		it("deletes nothing when there is no bust file", () => {
+			expect.hasAssertions();
+
+			withTemporaryDirectory((directory) => {
+				const cacheFile = path.join(directory, cacheFileFor(CACHE_FILE_FAST, "aaaa1111"));
+				fs.writeFileSync(cacheFile, "{}");
+
+				expect(sweepStaleCaches(directory, undefined)).toStrictEqual([]);
+				expect(fs.existsSync(cacheFile)).toBe(true);
+			});
+		});
+	});
+
+	describe("resolveCacheKey", () => {
+		it("separates the agent, editor, CI and default variants", () => {
+			expect.hasAssertions();
+
+			const keys = [
+				resolveCacheKey({}),
+				resolveCacheKey({ CLAUDECODE: "1" }),
+				resolveCacheKey({ VSCODE_PID: "1" }),
+				resolveCacheKey({ CI: "true" }),
+			];
+
+			const unique = new Set(keys);
+
+			expect(unique.size).toBe(keys.length);
+		});
+
+		it("pins a git-hook run to the same variant as a plain run", () => {
+			expect.hasAssertions();
+
+			// `isInAgentSession` and `isInEditorEnvironment` both return false
+			// under GIT_HOOK, so a hook run shares the no-agent cache rather than
+			// opening a third one.
+			expect(resolveCacheKey({ CLAUDECODE: "1", GIT_HOOK: "1" })).toBe(resolveCacheKey({}));
+		});
+
+		it("honours the ISENTINEL_LINT_CACHE_KEY escape hatch", () => {
+			expect.hasAssertions();
+
+			expect(resolveCacheKey({ ISENTINEL_LINT_CACHE_KEY: "strict" })).not.toBe(
+				resolveCacheKey({}),
+			);
+			expect(resolveCacheKey({ ISENTINEL_LINT_CACHE_KEY: "strict" })).toBe(
+				resolveCacheKey({ ISENTINEL_LINT_CACHE_KEY: "strict" }),
+			);
 		});
 	});
 
@@ -559,9 +690,9 @@ describe("composeCommands --print", () => {
 		withTemporaryDirectory((directory) => {
 			expect(printLines([], directory)).toStrictEqual([
 				"oxlint --type-aware .",
-				"ESLINT_TYPE_AWARE=off eslint --cache --cache-location .eslintcache-fast " +
+				`ESLINT_TYPE_AWARE=off eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_FAST)} ` +
 					"--no-warn-ignored --concurrency off .",
-				"ESLINT_TYPE_AWARE=only eslint --cache --cache-location .eslintcache-typeaware " +
+				`ESLINT_TYPE_AWARE=only eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_TYPE_AWARE)} ` +
 					"--no-warn-ignored --concurrency off .",
 			]);
 		});
@@ -573,7 +704,7 @@ describe("composeCommands --print", () => {
 		withTemporaryDirectory((directory) => {
 			expect(printLines(["--type-aware=off"], directory)).toStrictEqual([
 				"oxlint .",
-				"ESLINT_TYPE_AWARE=off eslint --cache --cache-location .eslintcache-fast " +
+				`ESLINT_TYPE_AWARE=off eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_FAST)} ` +
 					"--no-warn-ignored --concurrency off .",
 			]);
 		});
@@ -585,7 +716,7 @@ describe("composeCommands --print", () => {
 		withTemporaryDirectory((directory) => {
 			expect(printLines(["--type-aware=only"], directory)).toStrictEqual([
 				"oxlint --type-aware .",
-				"ESLINT_TYPE_AWARE=only eslint --cache --cache-location .eslintcache-typeaware " +
+				`ESLINT_TYPE_AWARE=only eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_TYPE_AWARE)} ` +
 					"--no-warn-ignored --concurrency off .",
 			]);
 		});
@@ -597,7 +728,7 @@ describe("composeCommands --print", () => {
 		withTemporaryDirectory((directory) => {
 			expect(printLines(["--type-aware=full"], directory)).toStrictEqual([
 				"oxlint --type-aware .",
-				"eslint --cache --cache-location .eslintcache --no-warn-ignored --concurrency off .",
+				`eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_DEFAULT)} --no-warn-ignored --concurrency off .`,
 			]);
 		});
 	});
@@ -608,8 +739,7 @@ describe("composeCommands --print", () => {
 		withTemporaryDirectory((directory) => {
 			expect(printLines([], directory, { CI: "true" })).toStrictEqual([
 				"oxlint --type-aware .",
-				"eslint --cache --cache-location .eslintcache --no-warn-ignored --concurrency off " +
-					"--cache-strategy content .",
+				`eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_DEFAULT, { CI: "true" })} --no-warn-ignored --concurrency off --cache-strategy content .`,
 			]);
 		});
 	});
@@ -620,8 +750,7 @@ describe("composeCommands --print", () => {
 		withTemporaryDirectory((directory) => {
 			expect(printLines(["--fix"], directory)).toStrictEqual([
 				"oxlint --type-aware --fix .",
-				"eslint --cache --cache-location .eslintcache --no-warn-ignored --concurrency off " +
-					"--fix .",
+				`eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_DEFAULT)} --no-warn-ignored --concurrency off --fix .`,
 			]);
 		});
 	});
@@ -717,10 +846,18 @@ describe("applyPackageJsonBust", () => {
 		fs.writeFileSync(path.join(directory, "package.json"), JSON.stringify(value));
 	}
 
+	const key = resolveCacheKey({});
+
 	function seedCaches(directory: string): void {
 		for (const name of ALL_CACHE_FILES) {
-			fs.writeFileSync(path.join(directory, name), "{}");
+			fs.writeFileSync(path.join(directory, cacheFileFor(name, key)), "{}");
 		}
+	}
+
+	function everyCacheExists(directory: string): boolean {
+		return ALL_CACHE_FILES.every((name) => {
+			return fs.existsSync(path.join(directory, cacheFileFor(name, key)));
+		});
 	}
 
 	it("stores the hash without busting on the first run", () => {
@@ -730,13 +867,10 @@ describe("applyPackageJsonBust", () => {
 			writePackageJson(directory, { exports: "./index.js" });
 			seedCaches(directory);
 
-			const outcome = applyPackageJsonBust(directory);
+			const outcome = applyPackageJsonBust(directory, key);
 
 			expect(outcome).toStrictEqual({ busted: false, firstRun: true });
-
-			for (const name of ALL_CACHE_FILES) {
-				expect(fs.existsSync(path.join(directory, name))).toBe(true);
-			}
+			expect(everyCacheExists(directory)).toBe(true);
 		});
 	});
 
@@ -745,16 +879,22 @@ describe("applyPackageJsonBust", () => {
 
 		withTemporaryDirectory((directory) => {
 			writePackageJson(directory, { exports: "./index.js" });
-			applyPackageJsonBust(directory);
+			applyPackageJsonBust(directory, key);
 			seedCaches(directory);
 
 			writePackageJson(directory, { exports: "./other.js" });
-			const outcome = applyPackageJsonBust(directory);
+			const outcome = applyPackageJsonBust(directory, key);
 
 			expect(outcome).toStrictEqual({ busted: true, firstRun: false });
-			expect(fs.existsSync(path.join(directory, CACHE_FILE_TYPE_AWARE))).toBe(false);
-			expect(fs.existsSync(path.join(directory, ".eslintcache"))).toBe(false);
-			expect(fs.existsSync(path.join(directory, CACHE_FILE_FAST))).toBe(true);
+			expect(
+				fs.existsSync(path.join(directory, cacheFileFor(CACHE_FILE_TYPE_AWARE, key))),
+			).toBe(false);
+			expect(fs.existsSync(path.join(directory, cacheFileFor(CACHE_FILE_DEFAULT, key)))).toBe(
+				false,
+			);
+			expect(fs.existsSync(path.join(directory, cacheFileFor(CACHE_FILE_FAST, key)))).toBe(
+				true,
+			);
 		});
 	});
 
@@ -763,7 +903,7 @@ describe("applyPackageJsonBust", () => {
 
 		withTemporaryDirectory((directory) => {
 			writePackageJson(directory, { exports: "./index.js", scripts: { build: "tsc" } });
-			applyPackageJsonBust(directory);
+			applyPackageJsonBust(directory, key);
 			seedCaches(directory);
 
 			writePackageJson(directory, {
@@ -771,14 +911,57 @@ describe("applyPackageJsonBust", () => {
 				scripts: { build: "tsc --noEmit" },
 				version: "9.9.9",
 			});
-			const outcome = applyPackageJsonBust(directory);
+			const outcome = applyPackageJsonBust(directory, key);
 
 			expect(outcome).toStrictEqual({ busted: false, firstRun: false });
-
-			for (const name of ALL_CACHE_FILES) {
-				expect(fs.existsSync(path.join(directory, name))).toBe(true);
-			}
+			expect(everyCacheExists(directory)).toBe(true);
 		});
+	});
+
+	it("lets each variant observe the same bump independently", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const agentKey = resolveCacheKey({ CLAUDECODE: "1" });
+			writePackageJson(directory, { exports: "./index.js" });
+			applyPackageJsonBust(directory, key);
+			applyPackageJsonBust(directory, agentKey);
+
+			seedCaches(directory);
+			for (const name of ALL_CACHE_FILES) {
+				fs.writeFileSync(path.join(directory, cacheFileFor(name, agentKey)), "{}");
+			}
+
+			writePackageJson(directory, { exports: "./other.js" });
+
+			// The no-agent run busts only its own caches, and crucially does not
+			// consume the bump on the agent variant's behalf: a shared state file
+			// would make the second call a no-op and leave the agent's type-aware
+			// caches permanently stale.
+			expect(applyPackageJsonBust(directory, key)).toStrictEqual({
+				busted: true,
+				firstRun: false,
+			});
+			expect(
+				fs.existsSync(path.join(directory, cacheFileFor(CACHE_FILE_TYPE_AWARE, agentKey))),
+			).toBe(true);
+
+			expect(applyPackageJsonBust(directory, agentKey)).toStrictEqual({
+				busted: true,
+				firstRun: false,
+			});
+			expect(
+				fs.existsSync(path.join(directory, cacheFileFor(CACHE_FILE_TYPE_AWARE, agentKey))),
+			).toBe(false);
+		});
+	});
+
+	it("stores each variant's hash under its own state file", () => {
+		expect.hasAssertions();
+
+		expect(packageHashStatePath("/project", "aaaa1111")).not.toBe(
+			packageHashStatePath("/project", "bbbb2222"),
+		);
 	});
 
 	it("hashes resolution fields independent of key order", () => {
@@ -1415,7 +1598,7 @@ describe("explicit --type-aware selection in CI", () => {
 		withTemporaryDirectory((directory) => {
 			expect(printLines(["--type-aware=only"], directory, { CI: "true" })).toStrictEqual([
 				"oxlint --type-aware .",
-				"ESLINT_TYPE_AWARE=only eslint --cache --cache-location .eslintcache-typeaware " +
+				`ESLINT_TYPE_AWARE=only eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_TYPE_AWARE, { CI: "true" })} ` +
 					"--no-warn-ignored --concurrency off --cache-strategy content .",
 			]);
 		});
@@ -1427,7 +1610,7 @@ describe("explicit --type-aware selection in CI", () => {
 		withTemporaryDirectory((directory) => {
 			expect(printLines(["--type-aware=off"], directory, { CI: "true" })).toStrictEqual([
 				"oxlint .",
-				"ESLINT_TYPE_AWARE=off eslint --cache --cache-location .eslintcache-fast " +
+				`ESLINT_TYPE_AWARE=off eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_FAST, { CI: "true" })} ` +
 					"--no-warn-ignored --concurrency off --cache-strategy content .",
 			]);
 		});


### PR DESCRIPTION
Fixes #595.

## Problem

ESLint stores a `hashOfConfig` per cache entry, so two runs that resolve different configs invalidate each other's entries wholesale when they share a cache file. Agent and human runs *do* resolve different configs, and both wrote to the same file — so each switch destroyed the other's entries. Alternating re-lints the whole project in both directions, forever.

Measured on a 3128-file consumer project: **17.3s stable-env vs ~42s on any alternation**, ~25s wasted per switch.

Two independent causes, confirmed by `--print-config` diff with all six agent env vars isolated:

| Pass | Rule delta | Cause |
|---|---|---|
| typed | `roblox/lua-truthiness`, `roblox/no-array-pairs` warn→error | this preset (`factory.ts:293-297`) |
| fast | `stop-it/no-unused-imports` error→off | the **consumer's own** config |

Ground-truth hashes from real scratch caches: `off` 1a2flr4→e9j2dq, `only` 9dwe7v→128vt94. Both passes flip.

## Fix

Give each config variant its own cache file, keyed by an 8-char hash of `[isInAgentSession, isInEditorEnvironment, isCi, ISENTINEL_LINT_CACHE_KEY]`. Nothing is invalidated; variants simply stop overwriting each other.

`ISENTINEL_LINT_CACHE_KEY` is an escape hatch: consumer-authored config branches (the fast-pass cause above) are invisible to any key this preset derives.

The key is env-derived rather than config-derived because hashing the resolved config costs a full `eslint --print-config` (~4.6s/run, measured), and the key stored in an existing cache describes the *previous* run.

### Two correctness prerequisites

Splitting the caches breaks a 1:1 invariant that two runner-owned mechanisms rely on — both keyed per-*mode*, not per-variant, and both invisible to ESLint's own `hashOfConfig`:

1. **Builder state** (`affected.ts`) is drained destructively. An agent run would advance the buildinfo while invalidating only its own cache; the next human run sees an empty affected set with stale entries in its warm cache, and since those mtimes never changed the typed pass auto-skips — **silent stale diagnostics**. Now keyed per variant.
2. **package.json resolution hash** (`package-hash.ts`) is consumed once. A shared state file lets the first variant absorb a dependency bump on every other variant's behalf. Now keyed per variant. Still deliberately spares the fast cache (a syntactic lint is immune to resolution changes).

### Bust sweep

`isCacheStale` reports a *missing* file as fresh, and the old gate was all-or-nothing over only the selected passes. That let an unselected stale variant survive a config edit and then wipe every fresh variant on the next run — the same mutual invalidation, relocated to the config-edit path. Replaced with a per-file sweep over `.eslintcache*`, in the same load-bearing position (before sizing), still gated so `--print` never deletes.

### Sizing

No new logic needed: a variant switch means the cache file is absent, which `mutatingDirtyCount` already treats as fully dirty, so the pass gets full concurrency instead of being sized against a cache it is about to miss entirely.

## Also

- `hk.pkl`: oxlint + eslint steps folded into one `isentinel-lint` step, with a `build` step it `depends` on — the CLI shims to `dist/`, and hk runs steps concurrently.
- CI cache path and `.gitignore` widened to `.eslintcache*`.

## Rejected alternatives

- **Report-time promotion** (`--max-warnings 0`): only fixes the preset's severity flip, leaves the consumer-caused fast-pass flip in place.
- **Severity projection** (rewrite cached severities, no linting): same gap — `stop-it/no-unused-imports` goes error→*off*, not a severity change at all.
- **Re-lint with only the changed rules**: measured ~20% saving on the typed pass, ~0% on the fast pass (1 rule costs the same as 1160), and ~4.6s to discover the diff. Net zero.

## Verification

`pnpm lint`, `pnpm typecheck`, `pnpm test` all pass (290 tests). 12 new tests, including end-to-end `plan()` runs asserting that alternating runs keep both caches warm, that a config edit busts only the individually stale variant, that both state files are keyed, and that `--print` never deletes.

Known flake, pre-existing and unrelated: the fixture specs failed once in 14 full-suite runs under parallel load, passing in isolation. Filed separately.

https://claude.ai/code/session_01SSYa5vWQgRQF3RJ9kPvGRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ESLint caches are now separated by configuration variant, including agent, editor, and CI environments.
  * Added support for a custom cache key to prevent collisions when configuration depends on undetected environment values.
  * Stale cache files are automatically identified and cleaned up without affecting active variants.

* **Documentation**
  * Updated linting documentation with cache naming, isolation, and invalidation details.

* **Bug Fixes**
  * Improved cache and type-aware state handling to prevent cross-configuration interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->