### PR TITLE
fix(lint-cli): follow project references for solution-style tsconfigs

### DIFF
--- a/src/lint-cli/affected.ts
+++ b/src/lint-cli/affected.ts
@@ -1,10 +1,14 @@
 // cspell:words tsbuildinfo typeaware buildinfo mtimes normalised stabilise
+// cspell:words unparseable slugified sanitise optimisation unsuffixed
+import crypto from "node:crypto";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import process from "node:process";
 import type * as TypeScript from "typescript";
 
+import { CACHE_KEY_LENGTH } from "./cache-key.ts";
+import { toPosix } from "./paths.ts";
 import type { TypeAwareMode } from "./types.ts";
 
 /** Result of a builder pass over the consumer's program. */
@@ -22,7 +26,35 @@ export interface AffectedResult {
 	firstRun: boolean;
 }
 
-let warned = false;
+/** One resolved TypeScript project that actually owns source files. */
+interface ResolvedProject {
+	/** Digest of the project's config path, discriminating its buildinfo. */
+	id: string;
+	/** The absolute root file names the builder compiles. */
+	fileNames: Array<string>;
+	/** The project's own parsed compiler options. */
+	options: TypeScript.CompilerOptions;
+}
+
+/** One builder pass over a single resolved project. */
+interface BuilderRun {
+	/** The variant's buildinfo file (see {@link builderStatePath}). */
+	buildInfoPath: string;
+	/** The resolved project to build (see {@link collectProjects}). */
+	project: ResolvedProject;
+	/** The resolved TypeScript module. */
+	ts: typeof TypeScript;
+}
+
+/** Outcome of a project-reference walk (see {@link collectProjects}). */
+interface ProjectWalkResult {
+	/** False when the entry tsconfig itself could not be read. */
+	entryReadable: boolean;
+	/** Every file-owning project reachable from the entry config. */
+	projects: Array<ResolvedProject>;
+}
+
+const warned = new Set<string>();
 
 /**
  * Resolve the builder incremental-state (`.tsbuildinfo`) file for a mode and
@@ -43,21 +75,20 @@ let warned = false;
  * @param cwd - The consumer project root.
  * @param mode - The active ESLint type-aware mode (never `"off"` here).
  * @param key - The config-variant key from `resolveCacheKey`.
+ * @param projectId - {@link projectDigest} of the project's tsconfig. Every
+ *   project is suffixed, including the entry one: a solution's members each
+ *   need their own state, and an unsuffixed special case for the entry config
+ *   would make `${key}` and `${key}-${digest}` ambiguous to parse back.
  * @returns The absolute path to the mode's buildinfo file.
  */
 export function builderStatePath(
 	cwd: string,
 	mode: TypeAwareMode | undefined,
 	key: string,
+	projectId: string,
 ): string {
 	const suffix = mode === "only" ? "typeaware" : "full";
-	return path.join(
-		cwd,
-		"node_modules",
-		".cache",
-		"isentinel-lint",
-		`tsbuildinfo-${suffix}-${key}`,
-	);
+	return path.join(builderStateDirectory(cwd), `tsbuildinfo-${suffix}-${key}-${projectId}`);
 }
 
 /**
@@ -95,12 +126,187 @@ export function computeAffectedFiles(
 	}
 
 	try {
-		return runBuilder(ts, configPath, builderStatePath(cwd, mode, key));
+		const { entryReadable, projects } = collectProjects(ts, configPath);
+
+		if (projects.length === 0) {
+			// A parse failure already emitted a precise message naming the file,
+			// so only the genuinely-empty case — a readable config whose files,
+			// includes and references resolve to nothing — needs the generic one.
+			if (entryReadable) {
+				warnOnce(
+					`no TypeScript files resolved from ${path.basename(configPath)}; ` +
+						"skipping type-aware cache invalidation",
+				);
+			}
+
+			return undefined;
+		}
+
+		// Every project's state lands in this one directory, so create it once
+		// here rather than once per builder.
+		fs.mkdirSync(builderStateDirectory(cwd), { recursive: true });
+
+		const affected = new Set<string>();
+		let warmProjects = 0;
+		for (const project of projects) {
+			const result = runBuilder({
+				buildInfoPath: builderStatePath(cwd, mode, key, project.id),
+				project,
+				ts,
+			});
+
+			warmProjects += result.firstRun ? 0 : 1;
+			for (const file of result.affected) {
+				affected.add(file);
+			}
+		}
+
+		// The run counts as first only when NO project had prior state. Reporting
+		// first-run because a *single* project is new would be unsafe: builders
+		// are drained destructively, so every warm project's state would have
+		// advanced while the caller discarded its affected set — leaving stale
+		// cache entries whose mtimes never change and which nothing revisits.
+		// A newly added project instead contributes its whole file set, which
+		// over-invalidates (at worst tripping the bust threshold) rather than
+		// under-invalidating.
+		return { affected, firstRun: warmProjects === 0 };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		warnOnce(`type-aware cache invalidation failed: ${message}`);
 		return undefined;
 	}
+}
+
+/**
+ * The directory every builder state file lives in.
+ *
+ * @param cwd - The consumer project root.
+ * @returns The absolute path to the runner's cache directory.
+ */
+function builderStateDirectory(cwd: string): string {
+	return path.join(cwd, "node_modules", ".cache", "isentinel-lint");
+}
+
+/**
+ * Emit a warning at most once per distinct message. Keyed by message rather
+ * than a single global flag so per-project degradation (one unreadable
+ * reference among many) stays reportable instead of being swallowed by an
+ * earlier, unrelated warning.
+ *
+ * @param message - The warning text, also its dedupe key.
+ */
+function warnOnce(message: string): void {
+	if (warned.has(message)) {
+		return;
+	}
+
+	warned.add(message);
+	process.stderr.write(`isentinel-lint: ${message}\n`);
+}
+
+/**
+ * Derive a project's buildinfo discriminator from its canonical config path.
+ * Hashed rather than slugified so nested paths stay short and two configs that
+ * would sanitise to the same slug cannot collide.
+ *
+ * @param canonicalPath - The project's canonical tsconfig path.
+ * @returns A filename-safe hex digest.
+ */
+function projectDigest(canonicalPath: string): string {
+	return crypto
+		.createHash("sha256")
+		.update(canonicalPath)
+		.digest("hex")
+		.slice(0, CACHE_KEY_LENGTH);
+}
+
+/**
+ * Walk the project-reference graph from an entry tsconfig, collecting every
+ * project that owns files.
+ *
+ * `parseJsonConfigFileContent` does not follow `references`, so a
+ * solution-style tsconfig (`files: []`, `include: []`) resolves to zero file
+ * names on its own. Recursing gives referenced-project consumers real
+ * cross-file invalidation instead of a silent no-op. References nest — a
+ * referenced project may itself be solution-style — so this recurses rather
+ * than reading one level, and the visited set guards against reference cycles
+ * and diamond graphs.
+ *
+ * A referenced config that cannot be read is warned about and skipped rather
+ * than failing the whole walk: one broken reference should degrade invalidation
+ * for its own files, not for every sibling project.
+ *
+ * @param ts - The resolved TypeScript module.
+ * @param entryPath - The tsconfig to start from.
+ * @returns The file-owning projects and whether the entry config parsed.
+ */
+function collectProjects(ts: typeof TypeScript, entryPath: string): ProjectWalkResult {
+	const projects: Array<ResolvedProject> = [];
+	const seen = new Set<string>();
+	let entryReadable = true;
+
+	/**
+	 * Canonical form of a config path, for cycle detection and digesting.
+	 * TypeScript reaches the same file through differently-cased paths on a
+	 * case-insensitive filesystem, so fold case only there. Folding
+	 * unconditionally would collapse two genuinely distinct sibling configs
+	 * on a case-sensitive filesystem into one — dropping all but the first
+	 * from the walk and colliding their buildinfo digests.
+	 *
+	 * @param configPath - The path to canonicalize.
+	 * @returns The canonical form.
+	 */
+	function canonical(configPath: string): string {
+		const resolved = toPosix(path.resolve(configPath));
+		return ts.sys.useCaseSensitiveFileNames ? resolved : resolved.toLowerCase();
+	}
+
+	/**
+	 * Visit one config, recording it when it owns files and recursing into its
+	 * references.
+	 *
+	 * @param configPath - The tsconfig to resolve at this step.
+	 */
+	function walk(configPath: string): void {
+		const key = canonical(configPath);
+		if (seen.has(key)) {
+			return;
+		}
+
+		seen.add(key);
+
+		const configFile = ts.readConfigFile(configPath, (file) => ts.sys.readFile(file));
+		if (configFile.error !== undefined) {
+			warnOnce(`${configPath} could not be read; its files skip type-aware invalidation`);
+			if (configPath === entryPath) {
+				entryReadable = false;
+			}
+
+			return;
+		}
+
+		const parsed = ts.parseJsonConfigFileContent(
+			configFile.config,
+			ts.sys,
+			path.dirname(configPath),
+		);
+
+		if (parsed.fileNames.length > 0) {
+			projects.push({
+				id: projectDigest(key),
+				fileNames: parsed.fileNames,
+				options: parsed.options,
+			});
+		}
+
+		const references = parsed.projectReferences ?? [];
+		for (const reference of references) {
+			walk(ts.resolveProjectReferencePath(reference));
+		}
+	}
+
+	walk(entryPath);
+	return { entryReadable, projects };
 }
 
 /**
@@ -120,15 +326,6 @@ function loadTypescript(cwd: string): typeof TypeScript | undefined {
 	} catch {
 		return undefined;
 	}
-}
-
-function warnOnce(message: string): void {
-	if (warned) {
-		return;
-	}
-
-	warned = true;
-	process.stderr.write(`isentinel-lint: ${message}\n`);
 }
 
 /**
@@ -174,37 +371,39 @@ function collectAffected(
 }
 
 /**
+ * Persist the builder's incremental state by emitting ONLY the buildinfo.
+ * `program.emit` walks remaining affected files and writes the `.tsbuildinfo`;
+ * the writeFile callback swallows every other output so no JS/`.d.ts` reaches
+ * the consumer's tree.
+ *
+ * The emit is what computes each file's real declaration signature, so it
+ * cannot be swapped for the cheaper `emitBuildInfo`: without it the shape hash
+ * degrades to a source-text hash and every implementation-only edit invalidates
+ * all its importers.
+ *
+ * @param builder - The drained builder program.
+ * @param buildInfoPath - The variant's buildinfo file.
+ */
+function persistBuilderState(
+	builder: TypeScript.EmitAndSemanticDiagnosticsBuilderProgram,
+	buildInfoPath: string,
+): void {
+	const normalizedBuildInfo = path.normalize(buildInfoPath);
+	builder.emit(undefined, (fileName, data) => {
+		if (path.normalize(fileName) === normalizedBuildInfo) {
+			fs.writeFileSync(fileName, data);
+		}
+	});
+}
+
+/**
  * Drive the incremental builder: read prior state, drain the affected set
  * without reporting diagnostics, then persist updated state.
  *
- * @param ts - The resolved TypeScript module.
- * @param configPath - The resolved tsconfig path.
- * @param buildInfoPath - The variant's buildinfo file (see {@link builderStatePath}).
+ * @param build - The project, its state file, and the run's shared handles.
  * @returns The affected result.
  */
-function runBuilder(
-	ts: typeof TypeScript,
-	configPath: string,
-	buildInfoPath: string,
-): AffectedResult | undefined {
-	const configFile = ts.readConfigFile(configPath, (file) => ts.sys.readFile(file));
-	if (configFile.error !== undefined) {
-		warnOnce("tsconfig.json could not be read; skipping type-aware cache invalidation");
-		return undefined;
-	}
-
-	const basePath = path.dirname(configPath);
-	// Known limitation: `parseJsonConfigFileContent` does not follow project
-	// references, so a solution-style/project-reference tsconfig yields an empty
-	// `fileNames`. Builder invalidation then becomes a silent no-op and the
-	// runner falls back to plain mtime dirtiness — lint results stay correct,
-	// only cross-file type invalidation is skipped.
-	const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, basePath);
-	if (parsed.fileNames.length === 0) {
-		return { affected: new Set(), firstRun: false };
-	}
-
-	fs.mkdirSync(path.dirname(buildInfoPath), { recursive: true });
+function runBuilder({ buildInfoPath, project, ts }: BuilderRun): AffectedResult {
 	const firstRun = !fs.existsSync(buildInfoPath);
 
 	// Force the settings the shape-hash BFS depends on:
@@ -213,11 +412,21 @@ function runBuilder(
 	//   (unchanged public surface) does NOT propagate to importers. Without it,
 	//   the hash is the full-text hash and every dependent is invalidated.
 	// - `incremental: true` + `tsBuildInfoFile` persist state in OUR cache dir.
-	// - `composite`/`declarationMap` off, `noEmit` false: we DO emit so real
-	//   `.d.ts` signatures are computed, but the emit `writeFile` (below)
-	//   discards everything except the buildinfo, so nothing lands in the tree.
+	// - `composite`/`declarationMap` off, `noEmit` false: see
+	//   {@link persistBuilderState} for why we emit and what happens to it.
+	//
+	// Each project builds under its OWN options: a solution's members routinely
+	// disagree (different `lib`, `types`, `jsx`), and forcing the entry config's
+	// options onto all of them would resolve modules differently than the real
+	// build and skew the shape hashes.
+	//
+	// Project references are deliberately NOT forwarded to the builder. With
+	// `composite: false` the builder would look for referenced projects' emitted
+	// `.d.ts` outputs, which need not exist; letting each program resolve
+	// imports to sibling *sources* costs some duplicated work across projects
+	// but keeps cross-project shape hashing real.
 	const options: TypeScript.CompilerOptions = {
-		...parsed.options,
+		...project.options,
 		composite: false,
 		declaration: true,
 		declarationMap: false,
@@ -230,30 +439,34 @@ function runBuilder(
 	const host = ts.createIncrementalCompilerHost(options, ts.sys);
 	const oldProgram = ts.readBuilderProgram(options, host);
 	const builder = ts.createEmitAndSemanticDiagnosticsBuilderProgram(
-		parsed.fileNames,
+		project.fileNames,
 		options,
 		host,
 		oldProgram,
 	);
 
 	const affected = new Set<string>();
+	let touched = false;
 	let next = builder.getSemanticDiagnosticsOfNextAffectedFile();
 	while (next !== undefined) {
 		// We deliberately discard `next.result` (the diagnostics); only the
-		// affected set matters here.
+		// affected set matters here. `touched` tracks the raw yield rather than
+		// `affected.size`, which excludes node_modules: a dependency-only change
+		// still advances builder state that must be persisted.
+		touched = true;
 		collectAffected(next.affected, affected);
 		next = builder.getSemanticDiagnosticsOfNextAffectedFile();
 	}
 
-	// Persist builder state by emitting ONLY the buildinfo. `program.emit` walks
-	// remaining affected files and writes the `.tsbuildinfo`; the writeFile
-	// callback swallows every other output so no JS/`.d.ts` reaches disk.
-	const normalizedBuildInfo = path.normalize(buildInfoPath);
-	builder.emit(undefined, (fileName, data) => {
-		if (path.normalize(fileName) === normalizedBuildInfo) {
-			fs.writeFileSync(fileName, data);
-		}
-	});
+	// The builder found nothing affected, so the state on disk already describes
+	// this program and re-emitting would reproduce it byte for byte. Skipping is
+	// not just an optimisation: with the affected queue drained, `emit` falls
+	// back to walking the WHOLE program, which on a large project costs tens of
+	// seconds on every warm run — the common case this runner exists to make
+	// fast.
+	if (touched) {
+		persistBuilderState(builder, buildInfoPath);
+	}
 
 	return { affected, firstRun };
 }

--- a/src/lint-cli/cache-key.ts
+++ b/src/lint-cli/cache-key.ts
@@ -3,7 +3,7 @@ import crypto from "node:crypto";
 import { isCi, isInAgentSession, isInEditorEnvironment } from "../utils.ts";
 
 /** Length of the hex digest slice used to suffix cache and state files. */
-const CACHE_KEY_LENGTH = 8;
+export const CACHE_KEY_LENGTH = 8;
 
 /**
  * Environment variable a consumer sets to fold its own config branches into the

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -1,4 +1,4 @@
-// cspell:words tsbuildinfo typeaware globals CLAUDECODE
+// cspell:words tsbuildinfo typeaware globals CLAUDECODE normalised buildinfo
 import fileEntryCache from "file-entry-cache";
 import fs from "node:fs";
 import { createRequire } from "node:module";
@@ -85,6 +85,52 @@ function withFixture(files: Record<string, string>, run: (directory: string) => 
 	}
 }
 
+/**
+ * A solution-style entry tsconfig whose files all live behind `references`, one
+ * of them behind a *nested* solution — the shape that made builder invalidation
+ * a silent no-op before reference resolution recursed.
+ */
+const SOLUTION_FIXTURE = {
+	"app/b.ts": "import { a } from '../src/a';\nexport function b() { return a(); }\n",
+	"app/tsconfig.json": JSON.stringify({
+		compilerOptions: { composite: true, module: "commonjs", strict: true, target: "es2020" },
+		include: ["."],
+	}),
+	"nested-solution/tsconfig.json": JSON.stringify({
+		files: [],
+		include: [],
+		references: [{ path: "../app" }],
+	}),
+	"src/a.ts": "export function a() { return 1; }\n",
+	"tsconfig.json": JSON.stringify({
+		files: [],
+		include: [],
+		references: [{ path: "./tsconfig.lib.json" }, { path: "./nested-solution" }],
+	}),
+	"tsconfig.lib.json": JSON.stringify({
+		compilerOptions: { composite: true, module: "commonjs", strict: true, target: "es2020" },
+		include: ["src"],
+	}),
+};
+
+/**
+ * Builder state files matching a prefix. Every project's buildinfo is suffixed
+ * with a digest of its tsconfig path, which is a temp directory here and so
+ * cannot be spelled out — tests match the stable prefix and count instead.
+ *
+ * @param directory - The fixture project root.
+ * @param prefix - The `tsbuildinfo-<mode>-<key>` prefix to match.
+ * @returns The matching file names, empty when the cache directory is absent.
+ */
+function builderStateFiles(directory: string, prefix: string): Array<string> {
+	const stateDirectory = path.join(directory, "node_modules/.cache/isentinel-lint");
+	if (!fs.existsSync(stateDirectory)) {
+		return [];
+	}
+
+	return fs.readdirSync(stateDirectory).filter((name) => name.startsWith(prefix));
+}
+
 function seedCache(cacheFile: string, files: Array<string>): void {
 	const cache = fileEntryCache.create(path.basename(cacheFile), path.dirname(cacheFile), false);
 	for (const file of files) {
@@ -158,6 +204,62 @@ describe("computeAffectedFiles", () => {
 			expect(computeAffectedFiles(directory, undefined, TEST_KEY)).toBeUndefined();
 		});
 	});
+
+	it("resolves files through a nested solution-style reference graph", () => {
+		expect.hasAssertions();
+
+		withFixture(SOLUTION_FIXTURE, (directory) => {
+			const first = computeAffectedFiles(directory, undefined, TEST_KEY);
+
+			expect(first?.firstRun).toBe(true);
+			// The entry tsconfig owns no files; both of these come from a
+			// referenced project, `app/b.ts` via a nested solution-style one.
+			// `affected` holds OS-normalised paths, so compare in that form.
+			expect(first?.affected).toContain(path.normalize(path.join(directory, "src/a.ts")));
+			expect(first?.affected).toContain(path.normalize(path.join(directory, "app/b.ts")));
+		});
+	});
+
+	it("keeps builder state per referenced project", () => {
+		expect.hasAssertions();
+
+		withFixture(SOLUTION_FIXTURE, (directory) => {
+			computeAffectedFiles(directory, "only", TEST_KEY);
+
+			// One per file-owning project (lib + app); the file-less entry
+			// tsconfig contributes no state of its own.
+			expect(builderStateFiles(directory, `tsbuildinfo-typeaware-${TEST_KEY}`)).toHaveLength(
+				2,
+			);
+		});
+	});
+
+	it("does not report first-run when only some projects are new", () => {
+		expect.hasAssertions();
+
+		withFixture(SOLUTION_FIXTURE, (directory) => {
+			// Warm every project, then drop one project's state so it looks newly
+			// added while its siblings stay warm — the shape of a solution that
+			// gains a reference.
+			computeAffectedFiles(directory, "only", TEST_KEY);
+			const stateDirectory = path.join(directory, "node_modules/.cache/isentinel-lint");
+			const prefix = `tsbuildinfo-typeaware-${TEST_KEY}`;
+			const stateFiles = builderStateFiles(directory, prefix);
+
+			expect(stateFiles.length).toBeGreaterThan(1);
+
+			const [firstState = ""] = stateFiles;
+			fs.rmSync(path.join(stateDirectory, firstState));
+
+			const result = computeAffectedFiles(directory, "only", TEST_KEY);
+
+			// The run is first-run only when NO project had prior state.
+			// Reporting it here (as an OR-fold across projects would) would make
+			// the caller discard the warm projects' drained affected sets while
+			// their builder state had already advanced — the stale-cache defect.
+			expect(result?.firstRun).toBe(false);
+		});
+	});
 });
 
 describe("applyTypeAwareInvalidation", () => {
@@ -226,6 +328,27 @@ describe("applyTypeAwareInvalidation", () => {
 				expect(cacheHasEntry(cacheFile, fileC)).toBe(false);
 			},
 		);
+	});
+
+	it("invalidates an importer in another referenced project", () => {
+		expect.hasAssertions();
+
+		withFixture(SOLUTION_FIXTURE, (directory) => {
+			const cacheFile = path.join(directory, ".eslintcache");
+			const fileA = path.join(directory, "src/a.ts");
+			const fileB = path.join(directory, "app/b.ts");
+			computeAffectedFiles(directory, undefined, TEST_KEY);
+			seedCache(cacheFile, [fileA, fileB]);
+			fs.writeFileSync(fileA, "export function a() { return 'now a string'; }\n");
+			touch(fileA);
+
+			const dirty = new Set([normalizePath(fileA)]);
+			const outcome = invalidate(directory, [fileA, fileB], dirty);
+
+			expect(outcome.busted).toBe(false);
+			expect(outcome.invalidated).toContain(normalizePath(fileB));
+			expect(cacheHasEntry(cacheFile, fileB)).toBe(false);
+		});
 	});
 
 	it("invalidates everything on a global-augmentation edit", () => {
@@ -320,14 +443,9 @@ describe("applyTypeAwareInvalidation", () => {
 				expect(outcome.firstRun).toBe(true);
 				expect(outcome.busted).toBe(false);
 				expect(outcome.invalidated).toStrictEqual([]);
-				expect(
-					fs.existsSync(
-						path.join(
-							directory,
-							`node_modules/.cache/isentinel-lint/tsbuildinfo-full-${TEST_KEY}`,
-						),
-					),
-				).toBe(true);
+				expect(builderStateFiles(directory, `tsbuildinfo-full-${TEST_KEY}`)).toHaveLength(
+					1,
+				);
 				expect(cacheHasEntry(cacheFile, fileA)).toBe(true);
 				expect(cacheHasEntry(cacheFile, fileB)).toBe(true);
 			},
@@ -486,7 +604,7 @@ describe("composeCommands typed-pass skip", () => {
 });
 
 describe("plan mutation", () => {
-	const buildInfo = `node_modules/.cache/isentinel-lint/tsbuildinfo-typeaware-${TEST_KEY}`;
+	const buildInfo = `tsbuildinfo-typeaware-${TEST_KEY}`;
 
 	it("performs no I/O mutation in read-only (print) mode", () => {
 		expect.hasAssertions();
@@ -510,13 +628,13 @@ describe("plan mutation", () => {
 					"typed",
 				]);
 				// Read-only planning never runs the builder or deletes caches.
-				expect(fs.existsSync(path.join(directory, buildInfo))).toBe(false);
+				expect(builderStateFiles(directory, buildInfo)).toHaveLength(0);
 				expect(fs.existsSync(cacheFile)).toBe(true);
 
 				// The mutating plan, by contrast, runs the builder.
 				withoutGitEnvironment(() => plan(parseArguments([]), directory, {}, true));
 
-				expect(fs.existsSync(path.join(directory, buildInfo))).toBe(true);
+				expect(builderStateFiles(directory, buildInfo)).toHaveLength(1);
 			},
 		);
 	});
@@ -624,14 +742,12 @@ describe("per-variant cache isolation", () => {
 			computeAffectedFiles(directory, "only", TEST_KEY);
 			computeAffectedFiles(directory, "only", AGENT_KEY);
 
-			const stateDirectory = path.join(directory, "node_modules", ".cache", "isentinel-lint");
-
-			expect(
-				fs.existsSync(path.join(stateDirectory, `tsbuildinfo-typeaware-${TEST_KEY}`)),
-			).toBe(true);
-			expect(
-				fs.existsSync(path.join(stateDirectory, `tsbuildinfo-typeaware-${AGENT_KEY}`)),
-			).toBe(true);
+			expect(builderStateFiles(directory, `tsbuildinfo-typeaware-${TEST_KEY}`)).toHaveLength(
+				1,
+			);
+			expect(builderStateFiles(directory, `tsbuildinfo-typeaware-${AGENT_KEY}`)).toHaveLength(
+				1,
+			);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #602.

## Problem

`parseJsonConfigFileContent` does not follow `references`, so a solution-style entry tsconfig (`files: []`, `include: []`, only `references`) resolved to **zero** file names and the incremental builder never ran. The type-aware pass then silently degraded to plain mtime dirtiness — and via its auto-skip could report **stale cross-file diagnostics indefinitely**, since no TS mtime changes when an imported type does.

Confirmed on a real 3128-file roblox-ts consumer: `node_modules/.cache/isentinel-lint/` held no `tsbuildinfo-typeaware` at all. It's worse than a perf caveat — lint results were incorrect, not just unoptimised.

## Fix

- **Resolve the reference graph recursively.** References nest (a referenced project may itself be solution-style), so this walks the whole graph rather than reading one level, guarding against cycles/diamonds. One incremental builder runs per file-owning project, keyed by a digest of its canonical config path, unioning the affected sets. On the real consumer this goes from **0 → 3200** files, and editing a shared type now invalidates importers across *sibling* referenced projects.

- **A run is first-run only when no project had prior state.** Collapsing per-project state with an OR would discard every warm project's drained affected set the moment one project was new — builders drain destructively, so that would leave stale cache entries whose mtimes never change. A newly added project instead over-invalidates (at worst a cache bust) rather than under-invalidating.

- **Skip the buildinfo emit when nothing was affected.** With the affected queue drained, `emit` walks the whole program, which cost tens of seconds on every *warm* run of a large solution. Warm runs on the real consumer dropped ~50s → ~11s.

- **Case-sensitive path canonicalization** (folds case only when the host filesystem is case-insensitive), so distinct sibling configs differing only in case don't collide in cycle detection or digesting.

- **Clearer diagnostics:** warn once per distinct message, and suppress the generic "no files resolved" notice when the entry config itself failed to parse (previously emitted a second, misdirecting message pointing at globs rather than the parse error).

## Tests

Added coverage for nested solution-style resolution, per-project builder state, cross-project invalidation, and the mixed first-run/warm fold (verified this last test fails against the naive OR-fold). Full suite 294/294, typecheck and lint clean.

https://claude.ai/code/session_01SSYa5vWQgRQF3RJ9kPvGRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type-aware file invalidation for projects using nested TypeScript project references.
  - More accurately identifies affected files across referenced projects.
  - Prevents incorrect “first run” results when only some projects are new.
  - Improves warning handling so distinct messages are reported appropriately.

- **Tests**
  - Added coverage for solution-style project references, dependency changes, cache isolation, and builder-state persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->