### PR TITLE
fix(lint-cli): bust caches on config drift via imported modules

### DIFF
--- a/src/lint-cli/affected.ts
+++ b/src/lint-cli/affected.ts
@@ -2,7 +2,6 @@
 // cspell:words unparseable slugified sanitise optimisation unsuffixed
 import crypto from "node:crypto";
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
 import process from "node:process";
 import type * as TypeScript from "typescript";
@@ -10,6 +9,7 @@ import type * as TypeScript from "typescript";
 import { CACHE_KEY_LENGTH } from "./cache-key.ts";
 import { toPosix } from "./paths.ts";
 import type { TypeAwareMode } from "./types.ts";
+import { loadTypescript } from "./typescript.ts";
 
 /** Result of a builder pass over the consumer's program. */
 export interface AffectedResult {
@@ -307,25 +307,6 @@ function collectProjects(ts: typeof TypeScript, entryPath: string): ProjectWalkR
 
 	walk(entryPath);
 	return { entryReadable, projects };
-}
-
-/**
- * Resolve the consumer's `typescript` and load it lazily. Anchored at `cwd` so
- * resolution walks the consumer's `node_modules` (typescript is a peer of
- * typescript-eslint, never a dependency of this package). Using `createRequire`
- * rather than a static import keeps typescript out of the bundle and off the
- * load path unless the builder actually runs.
- *
- * @param cwd - The consumer project root to resolve from.
- * @returns The TypeScript module, or `undefined` when it cannot be resolved.
- */
-function loadTypescript(cwd: string): typeof TypeScript | undefined {
-	try {
-		const require = createRequire(path.join(cwd, "__isentinel-lint__.js"));
-		return require("typescript") as typeof TypeScript;
-	} catch {
-		return undefined;
-	}
 }
 
 /**

--- a/src/lint-cli/config-hash.ts
+++ b/src/lint-cli/config-hash.ts
@@ -4,13 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type * as TypeScript from "typescript";
 
-import {
-	CACHE_FILE_DEFAULT,
-	CACHE_FILE_FAST,
-	CACHE_FILE_TYPE_AWARE,
-	cacheFileFor,
-	ESLINT_CONFIG_FILE_PATTERN,
-} from "./constants.ts";
+import { ALL_CACHE_FILES, cacheFileFor } from "./constants.ts";
 import { loadTypescript } from "./typescript.ts";
 
 /**
@@ -29,6 +23,26 @@ export interface ConfigDriftOutcome {
 }
 
 /**
+ * One file in the config import closure, read once for both imports and hash.
+ */
+interface ClosureFile {
+	/** The file's UTF-8 content. */
+	content: string;
+	/** The absolute, normalized path. */
+	file: string;
+}
+
+/** The TypeScript state threaded through the closure walk. */
+interface ClosureResolver {
+	/** The shared module-resolution cache. */
+	cache: TypeScript.ModuleResolutionCache;
+	/** The compiler options resolved for module lookup. */
+	options: TypeScript.CompilerOptions;
+	/** The consumer's resolved TypeScript module. */
+	ts: typeof TypeScript;
+}
+
+/**
  * Resolve the persisted config-hash file for a config variant. Stored alongside
  * the builder state so it is cleaned with `node_modules`, and keyed like
  * `packageHashStatePath`: the stored hash is consumed once, so a shared file
@@ -40,16 +54,6 @@ export interface ConfigDriftOutcome {
  */
 export function configHashStatePath(cwd: string, key: string): string {
 	return path.join(cwd, "node_modules", ".cache", "isentinel-lint", `config-hash-${key}`);
-}
-
-/**
- * The flat-config entry-point subset of the cache-bust files — the walk roots.
- *
- * @param bustFiles - The whole cache-bust file set.
- * @returns Every bust file whose basename is a flat-config entry point.
- */
-export function configEntryPoints(bustFiles: Array<string>): Array<string> {
-	return bustFiles.filter((file) => ESLINT_CONFIG_FILE_PATTERN.test(path.basename(file)));
 }
 
 /**
@@ -69,12 +73,11 @@ export function configEntryPoints(bustFiles: Array<string>): Array<string> {
  * point exists, so the caller treats the check as a no-op.
  *
  * @param cwd - The consumer project root.
- * @param bustFiles - The whole cache-bust file set (config roots are derived).
+ * @param configFiles - The flat-config entry points (see `RepoFiles.configFiles`).
  * @returns The hex digest, or `undefined` when unavailable.
  */
-export function computeConfigHash(cwd: string, bustFiles: Array<string>): string | undefined {
-	const roots = configEntryPoints(bustFiles);
-	if (roots.length === 0) {
+export function computeConfigHash(cwd: string, configFiles: Array<string>): string | undefined {
+	if (configFiles.length === 0) {
 		return undefined;
 	}
 
@@ -83,22 +86,20 @@ export function computeConfigHash(cwd: string, bustFiles: Array<string>): string
 		return undefined;
 	}
 
-	const hash = crypto.createHash("sha256");
-	let hashedAny = false;
-	for (const file of discoverConfigClosure(ts, cwd, roots)) {
-		const content = safeReadUtf8(file);
-		if (content === undefined) {
-			continue;
-		}
+	const closure = discoverConfigClosure(ts, cwd, configFiles);
+	if (closure.length === 0) {
+		return undefined;
+	}
 
+	const hash = crypto.createHash("sha256");
+	for (const { content, file } of closure) {
 		hash.update(file);
 		hash.update("\0");
 		hash.update(content);
 		hash.update("\0");
-		hashedAny = true;
 	}
 
-	return hashedAny ? hash.digest("hex") : undefined;
+	return hash.digest("hex");
 }
 
 /**
@@ -113,15 +114,15 @@ export function computeConfigHash(cwd: string, bustFiles: Array<string>): string
  *
  * @param cwd - The consumer project root.
  * @param key - The config-variant key from `resolveCacheKey`.
- * @param bustFiles - The whole cache-bust file set (config roots are derived).
+ * @param configFiles - The flat-config entry points (see `RepoFiles.configFiles`).
  * @returns The drift outcome.
  */
 export function applyConfigDriftBust(
 	cwd: string,
 	key: string,
-	bustFiles: Array<string>,
+	configFiles: Array<string>,
 ): ConfigDriftOutcome {
-	const hash = computeConfigHash(cwd, bustFiles);
+	const hash = computeConfigHash(cwd, configFiles);
 	if (hash === undefined) {
 		return { busted: false, firstRun: false };
 	}
@@ -137,7 +138,7 @@ export function applyConfigDriftBust(
 		return { busted: false, firstRun: true };
 	}
 
-	for (const base of [CACHE_FILE_FAST, CACHE_FILE_TYPE_AWARE, CACHE_FILE_DEFAULT]) {
+	for (const base of ALL_CACHE_FILES) {
 		fs.rmSync(path.resolve(cwd, cacheFileFor(base, key)), { force: true });
 	}
 
@@ -175,33 +176,29 @@ function enqueueUnvisited(
 }
 
 /**
- * Resolve every in-project import of one file. `node_modules` results and
- * unresolvable specifiers are dropped, so a dependency swap (covered by the
- * lockfile bust) never enters the closure.
+ * Resolve every in-project import found in one file's already-read content.
+ * `node_modules` results and unresolvable specifiers are dropped, so a
+ * dependency swap (covered by the lockfile bust) never enters the closure.
  *
- * @param ts - The consumer's resolved TypeScript module.
- * @param options - The compiler options resolved for module lookup.
+ * @param resolver - The shared TypeScript resolution state.
  * @param file - The absolute path of the importing file.
+ * @param content - The importing file's content.
  * @returns The absolute, normalized in-project import targets.
  */
-function localImportsOf(
-	ts: typeof TypeScript,
-	options: TypeScript.CompilerOptions,
+function importsOf(
+	{ cache, options, ts }: ClosureResolver,
 	file: string,
+	content: string,
 ): Array<string> {
-	const text = safeReadUtf8(file);
-	if (text === undefined) {
-		return [];
-	}
-
 	const targets: Array<string> = [];
 	const nodeModules = `${path.sep}node_modules${path.sep}`;
-	for (const reference of ts.preProcessFile(text, true, true).importedFiles) {
+	for (const reference of ts.preProcessFile(content, true, true).importedFiles) {
 		const resolved = ts.resolveModuleName(
 			reference.fileName,
 			file,
 			options,
 			ts.sys,
+			cache,
 		).resolvedModule;
 		if (resolved === undefined || resolved.isExternalLibraryImport === true) {
 			continue;
@@ -237,45 +234,65 @@ function resolveCompilerOptions(ts: typeof TypeScript, cwd: string): TypeScript.
 		return {};
 	}
 
-	return ts.parseJsonConfigFileContent(read.config, ts.sys, path.dirname(configPath)).options;
+	// Only `.options` is needed, so a no-op `readDirectory` skips the full
+	// source-tree glob `parseJsonConfigFileContent` would otherwise run to build
+	// the (discarded) `.fileNames`; `extends` still resolves via readFile.
+	const host: TypeScript.ParseConfigHost = {
+		fileExists: (file) => ts.sys.fileExists(file),
+		readDirectory: () => [],
+		readFile: (file) => ts.sys.readFile(file),
+		useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+	};
+	return ts.parseJsonConfigFileContent(read.config, host, path.dirname(configPath)).options;
 }
 
 /**
  * Walk the local import closure of the config entry points. BFS with a
  * normalized-path visited set; the roots are included so their own content
- * contributes to the hash.
+ * contributes to the hash. Each file is read exactly once — the content feeds
+ * both import extraction and the hash.
  *
  * @param ts - The consumer's resolved TypeScript module.
  * @param cwd - The consumer project root.
  * @param roots - The config entry-point paths to start from.
- * @returns The absolute, normalized closure paths (roots included).
+ * @returns The readable closure files (roots included), each with its content.
  */
 function discoverConfigClosure(
 	ts: typeof TypeScript,
 	cwd: string,
 	roots: Array<string>,
-): Array<string> {
+): Array<ClosureFile> {
 	const options = resolveCompilerOptions(ts, cwd);
+	const resolver: ClosureResolver = {
+		cache: ts.createModuleResolutionCache(cwd, (fileName) => fileName, options),
+		options,
+		ts,
+	};
 	const visited = new Set<string>();
 	const queue: Array<string> = [];
-	for (const root of roots) {
-		const normalized = path.normalize(root);
-		if (!visited.has(normalized)) {
-			visited.add(normalized);
-			queue.push(normalized);
-		}
-	}
+	enqueueUnvisited(
+		roots.map((root) => path.normalize(root)),
+		visited,
+		queue,
+	);
 
+	const files: Array<ClosureFile> = [];
 	while (queue.length > 0 && visited.size <= MAX_CLOSURE_FILES) {
 		const file = queue.shift();
 		if (file === undefined) {
 			break;
 		}
 
-		enqueueUnvisited(localImportsOf(ts, options, file), visited, queue);
+		const content = safeReadUtf8(file);
+		if (content === undefined) {
+			continue;
+		}
+
+		files.push({ content, file });
+		enqueueUnvisited(importsOf(resolver, file, content), visited, queue);
 	}
 
-	return [...visited].sort();
+	return files;
 }
 
 function writeHash(statePath: string, hash: string): void {

--- a/src/lint-cli/config-hash.ts
+++ b/src/lint-cli/config-hash.ts
@@ -1,0 +1,284 @@
+// cspell:words extensionless mtimes typeaware
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type * as TypeScript from "typescript";
+
+import {
+	CACHE_FILE_DEFAULT,
+	CACHE_FILE_FAST,
+	CACHE_FILE_TYPE_AWARE,
+	cacheFileFor,
+	ESLINT_CONFIG_FILE_PATTERN,
+} from "./constants.ts";
+import { loadTypescript } from "./typescript.ts";
+
+/**
+ * Upper bound on the number of files walked from the config entry points. A
+ * flat-config import graph is a handful of local modules; the cap only guards
+ * against a pathological graph and never trips in practice.
+ */
+const MAX_CLOSURE_FILES = 500;
+
+/** Outcome of the config-drift hash check. */
+export interface ConfigDriftOutcome {
+	/** True when the hash changed and this variant's caches were deleted. */
+	busted: boolean;
+	/** True when no prior hash existed (state stored, no bust). */
+	firstRun: boolean;
+}
+
+/**
+ * Resolve the persisted config-hash file for a config variant. Stored alongside
+ * the builder state so it is cleaned with `node_modules`, and keyed like
+ * `packageHashStatePath`: the stored hash is consumed once, so a shared file
+ * would let the first variant to run absorb the drift for all of them.
+ *
+ * @param cwd - The consumer project root.
+ * @param key - The config-variant key from `resolveCacheKey`.
+ * @returns The absolute path to the stored-hash file.
+ */
+export function configHashStatePath(cwd: string, key: string): string {
+	return path.join(cwd, "node_modules", ".cache", "isentinel-lint", `config-hash-${key}`);
+}
+
+/**
+ * The flat-config entry-point subset of the cache-bust files — the walk roots.
+ *
+ * @param bustFiles - The whole cache-bust file set.
+ * @returns Every bust file whose basename is a flat-config entry point.
+ */
+export function configEntryPoints(bustFiles: Array<string>): Array<string> {
+	return bustFiles.filter((file) => ESLINT_CONFIG_FILE_PATTERN.test(path.basename(file)));
+}
+
+/**
+ * Hash the content of `eslint.config.*` and its transitive local import
+ * closure. This models the input ESLint keys its per-entry `hashOfConfig` on:
+ * ESLint re-lints every file when the resolved config changes, but the runner's
+ * dirty count only sees the config file (via `CACHE_BUST_PATTERNS`), not the
+ * modules it imports. Hashing content (not mtimes) means a checkout or a
+ * save-without-change never busts.
+ *
+ * The closure is discovered with the consumer's own TypeScript: a lexer
+ * extracts each specifier and `resolveModuleName` resolves it (honouring
+ * tsconfig `paths`/`baseUrl`, extension-less and `index` lookups, and
+ * re-export forwarding). External (`node_modules`) imports are dropped — a
+ * dependency swap is already covered by the lockfile bust and `package-hash`.
+ * Returns `undefined` when `typescript` is unresolvable or no config entry
+ * point exists, so the caller treats the check as a no-op.
+ *
+ * @param cwd - The consumer project root.
+ * @param bustFiles - The whole cache-bust file set (config roots are derived).
+ * @returns The hex digest, or `undefined` when unavailable.
+ */
+export function computeConfigHash(cwd: string, bustFiles: Array<string>): string | undefined {
+	const roots = configEntryPoints(bustFiles);
+	if (roots.length === 0) {
+		return undefined;
+	}
+
+	const ts = loadTypescript(cwd);
+	if (ts === undefined) {
+		return undefined;
+	}
+
+	const hash = crypto.createHash("sha256");
+	let hashedAny = false;
+	for (const file of discoverConfigClosure(ts, cwd, roots)) {
+		const content = safeReadUtf8(file);
+		if (content === undefined) {
+			continue;
+		}
+
+		hash.update(file);
+		hash.update("\0");
+		hash.update(content);
+		hash.update("\0");
+		hashedAny = true;
+	}
+
+	return hashedAny ? hash.digest("hex") : undefined;
+}
+
+/**
+ * Bust every one of this variant's ESLint caches when the config content
+ * changed since the last run. Deletes the fast, type-aware and default caches —
+ * the fast (syntactic-only) cache included, unlike the package.json bust, since
+ * a config change such as a rule-severity flip alters a syntactic lint too. The
+ * first run only stores the hash.
+ *
+ * Keyed per variant so each observes the drift independently on its own first
+ * run after it (see {@link configHashStatePath}).
+ *
+ * @param cwd - The consumer project root.
+ * @param key - The config-variant key from `resolveCacheKey`.
+ * @param bustFiles - The whole cache-bust file set (config roots are derived).
+ * @returns The drift outcome.
+ */
+export function applyConfigDriftBust(
+	cwd: string,
+	key: string,
+	bustFiles: Array<string>,
+): ConfigDriftOutcome {
+	const hash = computeConfigHash(cwd, bustFiles);
+	if (hash === undefined) {
+		return { busted: false, firstRun: false };
+	}
+
+	const statePath = configHashStatePath(cwd, key);
+	const stored = safeReadUtf8(statePath);
+	if (stored === hash) {
+		return { busted: false, firstRun: false };
+	}
+
+	writeHash(statePath, hash);
+	if (stored === undefined) {
+		return { busted: false, firstRun: true };
+	}
+
+	for (const base of [CACHE_FILE_FAST, CACHE_FILE_TYPE_AWARE, CACHE_FILE_DEFAULT]) {
+		fs.rmSync(path.resolve(cwd, cacheFileFor(base, key)), { force: true });
+	}
+
+	return { busted: true, firstRun: false };
+}
+
+function safeReadUtf8(filePath: string): string | undefined {
+	try {
+		return fs.readFileSync(filePath, "utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Add every not-yet-seen target to the visited set and the work queue.
+ *
+ * @param targets - The candidate import targets.
+ * @param visited - The set of already-seen paths (mutated).
+ * @param queue - The BFS work queue (mutated).
+ */
+function enqueueUnvisited(
+	targets: Array<string>,
+	visited: Set<string>,
+	queue: Array<string>,
+): void {
+	for (const target of targets) {
+		if (visited.has(target)) {
+			continue;
+		}
+
+		visited.add(target);
+		queue.push(target);
+	}
+}
+
+/**
+ * Resolve every in-project import of one file. `node_modules` results and
+ * unresolvable specifiers are dropped, so a dependency swap (covered by the
+ * lockfile bust) never enters the closure.
+ *
+ * @param ts - The consumer's resolved TypeScript module.
+ * @param options - The compiler options resolved for module lookup.
+ * @param file - The absolute path of the importing file.
+ * @returns The absolute, normalized in-project import targets.
+ */
+function localImportsOf(
+	ts: typeof TypeScript,
+	options: TypeScript.CompilerOptions,
+	file: string,
+): Array<string> {
+	const text = safeReadUtf8(file);
+	if (text === undefined) {
+		return [];
+	}
+
+	const targets: Array<string> = [];
+	const nodeModules = `${path.sep}node_modules${path.sep}`;
+	for (const reference of ts.preProcessFile(text, true, true).importedFiles) {
+		const resolved = ts.resolveModuleName(
+			reference.fileName,
+			file,
+			options,
+			ts.sys,
+		).resolvedModule;
+		if (resolved === undefined || resolved.isExternalLibraryImport === true) {
+			continue;
+		}
+
+		const target = path.normalize(resolved.resolvedFileName);
+		if (!target.includes(nodeModules)) {
+			targets.push(target);
+		}
+	}
+
+	return targets;
+}
+
+/**
+ * Resolve the consumer's compiler options from the nearest `tsconfig.json` so
+ * `resolveModuleName` honours `paths`/`baseUrl`. Falls back to empty options
+ * (relative and `node_modules` resolution still work) when none is found or it
+ * fails to parse.
+ *
+ * @param ts - The consumer's resolved TypeScript module.
+ * @param cwd - The consumer project root.
+ * @returns The parsed compiler options.
+ */
+function resolveCompilerOptions(ts: typeof TypeScript, cwd: string): TypeScript.CompilerOptions {
+	const configPath = ts.findConfigFile(cwd, (file) => ts.sys.fileExists(file), "tsconfig.json");
+	if (configPath === undefined) {
+		return {};
+	}
+
+	const read = ts.readConfigFile(configPath, (file) => ts.sys.readFile(file));
+	if (read.error !== undefined || read.config === undefined) {
+		return {};
+	}
+
+	return ts.parseJsonConfigFileContent(read.config, ts.sys, path.dirname(configPath)).options;
+}
+
+/**
+ * Walk the local import closure of the config entry points. BFS with a
+ * normalized-path visited set; the roots are included so their own content
+ * contributes to the hash.
+ *
+ * @param ts - The consumer's resolved TypeScript module.
+ * @param cwd - The consumer project root.
+ * @param roots - The config entry-point paths to start from.
+ * @returns The absolute, normalized closure paths (roots included).
+ */
+function discoverConfigClosure(
+	ts: typeof TypeScript,
+	cwd: string,
+	roots: Array<string>,
+): Array<string> {
+	const options = resolveCompilerOptions(ts, cwd);
+	const visited = new Set<string>();
+	const queue: Array<string> = [];
+	for (const root of roots) {
+		const normalized = path.normalize(root);
+		if (!visited.has(normalized)) {
+			visited.add(normalized);
+			queue.push(normalized);
+		}
+	}
+
+	while (queue.length > 0 && visited.size <= MAX_CLOSURE_FILES) {
+		const file = queue.shift();
+		if (file === undefined) {
+			break;
+		}
+
+		enqueueUnvisited(localImportsOf(ts, options, file), visited, queue);
+	}
+
+	return [...visited].sort();
+}
+
+function writeHash(statePath: string, hash: string): void {
+	fs.mkdirSync(path.dirname(statePath), { recursive: true });
+	fs.writeFileSync(statePath, hash);
+}

--- a/src/lint-cli/constants.ts
+++ b/src/lint-cli/constants.ts
@@ -20,6 +20,9 @@ export const DEFAULT_FAST_FILES_PER_WORKER = 800;
  */
 export const AFFECTED_BUST_THRESHOLD = 1000;
 
+/** Matches a flat-config entry-point basename (`eslint.config.*`). */
+export const ESLINT_CONFIG_FILE_PATTERN = /^eslint\.config\./;
+
 /**
  * Base name of every ESLint cache file the runner manages. Each real file adds
  * a pass suffix and a config-variant key (see {@link cacheFileFor}), so this

--- a/src/lint-cli/files.ts
+++ b/src/lint-cli/files.ts
@@ -4,7 +4,12 @@ import fs from "node:fs";
 import path from "node:path";
 import picomatch from "picomatch";
 
-import { CACHE_BUST_PATTERNS, LINTABLE_EXTENSIONS, TYPE_AWARE_EXTENSIONS } from "./constants.ts";
+import {
+	CACHE_BUST_PATTERNS,
+	ESLINT_CONFIG_FILE_PATTERN,
+	LINTABLE_EXTENSIONS,
+	TYPE_AWARE_EXTENSIONS,
+} from "./constants.ts";
 import { toPosix } from "./paths.ts";
 import { findWorkspaceRoot } from "./workspace.ts";
 
@@ -44,6 +49,13 @@ const TYPE_AWARE_EXTENSION_SET = new Set<string>(
 export interface RepoFiles {
 	/** Absolute paths of every cache-busting file (whole project). */
 	bustFiles: Array<string>;
+	/**
+	 * The flat-config entry-point subset of {@link RepoFiles.bustFiles} — the
+	 * files whose change should invalidate a config-derived signal (the hybrid
+	 * status and the config-drift hash). Derived once here so consumers do not
+	 * each re-filter `bustFiles`.
+	 */
+	configFiles: Array<string>;
 	/** Absolute paths of the lintable files within the lint targets. */
 	lintable: Array<string>;
 	/**
@@ -92,7 +104,9 @@ export function collectRepoFiles(cwd: string, targets: Array<string>): RepoFiles
 		}
 	}
 
-	return { bustFiles, lintable, targetsOutsideCwd, typeAware };
+	const configFiles = bustFiles.filter(isConfigEntryPoint);
+
+	return { bustFiles, configFiles, lintable, targetsOutsideCwd, typeAware };
 }
 
 /**
@@ -106,6 +120,16 @@ export function collectRepoFiles(cwd: string, targets: Array<string>): RepoFiles
  */
 export function collectLintableFiles(cwd: string, targets: Array<string>): Array<string> {
 	return collectRepoFiles(cwd, targets).lintable;
+}
+
+/**
+ * Whether an absolute path is a flat-config entry point.
+ *
+ * @param file - The absolute path to test.
+ * @returns True when the basename matches `eslint.config.*`.
+ */
+function isConfigEntryPoint(file: string): boolean {
+	return ESLINT_CONFIG_FILE_PATTERN.test(path.basename(file));
 }
 
 /**

--- a/src/lint-cli/hybrid.ts
+++ b/src/lint-cli/hybrid.ts
@@ -4,13 +4,11 @@ import path from "node:path";
 import process from "node:process";
 
 import { maxMtimeMs } from "./cache.ts";
+import { ESLINT_CONFIG_FILE_PATTERN } from "./constants.ts";
 import type { RepoFiles } from "./files.ts";
 import { hybridStatusPath, readHybridStatus, writeHybridStatus } from "./hybrid-status.ts";
 import type { HybridStatus } from "./hybrid-status.ts";
 import { resolveLocalBin } from "./resolve.ts";
-
-/** Matches the flat-config entry point (`eslint.config.js`, `.ts`, `.mjs`…). */
-const ESLINT_CONFIG_FILE_PATTERN = /^eslint\.config\./;
 
 /**
  * The stderr warning emitted when the resolved ESLint config is not hybrid, so

--- a/src/lint-cli/hybrid.ts
+++ b/src/lint-cli/hybrid.ts
@@ -1,10 +1,8 @@
 // cspell:words mtimes unparseable
 import { spawnSync } from "node:child_process";
-import path from "node:path";
 import process from "node:process";
 
 import { maxMtimeMs } from "./cache.ts";
-import { ESLINT_CONFIG_FILE_PATTERN } from "./constants.ts";
 import type { RepoFiles } from "./files.ts";
 import { hybridStatusPath, readHybridStatus, writeHybridStatus } from "./hybrid-status.ts";
 import type { HybridStatus } from "./hybrid-status.ts";
@@ -160,18 +158,6 @@ function readFreshHybridStatus(
 }
 
 /**
- * The ESLint-config subset of the cache-bust files: the files whose change
- * should invalidate the cached hybrid status. Lockfiles and tsconfigs are
- * excluded — only the ESLint config decides the `oxlint` option.
- *
- * @param bustFiles - The whole cache-bust file set.
- * @returns Every bust file whose basename is a flat-config entry point.
- */
-function eslintConfigFiles(bustFiles: Array<string>): Array<string> {
-	return bustFiles.filter((file) => ESLINT_CONFIG_FILE_PATTERN.test(path.basename(file)));
-}
-
-/**
  * Resolve the hybrid status, trusting a fresh cache file and otherwise probing.
  * Returns `undefined` only when a probe was attempted and failed.
  *
@@ -183,7 +169,7 @@ function resolveHybridStatus(
 	{ cwd, files, mutate }: OxlintRunInput,
 	probe: HybridProbe,
 ): HybridStatus | undefined {
-	const configMtime = maxMtimeMs(eslintConfigFiles(files.bustFiles));
+	const configMtime = maxMtimeMs(files.configFiles);
 
 	const cached = readFreshHybridStatus(cwd, configMtime);
 	if (cached !== undefined) {
@@ -196,7 +182,7 @@ function resolveHybridStatus(
 		return { oxlint: true };
 	}
 
-	const target = files.typeAware[0] ?? eslintConfigFiles(files.bustFiles)[0];
+	const target = files.typeAware[0] ?? files.configFiles[0];
 	if (target === undefined) {
 		return undefined;
 	}

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -17,6 +17,7 @@ import {
 	formatCommandLine,
 } from "./command.ts";
 import { computeWorkerCount, resolveWorkerLimits } from "./concurrency.ts";
+import { applyConfigDriftBust } from "./config-hash.ts";
 import { cacheFileFor } from "./constants.ts";
 import { collectRepoFiles } from "./files.ts";
 import type { RepoFiles } from "./files.ts";
@@ -200,6 +201,17 @@ export function plan(
 	// this run selected.
 	const canMutateCaches = mutate && options.cache;
 	const hasTypeAwarePass = descriptors.some((descriptor) => descriptor.invalidation !== "none");
+	if (canMutateCaches) {
+		// Config drift through a module `eslint.config.*` imports shifts ESLint's
+		// per-entry `hashOfConfig` (a full re-lint) but touches no bust file, so
+		// the mtime dirty count would size `--concurrency off` for a serial full
+		// re-lint. Content-hash the config's local import closure and delete all
+		// three of this variant's caches when it changed. Applies to every pass
+		// (a config change can alter a syntactic lint), so it runs before the
+		// type-aware-only package.json bust.
+		applyConfigDriftBust(cwd, key, files.bustFiles);
+	}
+
 	if (canMutateCaches && hasTypeAwarePass) {
 		applyPackageJsonBust(cwd, key);
 	}
@@ -530,10 +542,12 @@ function sizePass(descriptor: PassDescriptor, context: SizePassContext): PassPla
 	// The typed pass may only auto-skip when the dirty count is trustworthy; an
 	// outside-cwd target makes it unknowable, so never skip in that case.
 	//
-	// Known limitation: a skipped pass never runs, so ESLint's own per-entry
-	// config hash cannot catch a config change that arrived through a module the
-	// `eslint.config.*` imports (only the config file's own mtime busts here).
-	// Touch the config, or run with `--no-cache`, after editing such a module.
+	// A config change reaching the resolved config through a module the
+	// `eslint.config.*` imports busts this variant's caches up front (see
+	// `applyConfigDriftBust` in `plan`), so the dirty count reflects it and the
+	// pass is not wrongly skipped. Residual escape hatch for the cases that
+	// misses (dynamic `import()`, non-file config inputs): touch the config, or
+	// run with `--no-cache`.
 	const canSkip =
 		context.mutate && context.multiPass && descriptor === TYPED_PASS && !conservative;
 	if (canSkip && dirtyCount === 0) {

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -209,7 +209,7 @@ export function plan(
 		// three of this variant's caches when it changed. Applies to every pass
 		// (a config change can alter a syntactic lint), so it runs before the
 		// type-aware-only package.json bust.
-		applyConfigDriftBust(cwd, key, files.bustFiles);
+		applyConfigDriftBust(cwd, key, files.configFiles);
 	}
 
 	if (canMutateCaches && hasTypeAwarePass) {

--- a/src/lint-cli/typescript.ts
+++ b/src/lint-cli/typescript.ts
@@ -1,0 +1,22 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import type * as TypeScript from "typescript";
+
+/**
+ * Resolve the consumer's `typescript` and load it lazily. Anchored at `cwd` so
+ * resolution walks the consumer's `node_modules` (typescript is a peer of
+ * typescript-eslint, never a dependency of this package). Using `createRequire`
+ * rather than a static import keeps typescript out of the bundle and off the
+ * load path unless a caller actually needs it.
+ *
+ * @param cwd - The consumer project root to resolve from.
+ * @returns The TypeScript module, or `undefined` when it cannot be resolved.
+ */
+export function loadTypescript(cwd: string): typeof TypeScript | undefined {
+	try {
+		const require = createRequire(path.join(cwd, "__isentinel-lint__.js"));
+		return require("typescript") as typeof TypeScript;
+	} catch {
+		return undefined;
+	}
+}

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -9,11 +9,17 @@ import { describe, expect, it } from "vitest";
 import { computeAffectedFiles } from "../src/lint-cli/affected.ts";
 import { resolveCacheKey } from "../src/lint-cli/cache-key.ts";
 import { normalizePath, removeCacheEntries } from "../src/lint-cli/cache.ts";
-import { CACHE_FILE_TYPE_AWARE, cacheFileFor } from "../src/lint-cli/constants.ts";
+import {
+	applyConfigDriftBust,
+	computeConfigHash,
+	configHashStatePath,
+} from "../src/lint-cli/config-hash.ts";
+import { ALL_CACHE_FILES, CACHE_FILE_TYPE_AWARE, cacheFileFor } from "../src/lint-cli/constants.ts";
 import { writeHybridStatus } from "../src/lint-cli/hybrid-status.ts";
 import { applyTypeAwareInvalidation } from "../src/lint-cli/invalidation.ts";
 import { parseArguments } from "../src/lint-cli/options.ts";
 import { composeCommands, plan } from "../src/lint-cli/run.ts";
+import type { PassPlan } from "../src/lint-cli/run.ts";
 import { withoutGitEnvironment } from "./without-git.ts";
 
 /**
@@ -782,5 +788,268 @@ describe("resolveJsonModule invalidation", () => {
 				expect(cacheHasEntry(cacheFile, fileB)).toBe(false);
 			},
 		);
+	});
+});
+
+/** A config whose resolved shape depends on a local module it imports. */
+const CONFIG_IMPORT_FIXTURE = {
+	"eslint-rules.ts": "export const rules = { rules: {} };\n",
+	"eslint.config.ts": "import './eslint-rules';\nexport default [];\n",
+	"src/a.ts": "export function a(): number { return 1; }\n",
+	"tsconfig.json": TSCONFIG,
+};
+
+function configBustFiles(directory: string): Array<string> {
+	return [path.join(directory, "eslint.config.ts")];
+}
+
+function seedAllCaches(directory: string, key: string): void {
+	for (const name of ALL_CACHE_FILES) {
+		fs.writeFileSync(path.join(directory, cacheFileFor(name, key)), "{}");
+	}
+}
+
+function cacheExists(directory: string, key: string, name: string): boolean {
+	return fs.existsSync(path.join(directory, cacheFileFor(name, key)));
+}
+
+function everyCacheExists(directory: string, key: string): boolean {
+	return ALL_CACHE_FILES.every((name) => cacheExists(directory, key, name));
+}
+
+function anyCacheExists(directory: string, key: string): boolean {
+	return ALL_CACHE_FILES.some((name) => cacheExists(directory, key, name));
+}
+
+function editRules(directory: string): void {
+	fs.writeFileSync(
+		path.join(directory, "eslint-rules.ts"),
+		"export const rules = { rules: { x: 1 } };\n",
+	);
+}
+
+describe("applyConfigDriftBust", () => {
+	it("stores the hash without busting on the first run", () => {
+		expect.hasAssertions();
+
+		withFixture(CONFIG_IMPORT_FIXTURE, (directory) => {
+			seedAllCaches(directory, TEST_KEY);
+
+			const outcome = applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory));
+
+			expect(outcome).toStrictEqual({ busted: false, firstRun: true });
+			expect(everyCacheExists(directory, TEST_KEY)).toBe(true);
+		});
+	});
+
+	it("busts every cache when an imported config module changes", () => {
+		expect.hasAssertions();
+
+		withFixture(CONFIG_IMPORT_FIXTURE, (directory) => {
+			applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory));
+			seedAllCaches(directory, TEST_KEY);
+			editRules(directory);
+
+			const outcome = applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory));
+
+			expect(outcome).toStrictEqual({ busted: true, firstRun: false });
+			// Unlike the package.json bust, the fast (syntactic) cache is dropped
+			// too: a rule-severity change alters a syntactic lint.
+			expect(anyCacheExists(directory, TEST_KEY)).toBe(false);
+		});
+	});
+
+	it("does not bust when an imported module is only touched", () => {
+		expect.hasAssertions();
+
+		withFixture(CONFIG_IMPORT_FIXTURE, (directory) => {
+			applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory));
+			seedAllCaches(directory, TEST_KEY);
+			touch(path.join(directory, "eslint-rules.ts"));
+
+			const outcome = applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory));
+
+			// Content-addressed, so an mtime bump with identical content is a
+			// no-op.
+			expect(outcome).toStrictEqual({ busted: false, firstRun: false });
+			expect(everyCacheExists(directory, TEST_KEY)).toBe(true);
+		});
+	});
+
+	it("lets each variant observe the same drift independently", () => {
+		expect.hasAssertions();
+
+		withFixture(CONFIG_IMPORT_FIXTURE, (directory) => {
+			applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory));
+			applyConfigDriftBust(directory, AGENT_KEY, configBustFiles(directory));
+			seedAllCaches(directory, TEST_KEY);
+			seedAllCaches(directory, AGENT_KEY);
+			editRules(directory);
+
+			expect(
+				applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory)),
+			).toStrictEqual({
+				busted: true,
+				firstRun: false,
+			});
+			// The no-agent run must not consume the drift on the agent's behalf.
+			expect(everyCacheExists(directory, AGENT_KEY)).toBe(true);
+
+			expect(
+				applyConfigDriftBust(directory, AGENT_KEY, configBustFiles(directory)),
+			).toStrictEqual({
+				busted: true,
+				firstRun: false,
+			});
+			expect(anyCacheExists(directory, AGENT_KEY)).toBe(false);
+		});
+	});
+
+	it("stores each variant's hash under its own state file", () => {
+		expect.hasAssertions();
+
+		expect(configHashStatePath("/project", "aaaa1111")).not.toBe(
+			configHashStatePath("/project", "bbbb2222"),
+		);
+	});
+
+	it("no-ops when there is no config entry point", () => {
+		expect.hasAssertions();
+
+		withFixture(CONFIG_IMPORT_FIXTURE, (directory) => {
+			seedAllCaches(directory, TEST_KEY);
+
+			const outcome = applyConfigDriftBust(directory, TEST_KEY, []);
+
+			expect(outcome).toStrictEqual({ busted: false, firstRun: false });
+			expect(everyCacheExists(directory, TEST_KEY)).toBe(true);
+		});
+	});
+
+	it("no-ops when typescript cannot be resolved", () => {
+		expect.hasAssertions();
+
+		const directory = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-cfg-"));
+		try {
+			fs.writeFileSync(path.join(directory, "eslint.config.ts"), "export default [];\n");
+			const roots = [path.join(directory, "eslint.config.ts")];
+
+			expect(computeConfigHash(directory, roots)).toBeUndefined();
+			expect(applyConfigDriftBust(directory, TEST_KEY, roots)).toStrictEqual({
+				busted: false,
+				firstRun: false,
+			});
+		} finally {
+			fs.rmSync(directory, { force: true, recursive: true });
+		}
+	});
+});
+
+describe("computeConfigHash discovery", () => {
+	it("follows transitive imports and re-exports", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"a.ts": "export * from './b';\n",
+				"b.ts": "export const b = 1;\n",
+				"eslint.config.ts": "import './a';\nexport default [];\n",
+				"tsconfig.json": TSCONFIG,
+			},
+			(directory) => {
+				const before = computeConfigHash(directory, configBustFiles(directory));
+				fs.writeFileSync(path.join(directory, "b.ts"), "export const b = 2;\n");
+				const after = computeConfigHash(directory, configBustFiles(directory));
+
+				expect(before).toBeDefined();
+				expect(after).not.toBe(before);
+			},
+		);
+	});
+
+	it("resolves tsconfig path aliases", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"config/rules.ts": "export const rules = {};\n",
+				"eslint.config.ts": "import '@rules';\nexport default [];\n",
+				"tsconfig.json": JSON.stringify({
+					compilerOptions: {
+						baseUrl: ".",
+						module: "commonjs",
+						paths: { "@rules": ["./config/rules"] },
+						strict: true,
+						target: "es2020",
+					},
+					include: ["src"],
+				}),
+			},
+			(directory) => {
+				const before = computeConfigHash(directory, configBustFiles(directory));
+				fs.writeFileSync(
+					path.join(directory, "config/rules.ts"),
+					"export const rules = { x: 1 };\n",
+				);
+				const after = computeConfigHash(directory, configBustFiles(directory));
+
+				expect(before).toBeDefined();
+				expect(after).not.toBe(before);
+			},
+		);
+	});
+
+	it("ignores files the config does not import", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				"eslint.config.ts": "import './rules';\nexport default [];\n",
+				"rules.ts": "export const rules = {};\n",
+				"tsconfig.json": TSCONFIG,
+				"unrelated.ts": "export const x = 1;\n",
+			},
+			(directory) => {
+				const before = computeConfigHash(directory, configBustFiles(directory));
+				fs.writeFileSync(path.join(directory, "unrelated.ts"), "export const x = 2;\n");
+				const after = computeConfigHash(directory, configBustFiles(directory));
+
+				expect(before).toBeDefined();
+				expect(after).toBe(before);
+			},
+		);
+	});
+});
+
+describe("config drift sizing", () => {
+	function typedPass(runPlan: ReturnType<typeof plan>): PassPlan | undefined {
+		return runPlan.passes.find((pass) => pass.descriptor.label === "typed");
+	}
+
+	it("un-skips the typed pass when a module the config imports changed", () => {
+		expect.hasAssertions();
+
+		// Lint only `src`; the imported `eslint-rules.ts` sits at the root, so it
+		// is neither a lint target nor a cache-bust file. Editing it therefore
+		// changes nothing the mtime dirty count can see — only the config-drift
+		// bust can trigger the re-lint, isolating the fix.
+		withFixture(CONFIG_IMPORT_FIXTURE, (directory) => {
+			const cacheFile = path.join(directory, TYPE_AWARE_CACHE);
+			const fileA = path.join(directory, "src/a.ts");
+			const args = parseArguments(["src"]);
+			computeAffectedFiles(directory, "only", TEST_KEY);
+			seedCache(cacheFile, [fileA]);
+			const warm = withoutGitEnvironment(() => plan(args, directory, {}, true));
+
+			expect(typedPass(warm)?.shouldRun).toBe(false);
+
+			// No bust file changes on disk, but the resolved config (and ESLint's
+			// hashOfConfig) shifts, so the drift bust must delete the caches and
+			// the typed pass must run at full size.
+			editRules(directory);
+			const drifted = withoutGitEnvironment(() => plan(args, directory, {}, true));
+
+			expect(typedPass(drifted)?.shouldRun).toBe(true);
+		});
 	});
 });

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -1051,7 +1051,14 @@ describe("runConcurrent", () => {
 });
 
 function repoFiles(overrides: Partial<RepoFiles> = {}): RepoFiles {
-	return { bustFiles: [], lintable: [], targetsOutsideCwd: false, typeAware: [], ...overrides };
+	return {
+		bustFiles: [],
+		configFiles: [],
+		lintable: [],
+		targetsOutsideCwd: false,
+		typeAware: [],
+		...overrides,
+	};
 }
 
 function setMtimeInPast(filePath: string): void {
@@ -1157,7 +1164,7 @@ describe("resolveOxlintRun", () => {
 			const decision = resolveOxlintRun(
 				{
 					cwd: directory,
-					files: repoFiles({ bustFiles: [config] }),
+					files: repoFiles({ configFiles: [config] }),
 					mutate: true,
 					runEslint: true,
 					runOxlint: true,
@@ -1187,7 +1194,7 @@ describe("resolveOxlintRun", () => {
 			const decision = resolveOxlintRun(
 				{
 					cwd: directory,
-					files: repoFiles({ bustFiles: [config] }),
+					files: repoFiles({ configFiles: [config] }),
 					mutate: true,
 					runEslint: true,
 					runOxlint: true,
@@ -1221,7 +1228,7 @@ describe("resolveOxlintRun", () => {
 				{
 					cwd: directory,
 					files: repoFiles({
-						bustFiles: [config],
+						configFiles: [config],
 						typeAware: [path.join(directory, "a.ts")],
 					}),
 					mutate: true,
@@ -1315,7 +1322,7 @@ describe("resolveOxlintRun", () => {
 				{
 					cwd: directory,
 					files: repoFiles({
-						bustFiles: [config],
+						configFiles: [config],
 						typeAware: [path.join(directory, "a.ts")],
 					}),
 					mutate: false,


### PR DESCRIPTION
## Summary

Closes #596.

The `isentinel-lint` CLI sizes ESLint's `--concurrency` from its own mtime/checksum dirty count, which has no knowledge of ESLint's per-entry `hashOfConfig` invalidation. When the resolved config changes through a **module that `eslint.config.*` imports** — not the config file itself, not a lockfile/tsconfig — ESLint invalidates every entry and re-lints all files, while the CLI sees ~0 dirty files and picks `--concurrency off`. Measured: 3128 files, `off` = 869s vs `8` = 48s (**18x**); one real run took 17.8 min.

Numeric `--concurrency=N` is `min(N, filePaths.length)` — cache-blind (`eslint.js:426`); only `auto` honours `hashOfConfig`, at a hardcoded 50 files/worker. So the CLI's dirty count is the only cache-awareness in the pipeline, and the fix belongs there.

## Approach

Content-fingerprint the config's local import closure and bust this variant's caches when it changes — mirroring the existing `package-hash.ts` mechanism, but hashing config-module content instead of `package.json` fields.

- New `src/lint-cli/config-hash.ts`: discovers the closure via the consumer's own TypeScript (`preProcessFile` + `resolveModuleName`, honouring tsconfig `paths`/`baseUrl`, extension-less/`index`, re-exports; `node_modules` dropped), content-hashes it, and busts all three caches on change (fast included — a rule-severity change alters a syntactic lint too). Keyed per config variant.
- New `src/lint-cli/typescript.ts`: `loadTypescript` extracted from `affected.ts`, shared by both.
- Wired into `plan()` before the mtime sweep; deleted caches flow through the existing machinery, so the dirty count is correct **and** the typed pass stops wrongly auto-skipping.
- `RepoFiles.configFiles` computed once in `files.ts`; `hybrid.ts` and `config-hash.ts` consume it (removes two duplicate config-root filters).

Content-addressing (not mtimes) means a checkout or save-without-change never busts. For plain consumers whose config just does `export default isentinel({...})`, there are no local imports, so zero cost.

**Residual (accepted, all pre-existing):** dynamic `import()`/computed `require()` and non-file config inputs. Escape hatch — touch the config or `--no-cache` — remains.

## Tests

11 new tests in `lint-cli-invalidation.spec.ts`: first-run-stores, imported-module change busts all three caches, touch-only (identical content) no-bust, per-variant independence, no-config/no-typescript no-ops, transitive + `export *`, path-alias resolution, scoping, and a `plan()` regression proving the typed pass un-skips on drift with no on-disk bust signal.

`pnpm test` (305), `pnpm typecheck`, `pnpm lint` (oxlint + eslint), `pnpm build` + publint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lint cache invalidation when ESLint flat-config files or their imported modules change.
  * Ensured cache invalidation is tracked independently across configuration variants.
  * Prevented unrelated file changes from unnecessarily invalidating lint caches.
  * Improved typed lint pass behavior after configuration changes.
* **Reliability**
  * TypeScript is now loaded safely when available, without failing when it cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->