### PR TITLE
fix(lint-cli): drop ESLint-ignored files from the dirty count, and cap type-aware workers

### DIFF
--- a/src/lint-cli/concurrency.ts
+++ b/src/lint-cli/concurrency.ts
@@ -13,6 +13,12 @@ export interface WorkerHeuristicInput {
 
 /** Resolved limits derived from the environment and available CPUs. */
 export interface WorkerLimits {
+	/**
+	 * Whether `maxWorkers` came from an explicit `LINT_MAX_WORKERS`. A pass may
+	 * tighten the derived cap (see `TYPED_MAX_WORKERS`) but never an explicit
+	 * one.
+	 */
+	explicitMaxWorkers: boolean;
 	filesPerWorker: number;
 	maxWorkers: number;
 }
@@ -21,9 +27,12 @@ export interface WorkerLimits {
  * Derive the worker limits from environment overrides, falling back to the
  * default files-per-worker and a quarter of the available parallelism.
  *
- * Type-aware linting spends roughly `filesPerWorker^1.46` per worker with a
- * fixed ~6.5s TypeScript program construction cost, so the sweet spot is
- * ~200-400 files per worker rather than ESLint's syntax-tuned `auto`.
+ * A type-aware worker costs a fixed TypeScript program build plus roughly
+ * 10-20ms per file. The build is not a constant: `projectService` only builds
+ * the projects covering the files a worker was given, so splitting the run
+ * splits the build too — but each split still repeats the per-project floor,
+ * which is what keeps the sweet spot near 300 files per worker rather than
+ * ESLint's syntax-tuned `auto`.
  *
  * @param environment - The environment variables to read overrides from.
  * @param availableParallelism - The number of available CPUs.
@@ -35,11 +44,13 @@ export function resolveWorkerLimits(
 ): WorkerLimits {
 	const filesPerWorker =
 		parsePositiveInteger(environment["FILES_PER_WORKER"]) ?? DEFAULT_FILES_PER_WORKER;
-	const maxWorkers =
-		parsePositiveInteger(environment["LINT_MAX_WORKERS"]) ??
-		Math.floor(availableParallelism / 4);
+	const explicit = parsePositiveInteger(environment["LINT_MAX_WORKERS"]);
 
-	return { filesPerWorker, maxWorkers };
+	return {
+		explicitMaxWorkers: explicit !== undefined,
+		filesPerWorker,
+		maxWorkers: explicit ?? Math.floor(availableParallelism / 4),
+	};
 }
 
 /**

--- a/src/lint-cli/concurrency.ts
+++ b/src/lint-cli/concurrency.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_FAST_FILES_PER_WORKER, DEFAULT_FILES_PER_WORKER } from "./constants.ts";
+import {
+	DEFAULT_FAST_FILES_PER_WORKER,
+	DEFAULT_FILES_PER_WORKER,
+	TYPED_MAX_WORKERS,
+} from "./constants.ts";
 import { parseBoundedInteger } from "./parse.ts";
 
 /** Inputs to the (pure) worker-count heuristic. */
@@ -13,14 +17,16 @@ export interface WorkerHeuristicInput {
 
 /** Resolved limits derived from the environment and available CPUs. */
 export interface WorkerLimits {
-	/**
-	 * Whether `maxWorkers` came from an explicit `LINT_MAX_WORKERS`. A pass may
-	 * tighten the derived cap (see `TYPED_MAX_WORKERS`) but never an explicit
-	 * one.
-	 */
-	explicitMaxWorkers: boolean;
 	filesPerWorker: number;
+	/** The cap for a pass that builds no TypeScript program (the fast pass). */
 	maxWorkers: number;
+	/**
+	 * The cap for a pass that builds one: tighter, because concurrent program
+	 * builds saturate memory bandwidth before they saturate cores (see
+	 * {@link TYPED_MAX_WORKERS}). Both caps collapse to an explicit
+	 * `LINT_MAX_WORKERS`, which is a deliberate request and is never tightened.
+	 */
+	typedMaxWorkers: number;
 }
 
 /**
@@ -45,11 +51,12 @@ export function resolveWorkerLimits(
 	const filesPerWorker =
 		parsePositiveInteger(environment["FILES_PER_WORKER"]) ?? DEFAULT_FILES_PER_WORKER;
 	const explicit = parsePositiveInteger(environment["LINT_MAX_WORKERS"]);
+	const maxWorkers = explicit ?? Math.floor(availableParallelism / 4);
 
 	return {
-		explicitMaxWorkers: explicit !== undefined,
 		filesPerWorker,
-		maxWorkers: explicit ?? Math.floor(availableParallelism / 4),
+		maxWorkers,
+		typedMaxWorkers: explicit ?? Math.min(maxWorkers, TYPED_MAX_WORKERS),
 	};
 }
 

--- a/src/lint-cli/config-hash.ts
+++ b/src/lint-cli/config-hash.ts
@@ -115,14 +115,16 @@ export function computeConfigHash(cwd: string, configFiles: Array<string>): stri
  * @param cwd - The consumer project root.
  * @param key - The config-variant key from `resolveCacheKey`.
  * @param configFiles - The flat-config entry points (see `RepoFiles.configFiles`).
+ * @param hash - The config hash, when the caller already computed it (the
+ *   runner shares one hash between this bust and the ignore-set memo).
  * @returns The drift outcome.
  */
 export function applyConfigDriftBust(
 	cwd: string,
 	key: string,
 	configFiles: Array<string>,
+	hash: string | undefined = computeConfigHash(cwd, configFiles),
 ): ConfigDriftOutcome {
-	const hash = computeConfigHash(cwd, configFiles);
 	if (hash === undefined) {
 		return { busted: false, firstRun: false };
 	}

--- a/src/lint-cli/config-hash.ts
+++ b/src/lint-cli/config-hash.ts
@@ -112,18 +112,21 @@ export function computeConfigHash(cwd: string, configFiles: Array<string>): stri
  * Keyed per variant so each observes the drift independently on its own first
  * run after it (see {@link configHashStatePath}).
  *
+ * Takes the hash rather than computing it: the runner shares one hash between
+ * this bust and the ignore-set memo, and `undefined` then unambiguously means
+ * "unavailable" (no config entry point, or no resolvable TypeScript) rather
+ * than "the caller did not supply one".
+ *
  * @param cwd - The consumer project root.
  * @param key - The config-variant key from `resolveCacheKey`.
- * @param configFiles - The flat-config entry points (see `RepoFiles.configFiles`).
- * @param hash - The config hash, when the caller already computed it (the
- *   runner shares one hash between this bust and the ignore-set memo).
+ * @param hash - The config hash from {@link computeConfigHash}, or `undefined`
+ *   when it could not be computed (the check is then a no-op).
  * @returns The drift outcome.
  */
 export function applyConfigDriftBust(
 	cwd: string,
 	key: string,
-	configFiles: Array<string>,
-	hash: string | undefined = computeConfigHash(cwd, configFiles),
+	hash: string | undefined,
 ): ConfigDriftOutcome {
 	if (hash === undefined) {
 		return { busted: false, firstRun: false };

--- a/src/lint-cli/constants.ts
+++ b/src/lint-cli/constants.ts
@@ -2,7 +2,17 @@
 import { parseBoundedInteger } from "./parse.ts";
 
 /** Default number of files a single ESLint worker should handle. */
-export const DEFAULT_FILES_PER_WORKER = 350;
+export const DEFAULT_FILES_PER_WORKER = 300;
+
+/**
+ * Absolute worker cap for the passes that build a TypeScript program. Measured
+ * on a 32-thread / 16-core machine against a 3191-file type-aware run: 4-6
+ * workers all land at ~37-40s, then 8 workers regress to ~51s — concurrent
+ * program builds saturate memory bandwidth well before they saturate cores.
+ * Applies on top of the shared worker cap, and only bites on machines
+ * with 28 or more threads; an explicit `LINT_MAX_WORKERS` overrides it.
+ */
+export const TYPED_MAX_WORKERS = 6;
 
 /**
  * Default files-per-worker for the fast (`--type-aware=off`) pass. A syntactic

--- a/src/lint-cli/constants.ts
+++ b/src/lint-cli/constants.ts
@@ -66,9 +66,8 @@ export function cacheFileFor(baseName: string, key: string): string {
 // - LINTABLE_EXTENSIONS (GLOB_LINTABLE_EXTENSIONS): every extension the preset
 //   lints by default — TS/JS family plus JSONC, YAML, TOML, Markdown and Lua.
 //   A consumer that disables one of these features never caches those files, so
-//   they count as dirty every run and mildly inflate the worker count. That is
-//   harmless (a worker of cheap non-TS files never builds a TS program) and
-//   preferable to undercounting, so there is no knob.
+//   they would count as dirty every run; `resolveIgnoredFiles` drops them,
+//   since ESLint reports a file that no config matches as ignored.
 // - TYPE_AWARE_EXTENSIONS (GLOB_SRC_EXTENSIONS): the TS/JS-family subset the
 //   type-aware (`--type-aware=only`) config lints and the only files that ever
 //   enter the type-aware cache, so the typed pass sizes from just this subset.

--- a/src/lint-cli/files.ts
+++ b/src/lint-cli/files.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import picomatch from "picomatch";
 
+import { normalizePath } from "./cache.ts";
 import {
 	CACHE_BUST_PATTERNS,
 	ESLINT_CONFIG_FILE_PATTERN,
@@ -107,6 +108,29 @@ export function collectRepoFiles(cwd: string, targets: Array<string>): RepoFiles
 	const configFiles = bustFiles.filter(isConfigEntryPoint);
 
 	return { bustFiles, configFiles, lintable, targetsOutsideCwd, typeAware };
+}
+
+/**
+ * Drop the files ESLint declines to lint from the *target* lists, leaving the
+ * rest of the listing untouched.
+ *
+ * Only the `lintable` and `typeAware` lists are lint targets. The `bustFiles`
+ * and `configFiles` lists are whole-project cache-bust inputs — a tsconfig or
+ * lockfile is never linted, so filtering them by "would ESLint lint this" would
+ * empty them. Any list added to {@link RepoFiles} later has to make that same
+ * choice here, which is why this lives beside the type rather than at the call
+ * site.
+ *
+ * @param files - The collected repository files.
+ * @param ignored - The ignored set from `resolveIgnoredFiles` (normalized keys).
+ * @returns The listing with its target lists filtered.
+ */
+export function withoutIgnored(files: RepoFiles, ignored: ReadonlySet<string>): RepoFiles {
+	return {
+		...files,
+		lintable: retained(files.lintable, ignored),
+		typeAware: retained(files.typeAware, ignored),
+	};
 }
 
 /**
@@ -301,4 +325,8 @@ function walkFallback(cwd: string, targets: Array<string>): Array<string> {
 
 function listFiles(cwd: string, targets: Array<string>): Array<string> {
 	return gitListFiles(cwd, targets) ?? walkFallback(cwd, targets);
+}
+
+function retained(files: Array<string>, ignored: ReadonlySet<string>): Array<string> {
+	return files.filter((file) => !ignored.has(normalizePath(file)));
 }

--- a/src/lint-cli/ignored-child.ts
+++ b/src/lint-cli/ignored-child.ts
@@ -39,18 +39,17 @@ interface EslintModule {
  * @rejects {Error} When ESLint cannot be resolved from either location.
  */
 async function loadEslint(cwd: string): Promise<EslintModule> {
-	const require = createRequire(path.join(cwd, "noop.js"));
+	// A synthetic basename: `createRequire` resolves relative to a *file*, and
+	// this one is spelled so it can never collide with a real consumer module.
+	const requireFrom = createRequire(path.join(cwd, "__isentinel-lint__.js"));
 	let entry: string;
 	try {
-		entry = require.resolve("eslint");
+		entry = requireFrom.resolve("eslint");
 	} catch {
-		return import("eslint");
+		entry = createRequire(import.meta.url).resolve("eslint");
 	}
 
-	const namespace = (await import(pathToFileURL(entry).href)) as
-		| EslintModule
-		| { default: EslintModule };
-	return "ESLint" in namespace ? namespace : namespace.default;
+	return (await import(pathToFileURL(entry).href)) as EslintModule;
 }
 
 async function main(): Promise<void> {

--- a/src/lint-cli/ignored-child.ts
+++ b/src/lint-cli/ignored-child.ts
@@ -1,0 +1,79 @@
+/**
+ * Internal helper process for {@link file://./ignored.ts}. Loads the consumer's
+ * resolved ESLint config once and writes the ignored subset of a target list to
+ * a JSON file.
+ *
+ * Run as a child rather than in-process for two reasons: `isPathIgnored` is
+ * async while `plan` is synchronous end to end, and loading a consumer's flat
+ * config pulls their whole plugin tree (and jiti) into memory — 6-10s and
+ * several hundred MB in a large project, neither of which should outlive the
+ * one query the runner needs.
+ *
+ * Invoked as `node <this file> <cwd> <outFile>` with the JSON target array on
+ * stdin.
+ */
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+/** The subset of the `ESLint` class this helper uses. */
+interface EslintLike {
+	isPathIgnored: (filePath: string) => Promise<boolean>;
+}
+
+/** The subset of the `eslint` module namespace this helper uses. */
+interface EslintModule {
+	ESLint: new (options: { cwd: string }) => EslintLike;
+}
+
+/**
+ * Load the ESLint the consumer's config will be linted with: their own
+ * installation, resolved from `cwd`, falling back to the one resolvable from
+ * this file (the hoisted peer dependency) when `cwd` has no `node_modules` of
+ * its own — the case in the fixture-based tests.
+ *
+ * @param cwd - The consumer project root.
+ * @returns The `eslint` module namespace.
+ * @rejects {Error} When ESLint cannot be resolved from either location.
+ */
+async function loadEslint(cwd: string): Promise<EslintModule> {
+	const require = createRequire(path.join(cwd, "noop.js"));
+	let entry: string;
+	try {
+		entry = require.resolve("eslint");
+	} catch {
+		return import("eslint");
+	}
+
+	const namespace = (await import(pathToFileURL(entry).href)) as
+		| EslintModule
+		| { default: EslintModule };
+	return "ESLint" in namespace ? namespace : namespace.default;
+}
+
+async function main(): Promise<void> {
+	const [cwd, outFile] = process.argv.slice(2);
+	if (cwd === undefined || outFile === undefined) {
+		throw new Error("usage: node ignored-child <cwd> <outFile> (targets on stdin)");
+	}
+
+	const targets = JSON.parse(fs.readFileSync(0, "utf8")) as Array<string>;
+	const { ESLint } = await loadEslint(cwd);
+	const eslint = new ESLint({ cwd });
+
+	const ignored: Array<string> = [];
+	for (const target of targets) {
+		if (await eslint.isPathIgnored(target)) {
+			ignored.push(target);
+		}
+	}
+
+	fs.writeFileSync(outFile, JSON.stringify(ignored));
+}
+
+void main().catch(() => {
+	// The parent treats a non-zero exit as "no filtering"; nothing to report.
+	process.exitCode = 1;
+});

--- a/src/lint-cli/ignored.ts
+++ b/src/lint-cli/ignored.ts
@@ -1,0 +1,175 @@
+// cspell:words lintable typeaware
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+/** The persisted form of a resolved ignore set. */
+interface IgnoredState {
+	/** The config hash the set was computed against. */
+	hash: string;
+	/** The ignored target paths, exactly as they were passed in. */
+	ignored: Array<string>;
+}
+
+/** Reused for every miss, so callers never allocate on the no-op path. */
+const EMPTY: ReadonlySet<string> = new Set<string>();
+
+/** Inputs to {@link resolveIgnoredFiles}. */
+export interface IgnoredFilesContext {
+	/** The config-variant key from `resolveCacheKey`. */
+	key: string;
+	/** The config hash for this run, or `undefined` when unavailable. */
+	configHash: string | undefined;
+	/** The consumer project root. */
+	cwd: string;
+	/**
+	 * Whether the run may spawn the helper and write state (`--print` may
+	 * not).
+	 */
+	mutate: boolean;
+	/** Every lintable target, absolute (see `RepoFiles.lintable`). */
+	targets: Array<string>;
+}
+
+/**
+ * Resolve the persisted ignore-set file for a config variant. Stored beside the
+ * config hash it is keyed by, so `node_modules` removal clears both together.
+ *
+ * @param cwd - The consumer project root.
+ * @param key - The config-variant key from `resolveCacheKey`.
+ * @returns The absolute path to the stored ignore-set file.
+ */
+export function ignoredStatePath(cwd: string, key: string): string {
+	return path.join(cwd, "node_modules", ".cache", "isentinel-lint", `ignored-${key}`);
+}
+
+/**
+ * The lint targets ESLint declines to lint, so the runner can drop them from
+ * its dirty count.
+ *
+ * The file lists come from `git ls-files` filtered by extension and know
+ * nothing of the config's own `ignores`. ESLint writes no cache entry for a
+ * file it never lints, so every consumer-ignored file is reported dirty on
+ * every run, forever — which floors the type-aware pass's dirty count above
+ * zero and makes its auto-skip unreachable.
+ *
+ * Asking ESLint itself is the only correct answer, but loading a consumer's
+ * flat config costs several seconds. It is therefore memoised against the same
+ * config hash that drives the cache-drift bust: the answer can only change when
+ * the resolved config changes, and that already forces a full re-lint, so the
+ * recompute rides along with a run that was going to be slow anyway.
+ *
+ * Targets absent from a stored set are treated as not-ignored. That is the safe
+ * direction — it can only over-count dirty files, never skip a pass that had
+ * work to do — but it does mean a newly added ignored file keeps the typed pass
+ * awake until the next config change.
+ *
+ * @param context - The cwd, variant key, config hash, targets and mutate flag.
+ * @returns The ignored subset of `targets`, or an empty set when unavailable.
+ */
+export function resolveIgnoredFiles({
+	key,
+	configHash,
+	cwd,
+	mutate,
+	targets,
+}: IgnoredFilesContext): ReadonlySet<string> {
+	if (configHash === undefined || targets.length === 0) {
+		return EMPTY;
+	}
+
+	const statePath = ignoredStatePath(cwd, key);
+	const stored = readState(statePath);
+	if (stored?.hash === configHash) {
+		return new Set(stored.ignored);
+	}
+
+	if (!mutate) {
+		return EMPTY;
+	}
+
+	const ignored = queryIgnoredFiles(cwd, targets);
+	if (ignored === undefined) {
+		return EMPTY;
+	}
+
+	writeState(statePath, { hash: configHash, ignored });
+	return new Set(ignored);
+}
+
+/**
+ * Drop the ignored entries from a file list, preserving order.
+ *
+ * @param files - The target files.
+ * @param ignored - The ignored set from {@link resolveIgnoredFiles}.
+ * @returns The retained files (`files` itself when nothing was dropped).
+ */
+export function withoutIgnored(files: Array<string>, ignored: ReadonlySet<string>): Array<string> {
+	if (ignored.size === 0) {
+		return files;
+	}
+
+	return files.filter((file) => !ignored.has(file));
+}
+
+/**
+ * Resolve the helper entry point: the built `lint-ignored.mjs` beside this
+ * bundle, falling back to the TypeScript source sibling when running from
+ * `src` (tests and `node --experimental-strip-types`).
+ *
+ * @returns The absolute path to the helper module.
+ */
+function resolveHelperPath(): string {
+	const built = fileURLToPath(new URL("./lint-ignored.mjs", import.meta.url));
+	return fs.existsSync(built)
+		? built
+		: fileURLToPath(new URL("./ignored-child.ts", import.meta.url));
+}
+
+/**
+ * Spawn the helper and read back the ignored subset. Every failure mode (no
+ * resolvable ESLint, a config that throws, a malformed result) degrades to
+ * `undefined`, which the caller treats as "no filtering" — the behaviour before
+ * this existed.
+ *
+ * @param cwd - The consumer project root.
+ * @param targets - The target files to classify.
+ * @returns The ignored targets, or `undefined` when the query failed.
+ */
+function queryIgnoredFiles(cwd: string, targets: Array<string>): Array<string> | undefined {
+	const outFile = path.join(
+		fs.mkdtempSync(path.join(os.tmpdir(), "isentinel-lint-ignored-")),
+		"ignored.json",
+	);
+
+	try {
+		execFileSync(process.execPath, [resolveHelperPath(), cwd, outFile], {
+			cwd,
+			input: JSON.stringify(targets),
+			maxBuffer: 64 * 1024 * 1024,
+			stdio: ["pipe", "ignore", "ignore"],
+		});
+		const parsed = JSON.parse(fs.readFileSync(outFile, "utf8")) as unknown;
+		return Array.isArray(parsed) ? (parsed as Array<string>) : undefined;
+	} catch {
+		return undefined;
+	} finally {
+		fs.rmSync(path.dirname(outFile), { force: true, recursive: true });
+	}
+}
+
+function readState(statePath: string): IgnoredState | undefined {
+	try {
+		return JSON.parse(fs.readFileSync(statePath, "utf8")) as IgnoredState;
+	} catch {
+		return undefined;
+	}
+}
+
+function writeState(statePath: string, state: IgnoredState): void {
+	fs.mkdirSync(path.dirname(statePath), { recursive: true });
+	fs.writeFileSync(statePath, JSON.stringify(state));
+}

--- a/src/lint-cli/ignored.ts
+++ b/src/lint-cli/ignored.ts
@@ -4,14 +4,26 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
+
+import { normalizePath } from "./cache.ts";
+import { resolveIgnoredHelper } from "./resolve.ts";
+
+/**
+ * Schema version of the persisted ignore set. The config hash only says the
+ * config itself is unchanged, so it cannot catch a CLI upgrade that changed the
+ * stored shape — a stale file would then be accepted and every lookup would
+ * silently miss. Bump this whenever {@link IgnoredState} changes meaning.
+ */
+const IGNORED_STATE_VERSION = 1;
 
 /** The persisted form of a resolved ignore set. */
 interface IgnoredState {
 	/** The config hash the set was computed against. */
 	hash: string;
-	/** The ignored target paths, exactly as they were passed in. */
+	/** The ignored targets, as {@link normalizePath} keys. */
 	ignored: Array<string>;
+	/** The {@link IGNORED_STATE_VERSION} the file was written by. */
+	version: number;
 }
 
 /** Reused for every miss, so callers never allocate on the no-op path. */
@@ -47,8 +59,8 @@ export function ignoredStatePath(cwd: string, key: string): string {
 }
 
 /**
- * The lint targets ESLint declines to lint, so the runner can drop them from
- * its dirty count.
+ * The lint targets ESLint declines to lint, as {@link normalizePath} keys, so
+ * the runner can drop them from its dirty count.
  *
  * The file lists come from `git ls-files` filtered by extension and know
  * nothing of the config's own `ignores`. ESLint writes no cache entry for a
@@ -59,8 +71,10 @@ export function ignoredStatePath(cwd: string, key: string): string {
  * Asking ESLint itself is the only correct answer, but loading a consumer's
  * flat config costs several seconds. It is therefore memoised against the same
  * config hash that drives the cache-drift bust: the answer can only change when
- * the resolved config changes, and that already forces a full re-lint, so the
- * recompute rides along with a run that was going to be slow anyway.
+ * the resolved config changes. That recompute is a blocking cost on the run
+ * that pays it, but it is a run whose caches the drift bust just deleted, so
+ * every file re-lints anyway — and the ignore set still sizes that re-lint's
+ * workers, which is why it is computed then rather than deferred.
  *
  * Targets absent from a stored set are treated as not-ignored. That is the safe
  * direction — it can only over-count dirty files, never skip a pass that had
@@ -83,7 +97,7 @@ export function resolveIgnoredFiles({
 
 	const statePath = ignoredStatePath(cwd, key);
 	const stored = readState(statePath);
-	if (stored?.hash === configHash) {
+	if (stored?.hash === configHash && stored.version === IGNORED_STATE_VERSION) {
 		return new Set(stored.ignored);
 	}
 
@@ -91,42 +105,13 @@ export function resolveIgnoredFiles({
 		return EMPTY;
 	}
 
-	const ignored = queryIgnoredFiles(cwd, targets);
+	const ignored = queryIgnoredFiles(cwd, targets)?.map((file) => normalizePath(file));
 	if (ignored === undefined) {
 		return EMPTY;
 	}
 
-	writeState(statePath, { hash: configHash, ignored });
+	writeState(statePath, { hash: configHash, ignored, version: IGNORED_STATE_VERSION });
 	return new Set(ignored);
-}
-
-/**
- * Drop the ignored entries from a file list, preserving order.
- *
- * @param files - The target files.
- * @param ignored - The ignored set from {@link resolveIgnoredFiles}.
- * @returns The retained files (`files` itself when nothing was dropped).
- */
-export function withoutIgnored(files: Array<string>, ignored: ReadonlySet<string>): Array<string> {
-	if (ignored.size === 0) {
-		return files;
-	}
-
-	return files.filter((file) => !ignored.has(file));
-}
-
-/**
- * Resolve the helper entry point: the built `lint-ignored.mjs` beside this
- * bundle, falling back to the TypeScript source sibling when running from
- * `src` (tests and `node --experimental-strip-types`).
- *
- * @returns The absolute path to the helper module.
- */
-function resolveHelperPath(): string {
-	const built = fileURLToPath(new URL("./lint-ignored.mjs", import.meta.url));
-	return fs.existsSync(built)
-		? built
-		: fileURLToPath(new URL("./ignored-child.ts", import.meta.url));
 }
 
 /**
@@ -135,18 +120,21 @@ function resolveHelperPath(): string {
  * `undefined`, which the caller treats as "no filtering" — the behaviour before
  * this existed.
  *
+ * The result comes back through a scratch file rather than stdout: loading a
+ * consumer's config evaluates their plugins, and anything one of those prints
+ * would land in the middle of the JSON.
+ *
  * @param cwd - The consumer project root.
  * @param targets - The target files to classify.
  * @returns The ignored targets, or `undefined` when the query failed.
  */
 function queryIgnoredFiles(cwd: string, targets: Array<string>): Array<string> | undefined {
-	const outFile = path.join(
-		fs.mkdtempSync(path.join(os.tmpdir(), "isentinel-lint-ignored-")),
-		"ignored.json",
-	);
+	// One query per process at a time, so the pid is collision-free even when
+	// the consumer lints several packages in parallel.
+	const outFile = path.join(os.tmpdir(), `isentinel-lint-ignored-${process.pid}.json`);
 
 	try {
-		execFileSync(process.execPath, [resolveHelperPath(), cwd, outFile], {
+		execFileSync(process.execPath, [resolveIgnoredHelper(), cwd, outFile], {
 			cwd,
 			input: JSON.stringify(targets),
 			maxBuffer: 64 * 1024 * 1024,
@@ -157,7 +145,7 @@ function queryIgnoredFiles(cwd: string, targets: Array<string>): Array<string> |
 	} catch {
 		return undefined;
 	} finally {
-		fs.rmSync(path.dirname(outFile), { force: true, recursive: true });
+		fs.rmSync(outFile, { force: true });
 	}
 }
 

--- a/src/lint-cli/passes.ts
+++ b/src/lint-cli/passes.ts
@@ -1,7 +1,12 @@
 // cspell:words typeaware
 import { resolveFastFilesPerWorker } from "./concurrency.ts";
 import type { WorkerLimits } from "./concurrency.ts";
-import { CACHE_FILE_DEFAULT, CACHE_FILE_FAST, CACHE_FILE_TYPE_AWARE } from "./constants.ts";
+import {
+	CACHE_FILE_DEFAULT,
+	CACHE_FILE_FAST,
+	CACHE_FILE_TYPE_AWARE,
+	TYPED_MAX_WORKERS,
+} from "./constants.ts";
 import type { LintCliOptions, ToolLabel, TypeAwareMode } from "./types.ts";
 
 /**
@@ -34,6 +39,15 @@ export interface PassDescriptor {
 	/** `concurrently` prefix / ESLint child label. */
 	label: ToolLabel;
 	/**
+	 * Resolve the worker cap for this pass. The passes that build a TypeScript
+	 * program tighten the shared cap (see `TYPED_MAX_WORKERS`); the syntactic
+	 * fast pass, which builds none, keeps it.
+	 *
+	 * @param limits - The shared worker limits.
+	 * @returns The worker cap for this pass.
+	 */
+	maxWorkers: (limits: WorkerLimits) => number;
+	/**
 	 * Value for the child's `ESLINT_TYPE_AWARE`, moving in lockstep with the
 	 * label. `undefined` leaves it unset (the full config).
 	 */
@@ -50,6 +64,7 @@ export const FAST_PASS: PassDescriptor = {
 	filesPerWorker: (_limits, environment) => resolveFastFilesPerWorker(environment),
 	invalidation: "none",
 	label: "fast",
+	maxWorkers: (limits) => limits.maxWorkers,
 	typeAwareEnv: "off",
 	typeAwareOnly: false,
 };
@@ -60,6 +75,7 @@ export const TYPED_PASS: PassDescriptor = {
 	filesPerWorker: (limits) => limits.filesPerWorker,
 	invalidation: "only",
 	label: "typed",
+	maxWorkers: cappedMaxWorkers,
 	typeAwareEnv: "only",
 	typeAwareOnly: true,
 };
@@ -70,6 +86,7 @@ export const FULL_PASS: PassDescriptor = {
 	filesPerWorker: (limits) => limits.filesPerWorker,
 	invalidation: "full",
 	label: "eslint",
+	maxWorkers: cappedMaxWorkers,
 	typeAwareEnv: undefined,
 	typeAwareOnly: false,
 };
@@ -106,4 +123,17 @@ export function selectPasses(options: LintCliOptions, ci: boolean): Array<PassDe
 	}
 
 	return [FAST_PASS, TYPED_PASS];
+}
+
+/**
+ * Tighten the shared worker cap for a pass that builds a TypeScript program,
+ * unless the user pinned `LINT_MAX_WORKERS` — an explicit request always wins.
+ *
+ * @param limits - The shared worker limits.
+ * @returns The capped worker count.
+ */
+function cappedMaxWorkers(limits: WorkerLimits): number {
+	return limits.explicitMaxWorkers
+		? limits.maxWorkers
+		: Math.min(limits.maxWorkers, TYPED_MAX_WORKERS);
 }

--- a/src/lint-cli/passes.ts
+++ b/src/lint-cli/passes.ts
@@ -1,12 +1,7 @@
 // cspell:words typeaware
 import { resolveFastFilesPerWorker } from "./concurrency.ts";
 import type { WorkerLimits } from "./concurrency.ts";
-import {
-	CACHE_FILE_DEFAULT,
-	CACHE_FILE_FAST,
-	CACHE_FILE_TYPE_AWARE,
-	TYPED_MAX_WORKERS,
-} from "./constants.ts";
+import { CACHE_FILE_DEFAULT, CACHE_FILE_FAST, CACHE_FILE_TYPE_AWARE } from "./constants.ts";
 import type { LintCliOptions, ToolLabel, TypeAwareMode } from "./types.ts";
 
 /**
@@ -39,15 +34,6 @@ export interface PassDescriptor {
 	/** `concurrently` prefix / ESLint child label. */
 	label: ToolLabel;
 	/**
-	 * Resolve the worker cap for this pass. The passes that build a TypeScript
-	 * program tighten the shared cap (see `TYPED_MAX_WORKERS`); the syntactic
-	 * fast pass, which builds none, keeps it.
-	 *
-	 * @param limits - The shared worker limits.
-	 * @returns The worker cap for this pass.
-	 */
-	maxWorkers: (limits: WorkerLimits) => number;
-	/**
 	 * Value for the child's `ESLINT_TYPE_AWARE`, moving in lockstep with the
 	 * label. `undefined` leaves it unset (the full config).
 	 */
@@ -64,7 +50,6 @@ export const FAST_PASS: PassDescriptor = {
 	filesPerWorker: (_limits, environment) => resolveFastFilesPerWorker(environment),
 	invalidation: "none",
 	label: "fast",
-	maxWorkers: (limits) => limits.maxWorkers,
 	typeAwareEnv: "off",
 	typeAwareOnly: false,
 };
@@ -75,7 +60,6 @@ export const TYPED_PASS: PassDescriptor = {
 	filesPerWorker: (limits) => limits.filesPerWorker,
 	invalidation: "only",
 	label: "typed",
-	maxWorkers: cappedMaxWorkers,
 	typeAwareEnv: "only",
 	typeAwareOnly: true,
 };
@@ -86,7 +70,6 @@ export const FULL_PASS: PassDescriptor = {
 	filesPerWorker: (limits) => limits.filesPerWorker,
 	invalidation: "full",
 	label: "eslint",
-	maxWorkers: cappedMaxWorkers,
 	typeAwareEnv: undefined,
 	typeAwareOnly: false,
 };
@@ -126,14 +109,15 @@ export function selectPasses(options: LintCliOptions, ci: boolean): Array<PassDe
 }
 
 /**
- * Tighten the shared worker cap for a pass that builds a TypeScript program,
- * unless the user pinned `LINT_MAX_WORKERS` — an explicit request always wins.
+ * The worker cap for a pass. `invalidation` already records whether a pass
+ * builds a TypeScript program — the fast pass runs no builder precisely because
+ * it builds none — so it doubles as the cap selector rather than restating the
+ * same fact per descriptor.
  *
+ * @param descriptor - The pass being sized.
  * @param limits - The shared worker limits.
- * @returns The capped worker count.
+ * @returns The worker cap for this pass.
  */
-function cappedMaxWorkers(limits: WorkerLimits): number {
-	return limits.explicitMaxWorkers
-		? limits.maxWorkers
-		: Math.min(limits.maxWorkers, TYPED_MAX_WORKERS);
+export function maxWorkersFor(descriptor: PassDescriptor, limits: WorkerLimits): number {
+	return descriptor.invalidation === "none" ? limits.maxWorkers : limits.typedMaxWorkers;
 }

--- a/src/lint-cli/resolve.ts
+++ b/src/lint-cli/resolve.ts
@@ -1,4 +1,5 @@
 import { getPackageInfoSync } from "local-pkg";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -52,4 +53,23 @@ export function resolveLocalBin(name: string, cwd: string): string {
  */
 export function resolveAgentsFormatter(): string {
 	return fileURLToPath(new URL("./formatter-agents.mjs", import.meta.url));
+}
+
+/**
+ * Resolve the ignored-files helper shipped alongside this entry (built from
+ * `src/lint-cli/ignored-child.ts` to `lint-ignored.mjs`).
+ *
+ * Unlike {@link resolveAgentsFormatter} this falls back to the TypeScript
+ * source sibling, because the runner spawns it itself and the fixture tests run
+ * from `src` where no bundle exists. The fallback means the tests never
+ * exercise the shipped path — a broken or unshipped `dist` entry degrades the
+ * runner to "no ignore filtering" rather than failing.
+ *
+ * @returns The absolute path to the helper module.
+ */
+export function resolveIgnoredHelper(): string {
+	const built = fileURLToPath(new URL("./lint-ignored.mjs", import.meta.url));
+	return fs.existsSync(built)
+		? built
+		: fileURLToPath(new URL("./ignored-child.ts", import.meta.url));
 }

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -544,19 +544,16 @@ function sizePass(descriptor: PassDescriptor, context: SizePassContext): PassPla
 	const dirtyCount = passDirtyCount(descriptor, cacheFile, context);
 	const conservative = context.files.targetsOutsideCwd;
 	const filesPerWorker = descriptor.filesPerWorker(context.limits, context.environment);
+	const maxWorkers = descriptor.maxWorkers(context.limits);
 
 	// Outside-cwd targets are absent from the cwd-relative listing, so the dirty
 	// count under-counts them — size for the worker cap instead (maxWorkers *
 	// filesPerWorker ceils back to exactly maxWorkers).
-	const sizingDirtyCount = conservative ? context.limits.maxWorkers * filesPerWorker : dirtyCount;
+	const sizingDirtyCount = conservative ? maxWorkers * filesPerWorker : dirtyCount;
 
 	const concurrency =
 		context.options.concurrency ??
-		computeWorkerCount({
-			dirtyCount: sizingDirtyCount,
-			filesPerWorker,
-			maxWorkers: context.limits.maxWorkers,
-		});
+		computeWorkerCount({ dirtyCount: sizingDirtyCount, filesPerWorker, maxWorkers });
 
 	// The typed pass may only auto-skip when the dirty count is trustworthy; an
 	// outside-cwd target makes it unknowable, so never skip in that case.

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -17,11 +17,12 @@ import {
 	formatCommandLine,
 } from "./command.ts";
 import { computeWorkerCount, resolveWorkerLimits } from "./concurrency.ts";
-import { applyConfigDriftBust } from "./config-hash.ts";
+import { applyConfigDriftBust, computeConfigHash } from "./config-hash.ts";
 import { cacheFileFor } from "./constants.ts";
 import { collectRepoFiles } from "./files.ts";
 import type { RepoFiles } from "./files.ts";
 import { resolveOxlintRun } from "./hybrid.ts";
+import { resolveIgnoredFiles, withoutIgnored } from "./ignored.ts";
 import { applyTypeAwareInvalidation } from "./invalidation.ts";
 import { parseArguments } from "./options.ts";
 import { applyPackageJsonBust } from "./package-hash.ts";
@@ -201,6 +202,13 @@ export function plan(
 	// this run selected.
 	const canMutateCaches = mutate && options.cache;
 	const hasTypeAwarePass = descriptors.some((descriptor) => descriptor.invalidation !== "none");
+
+	// One hash per run, shared by the drift bust below and the ignore-set memo:
+	// both answer "has the resolved config changed since last time", and the
+	// closure walk is not worth doing twice. Only meaningful with caching on —
+	// `--no-cache` counts every file dirty regardless.
+	const configHash = options.cache ? computeConfigHash(cwd, files.configFiles) : undefined;
+
 	if (canMutateCaches) {
 		// Config drift through a module `eslint.config.*` imports shifts ESLint's
 		// per-entry `hashOfConfig` (a full re-lint) but touches no bust file, so
@@ -209,7 +217,7 @@ export function plan(
 		// three of this variant's caches when it changed. Applies to every pass
 		// (a config change can alter a syntactic lint), so it runs before the
 		// type-aware-only package.json bust.
-		applyConfigDriftBust(cwd, key, files.configFiles);
+		applyConfigDriftBust(cwd, key, files.configFiles, configHash);
 	}
 
 	if (canMutateCaches && hasTypeAwarePass) {
@@ -218,6 +226,17 @@ export function plan(
 
 	const clearedCaches = new Set(canMutateCaches ? sweepStaleCaches(cwd, newestBustMtime) : []);
 
+	// Drop the files ESLint declines to lint before anything sizes from them:
+	// they never enter a cache, so they would otherwise read as dirty forever
+	// and hold the typed pass's dirty count above zero (see
+	// `resolveIgnoredFiles`).
+	const ignored = resolveIgnoredFiles({ key, configHash, cwd, mutate, targets: files.lintable });
+	const sizingFiles: RepoFiles = {
+		...files,
+		lintable: withoutIgnored(files.lintable, ignored),
+		typeAware: withoutIgnored(files.typeAware, ignored),
+	};
+
 	const multiPass = descriptors.length > 1;
 	const passes = descriptors.map((descriptor) => {
 		return sizePass(descriptor, {
@@ -225,7 +244,7 @@ export function plan(
 			clearedCaches,
 			cwd,
 			environment,
-			files,
+			files: sizingFiles,
 			limits,
 			multiPass,
 			mutate,

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -19,14 +19,14 @@ import {
 import { computeWorkerCount, resolveWorkerLimits } from "./concurrency.ts";
 import { applyConfigDriftBust, computeConfigHash } from "./config-hash.ts";
 import { cacheFileFor } from "./constants.ts";
-import { collectRepoFiles } from "./files.ts";
+import { collectRepoFiles, withoutIgnored } from "./files.ts";
 import type { RepoFiles } from "./files.ts";
 import { resolveOxlintRun } from "./hybrid.ts";
-import { resolveIgnoredFiles, withoutIgnored } from "./ignored.ts";
+import { resolveIgnoredFiles } from "./ignored.ts";
 import { applyTypeAwareInvalidation } from "./invalidation.ts";
 import { parseArguments } from "./options.ts";
 import { applyPackageJsonBust } from "./package-hash.ts";
-import { selectPasses, TYPED_PASS } from "./passes.ts";
+import { maxWorkersFor, selectPasses, TYPED_PASS } from "./passes.ts";
 import type { PassDescriptor } from "./passes.ts";
 import { resolveAgentsFormatter, resolveLocalBin } from "./resolve.ts";
 import type { ChildCommand, LintCliOptions, ToolLabel } from "./types.ts";
@@ -217,7 +217,7 @@ export function plan(
 		// three of this variant's caches when it changed. Applies to every pass
 		// (a config change can alter a syntactic lint), so it runs before the
 		// type-aware-only package.json bust.
-		applyConfigDriftBust(cwd, key, files.configFiles, configHash);
+		applyConfigDriftBust(cwd, key, configHash);
 	}
 
 	if (canMutateCaches && hasTypeAwarePass) {
@@ -231,11 +231,7 @@ export function plan(
 	// and hold the typed pass's dirty count above zero (see
 	// `resolveIgnoredFiles`).
 	const ignored = resolveIgnoredFiles({ key, configHash, cwd, mutate, targets: files.lintable });
-	const sizingFiles: RepoFiles = {
-		...files,
-		lintable: withoutIgnored(files.lintable, ignored),
-		typeAware: withoutIgnored(files.typeAware, ignored),
-	};
+	const sizingFiles = withoutIgnored(files, ignored);
 
 	const multiPass = descriptors.length > 1;
 	const passes = descriptors.map((descriptor) => {
@@ -544,7 +540,7 @@ function sizePass(descriptor: PassDescriptor, context: SizePassContext): PassPla
 	const dirtyCount = passDirtyCount(descriptor, cacheFile, context);
 	const conservative = context.files.targetsOutsideCwd;
 	const filesPerWorker = descriptor.filesPerWorker(context.limits, context.environment);
-	const maxWorkers = descriptor.maxWorkers(context.limits);
+	const maxWorkers = maxWorkersFor(descriptor, context.limits);
 
 	// Outside-cwd targets are absent from the cwd-relative listing, so the dirty
 	// count under-counts them — size for the worker cap instead (maxWorkers *

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -549,6 +549,46 @@ describe("composeCommands typed-pass skip", () => {
 		);
 	});
 
+	it("skips the typed pass when the only uncached files are ESLint-ignored", () => {
+		expect.hasAssertions();
+
+		withFixture(
+			{
+				// A `.mjs` config so ESLint loads it without a TypeScript loader
+				// in the fixture's bare node_modules.
+				"eslint.config.mjs":
+					'export default [{ files: ["**/*.{ts,mjs}"], rules: {} }, ' +
+					'{ ignores: ["src/ignored.ts"] }];\n',
+				"src/a.ts": "export function a(): number { return 1; }\n",
+				"src/ignored.ts": "export function ignored(): number { return 2; }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+			(directory) => {
+				const cacheFile = path.join(directory, TYPE_AWARE_CACHE);
+				// Seed every file ESLint actually lints. `src/ignored.ts` is a
+				// target of the git listing but ESLint never lints it, so it
+				// has no cache entry and reads as dirty on every run — the
+				// phantom-dirty file that used to make the skip unreachable.
+				computeAffectedFiles(directory, "only", TEST_KEY);
+				seedCache(cacheFile, [
+					path.join(directory, "src/a.ts"),
+					path.join(directory, "eslint.config.mjs"),
+				]);
+
+				const { commands, notice } = withoutGitEnvironment(() => {
+					return composeCommands(parseArguments([]), {
+						cwd: directory,
+						dryRun: false,
+						environment: {},
+					});
+				});
+
+				expect(commands.map((command) => command.label)).not.toContain("typed");
+				expect(notice).toMatch(/skipping the type-aware/);
+			},
+		);
+	});
+
 	it("never skips the typed pass when a target resolves outside cwd", () => {
 		expect.hasAssertions();
 
@@ -794,7 +834,11 @@ describe("resolveJsonModule invalidation", () => {
 /** A config whose resolved shape depends on a local module it imports. */
 const CONFIG_IMPORT_FIXTURE = {
 	"eslint-rules.ts": "export const rules = { rules: {} };\n",
-	"eslint.config.ts": "import './eslint-rules';\nexport default [];\n",
+	// The config must actually match the fixture's files: ESLint reports a file
+	// no config matches as ignored, and the runner drops ignored files from its
+	// dirty count.
+	"eslint.config.ts":
+		"import './eslint-rules';\nexport default [{ files: ['**/*.ts'], rules: {} }];\n",
 	"src/a.ts": "export function a(): number { return 1; }\n",
 	"tsconfig.json": TSCONFIG,
 };

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -137,6 +137,27 @@ function builderStateFiles(directory: string, prefix: string): Array<string> {
 	return fs.readdirSync(stateDirectory).filter((name) => name.startsWith(prefix));
 }
 
+/**
+ * Compose a default (mutating) run inside a fixture, without the ambient git
+ * environment.
+ *
+ * @param directory - The fixture project root.
+ * @param argv - The CLI arguments (default: none).
+ * @returns The composed command plan.
+ */
+function composeInFixture(
+	directory: string,
+	argv: Array<string> = [],
+): ReturnType<typeof composeCommands> {
+	return withoutGitEnvironment(() => {
+		return composeCommands(parseArguments(argv), {
+			cwd: directory,
+			dryRun: false,
+			environment: {},
+		});
+	});
+}
+
 function seedCache(cacheFile: string, files: Array<string>): void {
 	const cache = fileEntryCache.create(path.basename(cacheFile), path.dirname(cacheFile), false);
 	for (const file of files) {
@@ -532,13 +553,7 @@ describe("composeCommands typed-pass skip", () => {
 				computeAffectedFiles(directory, "only", TEST_KEY);
 				seedCache(cacheFile, [fileA]);
 
-				const { commands, notice } = withoutGitEnvironment(() => {
-					return composeCommands(parseArguments([]), {
-						cwd: directory,
-						dryRun: false,
-						environment: {},
-					});
-				});
+				const { commands, notice } = composeInFixture(directory);
 
 				const labels = commands.map((command) => command.label);
 
@@ -575,13 +590,7 @@ describe("composeCommands typed-pass skip", () => {
 					path.join(directory, "eslint.config.mjs"),
 				]);
 
-				const { commands, notice } = withoutGitEnvironment(() => {
-					return composeCommands(parseArguments([]), {
-						cwd: directory,
-						dryRun: false,
-						environment: {},
-					});
-				});
+				const { commands, notice } = composeInFixture(directory);
 
 				expect(commands.map((command) => command.label)).not.toContain("typed");
 				expect(notice).toMatch(/skipping the type-aware/);
@@ -606,13 +615,7 @@ describe("composeCommands typed-pass skip", () => {
 				// "src" is in-cwd and clean, but "../elsewhere" escapes cwd, so
 				// the dirty count is unknowable: the typed pass must not
 				// auto-skip and a notice is emitted.
-				const { commands, notice } = withoutGitEnvironment(() => {
-					return composeCommands(parseArguments(["src", "../elsewhere"]), {
-						cwd: directory,
-						dryRun: false,
-						environment: {},
-					});
-				});
+				const { commands, notice } = composeInFixture(directory, ["src", "../elsewhere"]);
 
 				expect(commands.map((command) => command.label)).toContain("typed");
 				expect(notice).toMatch(/resolves outside the working directory/);
@@ -634,13 +637,7 @@ describe("composeCommands typed-pass skip", () => {
 				computeAffectedFiles(directory, "only", TEST_KEY);
 				seedCache(cacheFile, [fileA]);
 
-				const { commands, notice } = withoutGitEnvironment(() => {
-					return composeCommands(parseArguments(["--type-aware=only"]), {
-						cwd: directory,
-						dryRun: false,
-						environment: {},
-					});
-				});
+				const { commands, notice } = composeInFixture(directory, ["--type-aware=only"]);
 
 				expect(commands.map((command) => command.label)).toContain("typed");
 				expect(notice).toBeUndefined();
@@ -847,6 +844,16 @@ function configBustFiles(directory: string): Array<string> {
 	return [path.join(directory, "eslint.config.ts")];
 }
 
+/**
+ * The config hash a fixture's entry point currently hashes to.
+ *
+ * @param directory - The fixture project root.
+ * @returns The hash, or undefined when it could not be computed.
+ */
+function configHashFor(directory: string): string | undefined {
+	return computeConfigHash(directory, configBustFiles(directory));
+}
+
 function seedAllCaches(directory: string, key: string): void {
 	for (const name of ALL_CACHE_FILES) {
 		fs.writeFileSync(path.join(directory, cacheFileFor(name, key)), "{}");
@@ -879,7 +886,7 @@ describe("applyConfigDriftBust", () => {
 		withFixture(CONFIG_IMPORT_FIXTURE, (directory) => {
 			seedAllCaches(directory, TEST_KEY);
 
-			const outcome = applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory));
+			const outcome = applyConfigDriftBust(directory, TEST_KEY, configHashFor(directory));
 
 			expect(outcome).toStrictEqual({ busted: false, firstRun: true });
 			expect(everyCacheExists(directory, TEST_KEY)).toBe(true);
@@ -890,11 +897,11 @@ describe("applyConfigDriftBust", () => {
 		expect.hasAssertions();
 
 		withFixture(CONFIG_IMPORT_FIXTURE, (directory) => {
-			applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory));
+			applyConfigDriftBust(directory, TEST_KEY, configHashFor(directory));
 			seedAllCaches(directory, TEST_KEY);
 			editRules(directory);
 
-			const outcome = applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory));
+			const outcome = applyConfigDriftBust(directory, TEST_KEY, configHashFor(directory));
 
 			expect(outcome).toStrictEqual({ busted: true, firstRun: false });
 			// Unlike the package.json bust, the fast (syntactic) cache is dropped
@@ -907,11 +914,11 @@ describe("applyConfigDriftBust", () => {
 		expect.hasAssertions();
 
 		withFixture(CONFIG_IMPORT_FIXTURE, (directory) => {
-			applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory));
+			applyConfigDriftBust(directory, TEST_KEY, configHashFor(directory));
 			seedAllCaches(directory, TEST_KEY);
 			touch(path.join(directory, "eslint-rules.ts"));
 
-			const outcome = applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory));
+			const outcome = applyConfigDriftBust(directory, TEST_KEY, configHashFor(directory));
 
 			// Content-addressed, so an mtime bump with identical content is a
 			// no-op.
@@ -924,14 +931,14 @@ describe("applyConfigDriftBust", () => {
 		expect.hasAssertions();
 
 		withFixture(CONFIG_IMPORT_FIXTURE, (directory) => {
-			applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory));
-			applyConfigDriftBust(directory, AGENT_KEY, configBustFiles(directory));
+			applyConfigDriftBust(directory, TEST_KEY, configHashFor(directory));
+			applyConfigDriftBust(directory, AGENT_KEY, configHashFor(directory));
 			seedAllCaches(directory, TEST_KEY);
 			seedAllCaches(directory, AGENT_KEY);
 			editRules(directory);
 
 			expect(
-				applyConfigDriftBust(directory, TEST_KEY, configBustFiles(directory)),
+				applyConfigDriftBust(directory, TEST_KEY, configHashFor(directory)),
 			).toStrictEqual({
 				busted: true,
 				firstRun: false,
@@ -940,7 +947,7 @@ describe("applyConfigDriftBust", () => {
 			expect(everyCacheExists(directory, AGENT_KEY)).toBe(true);
 
 			expect(
-				applyConfigDriftBust(directory, AGENT_KEY, configBustFiles(directory)),
+				applyConfigDriftBust(directory, AGENT_KEY, configHashFor(directory)),
 			).toStrictEqual({
 				busted: true,
 				firstRun: false,
@@ -963,7 +970,11 @@ describe("applyConfigDriftBust", () => {
 		withFixture(CONFIG_IMPORT_FIXTURE, (directory) => {
 			seedAllCaches(directory, TEST_KEY);
 
-			const outcome = applyConfigDriftBust(directory, TEST_KEY, []);
+			const outcome = applyConfigDriftBust(
+				directory,
+				TEST_KEY,
+				computeConfigHash(directory, []),
+			);
 
 			expect(outcome).toStrictEqual({ busted: false, firstRun: false });
 			expect(everyCacheExists(directory, TEST_KEY)).toBe(true);
@@ -979,7 +990,9 @@ describe("applyConfigDriftBust", () => {
 			const roots = [path.join(directory, "eslint.config.ts")];
 
 			expect(computeConfigHash(directory, roots)).toBeUndefined();
-			expect(applyConfigDriftBust(directory, TEST_KEY, roots)).toStrictEqual({
+			expect(
+				applyConfigDriftBust(directory, TEST_KEY, computeConfigHash(directory, roots)),
+			).toStrictEqual({
 				busted: false,
 				firstRun: false,
 			});

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -31,6 +31,7 @@ import {
 	CACHE_FILE_FAST,
 	CACHE_FILE_TYPE_AWARE,
 	cacheFileFor,
+	TYPED_MAX_WORKERS,
 } from "../src/lint-cli/constants.ts";
 import { collectLintableFiles, collectRepoFiles } from "../src/lint-cli/files.ts";
 import type { RepoFiles } from "../src/lint-cli/files.ts";
@@ -52,6 +53,7 @@ import {
 	computePackageJsonHash,
 	packageHashStatePath,
 } from "../src/lint-cli/package-hash.ts";
+import { FAST_PASS, FULL_PASS, TYPED_PASS } from "../src/lint-cli/passes.ts";
 import { composeCommands, plan, runConcurrent, runLint } from "../src/lint-cli/run.ts";
 import type { ChildCommand, ComposeContext, LintCliOptions } from "../src/lint-cli/types.ts";
 import { CliError } from "../src/lint-cli/types.ts";
@@ -249,11 +251,44 @@ describe("computeWorkerCount", () => {
 	});
 });
 
-describe("resolveWorkerLimits", () => {
-	it("defaults to 350 files per worker and a quarter of the CPUs", () => {
+describe("per-pass worker caps", () => {
+	it("caps the program-building passes below the shared cap", () => {
 		expect.hasAssertions();
 
-		expect(resolveWorkerLimits({}, 16)).toStrictEqual({ filesPerWorker: 350, maxWorkers: 4 });
+		const limits = resolveWorkerLimits({}, 64);
+
+		expect(limits.maxWorkers).toBe(16);
+		expect(TYPED_PASS.maxWorkers(limits)).toBe(TYPED_MAX_WORKERS);
+		expect(FULL_PASS.maxWorkers(limits)).toBe(TYPED_MAX_WORKERS);
+		expect(FAST_PASS.maxWorkers(limits)).toBe(16);
+	});
+
+	it("leaves the shared cap alone when it is already the tighter one", () => {
+		expect.hasAssertions();
+
+		const limits = resolveWorkerLimits({}, 16);
+
+		expect(TYPED_PASS.maxWorkers(limits)).toBe(4);
+	});
+
+	it("never overrides an explicit LINT_MAX_WORKERS", () => {
+		expect.hasAssertions();
+
+		const limits = resolveWorkerLimits({ LINT_MAX_WORKERS: "12" }, 64);
+
+		expect(TYPED_PASS.maxWorkers(limits)).toBe(12);
+	});
+});
+
+describe("resolveWorkerLimits", () => {
+	it("defaults to 300 files per worker and a quarter of the CPUs", () => {
+		expect.hasAssertions();
+
+		expect(resolveWorkerLimits({}, 16)).toStrictEqual({
+			explicitMaxWorkers: false,
+			filesPerWorker: 300,
+			maxWorkers: 4,
+		});
 	});
 
 	it("honours env overrides", () => {
@@ -261,7 +296,11 @@ describe("resolveWorkerLimits", () => {
 
 		const limits = resolveWorkerLimits({ FILES_PER_WORKER: "200", LINT_MAX_WORKERS: "6" }, 16);
 
-		expect(limits).toStrictEqual({ filesPerWorker: 200, maxWorkers: 6 });
+		expect(limits).toStrictEqual({
+			explicitMaxWorkers: true,
+			filesPerWorker: 200,
+			maxWorkers: 6,
+		});
 	});
 
 	it("ignores invalid env overrides", () => {
@@ -269,7 +308,11 @@ describe("resolveWorkerLimits", () => {
 
 		const limits = resolveWorkerLimits({ FILES_PER_WORKER: "0", LINT_MAX_WORKERS: "x" }, 16);
 
-		expect(limits).toStrictEqual({ filesPerWorker: 350, maxWorkers: 4 });
+		expect(limits).toStrictEqual({
+			explicitMaxWorkers: false,
+			filesPerWorker: 300,
+			maxWorkers: 4,
+		});
 	});
 });
 
@@ -807,7 +850,7 @@ describe("plan", () => {
 });
 
 describe("fast pass sizing", () => {
-	it("sizes the fast pass from FAST_FILES_PER_WORKER and the typed pass from 350", () => {
+	it("sizes the fast pass from FAST_FILES_PER_WORKER and the typed pass from 300", () => {
 		expect.hasAssertions();
 
 		withTemporaryDirectory((directory) => {
@@ -824,7 +867,7 @@ describe("fast pass sizing", () => {
 			});
 
 			// Three dirty files: FAST_FILES_PER_WORKER=1 => 3 fast workers; the
-			// typed pass keeps the 350-file default => a single worker (off).
+			// typed pass keeps the 300-file default => a single worker (off).
 			expect(concurrencyArgument(commands, "fast")).toBe("3");
 			expect(concurrencyArgument(commands, "typed")).toBe("off");
 		});

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -53,7 +53,7 @@ import {
 	computePackageJsonHash,
 	packageHashStatePath,
 } from "../src/lint-cli/package-hash.ts";
-import { FAST_PASS, FULL_PASS, TYPED_PASS } from "../src/lint-cli/passes.ts";
+import { FAST_PASS, FULL_PASS, maxWorkersFor, TYPED_PASS } from "../src/lint-cli/passes.ts";
 import { composeCommands, plan, runConcurrent, runLint } from "../src/lint-cli/run.ts";
 import type { ChildCommand, ComposeContext, LintCliOptions } from "../src/lint-cli/types.ts";
 import { CliError } from "../src/lint-cli/types.ts";
@@ -258,9 +258,9 @@ describe("per-pass worker caps", () => {
 		const limits = resolveWorkerLimits({}, 64);
 
 		expect(limits.maxWorkers).toBe(16);
-		expect(TYPED_PASS.maxWorkers(limits)).toBe(TYPED_MAX_WORKERS);
-		expect(FULL_PASS.maxWorkers(limits)).toBe(TYPED_MAX_WORKERS);
-		expect(FAST_PASS.maxWorkers(limits)).toBe(16);
+		expect(maxWorkersFor(TYPED_PASS, limits)).toBe(TYPED_MAX_WORKERS);
+		expect(maxWorkersFor(FULL_PASS, limits)).toBe(TYPED_MAX_WORKERS);
+		expect(maxWorkersFor(FAST_PASS, limits)).toBe(16);
 	});
 
 	it("leaves the shared cap alone when it is already the tighter one", () => {
@@ -268,7 +268,7 @@ describe("per-pass worker caps", () => {
 
 		const limits = resolveWorkerLimits({}, 16);
 
-		expect(TYPED_PASS.maxWorkers(limits)).toBe(4);
+		expect(maxWorkersFor(TYPED_PASS, limits)).toBe(4);
 	});
 
 	it("never overrides an explicit LINT_MAX_WORKERS", () => {
@@ -276,7 +276,8 @@ describe("per-pass worker caps", () => {
 
 		const limits = resolveWorkerLimits({ LINT_MAX_WORKERS: "12" }, 64);
 
-		expect(TYPED_PASS.maxWorkers(limits)).toBe(12);
+		expect(maxWorkersFor(TYPED_PASS, limits)).toBe(12);
+		expect(maxWorkersFor(FAST_PASS, limits)).toBe(12);
 	});
 });
 
@@ -285,9 +286,9 @@ describe("resolveWorkerLimits", () => {
 		expect.hasAssertions();
 
 		expect(resolveWorkerLimits({}, 16)).toStrictEqual({
-			explicitMaxWorkers: false,
 			filesPerWorker: 300,
 			maxWorkers: 4,
+			typedMaxWorkers: 4,
 		});
 	});
 
@@ -297,9 +298,9 @@ describe("resolveWorkerLimits", () => {
 		const limits = resolveWorkerLimits({ FILES_PER_WORKER: "200", LINT_MAX_WORKERS: "6" }, 16);
 
 		expect(limits).toStrictEqual({
-			explicitMaxWorkers: true,
 			filesPerWorker: 200,
 			maxWorkers: 6,
+			typedMaxWorkers: 6,
 		});
 	});
 
@@ -309,9 +310,9 @@ describe("resolveWorkerLimits", () => {
 		const limits = resolveWorkerLimits({ FILES_PER_WORKER: "0", LINT_MAX_WORKERS: "x" }, 16);
 
 		expect(limits).toStrictEqual({
-			explicitMaxWorkers: false,
 			filesPerWorker: 300,
 			maxWorkers: 4,
+			typedMaxWorkers: 4,
 		});
 	});
 });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -77,6 +77,12 @@ export default defineConfig([
 	},
 	{
 		...sharedOptions,
+		// Shipped at dist/lint-ignored.mjs; the lint runner spawns this exact
+		// path to ask the consumer's ESLint which targets it ignores.
+		entry: { "lint-ignored": "src/lint-cli/ignored-child.ts" },
+	},
+	{
+		...sharedOptions,
 		deps: {
 			neverBundle: [
 				/^@typescript-eslint\//,


### PR DESCRIPTION
Investigates #598. Part A was real and is fixed here; part B's proposed fix is
falsified by measurement, and a defect of the opposite sign is fixed instead.

## A. Phantom-dirty ignored files (the reported bug)

File lists come from `git ls-files` filtered by extension and know nothing of
the ESLint config's own `ignores`. ESLint writes no cache entry for a file it
never lints, so every ignored file reads as dirty on **every** run — flooring
the type-aware pass's dirty count above zero and making its auto-skip
unreachable.

Measured against warmed caches, the permanently-dirty set is exactly the
ESLint-ignored set:

| repo | lintable targets | typed targets | permanently dirty (fast / typed) |
|---|---|---|---|
| this repo | 327 | 180 | 145 / 14 |
| a consumer | 4229 | 3643 | 971 / 452 |

The runner now asks ESLint itself via `isPathIgnored`, in a helper child
process — `isPathIgnored` is async while `plan()` is synchronous end to end, and
loading a consumer's flat config drags their whole plugin tree (and jiti) into
memory for one query. The answer is memoised against the config hash that
already drives the drift bust: it can only change when the resolved config
changes, and that already forces a full re-lint.

`isPathIgnored` also reports files that **no config matches**, so this covers
the disabled-feature extensions `constants.ts` previously wrote off as
unavoidable.

Verified end-to-end through the built CLI on this repo: the
`skipping the type-aware ESLint pass` notice, previously unreachable here, now
fires. The regression test fails with the filter stubbed out.

## B. Worker sizing — the opposite of what was proposed

#598 recommends `dirty <= 25 -> off, else maxWorkers`, on a premise of `n^1.46`
per-worker scaling where "more workers is strictly better until memory
saturates". Benchmarked across four subset sizes (wall clock, `--no-cache`,
32 logical / 16 physical cores):

| pass | n | off | 2w | 3w | 4w | 5w | 6w | 8w |
|---|---|---|---|---|---|---|---|---|
| typed | 219 | **12.7s** | 14.8 | 14.4 | | | | |
| typed | 608 | 30.2 | 21.3 | 20.1 | **19.6** | | | |
| typed | 1629 | 38.8 | 29.0 | 26.3 | 24.8 | | **23.6** | |
| typed | 3191 | 92.1 | 55.5 | 44.6 | 39.6 | **37.3** | 37.3 | 50.6 |
| fast | 1629 | **11.1s** | 13.1 | 11.7 | | | | |
| fast | 3258 | 33.5 | 22.8 | 19.9 | | | | **18.6** |

Both halves of the premise fail: `off` is optimal up to ~300 typed files, and
`maxWorkers` (8 here) is the single **worst** measured typed point. The real
defect is the opposite sign — the old cap of `availableParallelism / 4` sits
past a cliff, costing **+36%** on a full re-lint.

The `n^1.46` model doesn't hold either: it predicts 4 workers ≈ 25s where 39.6s
was measured. The data fits fixed-cost + linear, and the fixed cost is *not*
constant — `projectService` only builds the projects covering a worker's own
file share, so splitting the run splits the build, while still repeating each
project's per-project floor. That repeated floor is what pins the break-even
near 300 files per worker.

So: `DEFAULT_FILES_PER_WORKER` 350 → 300, and a new `TYPED_MAX_WORKERS = 6` on
the passes that build a program. The fast pass builds none and improves to 8
workers, so it keeps its own cap and its 800 files-per-worker unchanged. An
explicit `LINT_MAX_WORKERS` still wins. Worst-case regret against the measured
optimum drops from +36% to +2.6%.

The constants are fitted from one machine — see #607, which records the full
grid and the caveats (the cap of 6 is inert below 28 threads; all runs warm-FS;
self-calibration was measured and rejected at ~2.3s of total headroom).

## Follow-ups filed rather than folded in

- #607 — re-derive the constants on other machines and repo shapes.
- #608 — two ESLint 10 segfaults seen while benchmarking (a 16-worker child, and
  one *serial* run exiting 139).
- #609 — extract a shared state module; this adds the fifth hand-copy of
  "per-variant state under `node_modules/.cache/isentinel-lint`".
- #610 — memoise the ignore *predicate* rather than the answers, which would
  remove the residual documented on `resolveIgnoredFiles` (a newly added ignored
  file keeps the typed pass awake until the next config change).

Not addressed here: #598's part B recommendation is left standing on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linting now respects ESLint-ignored files when planning and sizing lint passes.
  * Added caching for ignored-file detection to improve repeated runs.
  * Type-aware linting uses a separate worker limit to improve resource management.

* **Bug Fixes**
  * Improved configuration-change detection and cache invalidation.
  * Reduced default files-per-worker sizing from 350 to 300 for more consistent performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->