### PR TITLE
refactor(lint-cli): extract a shared state module

### DIFF
--- a/src/cli/constants-generated.ts
+++ b/src/cli/constants-generated.ts
@@ -1,7 +1,7 @@
 export const versionsMap = {
   "eslint": "10.7.0",
   "eslint-plugin-jest": "29.15.4",
-  "eslint-plugin-react-jsx": "5.16.1",
-  "eslint-plugin-react-naming-convention": "5.16.1",
-  "eslint-plugin-react-x": "5.16.1"
+  "eslint-plugin-react-jsx": "5.17.1",
+  "eslint-plugin-react-naming-convention": "5.17.1",
+  "eslint-plugin-react-x": "5.17.1"
 }

--- a/src/lint-cli/affected.ts
+++ b/src/lint-cli/affected.ts
@@ -59,9 +59,7 @@ const warned = new Set<string>();
 
 /**
  * Resolve the builder incremental-state (`.tsbuildinfo`) file for a mode and
- * config variant. Stored under `node_modules/.cache/isentinel-lint/` so it
- * never pollutes the consumer's source tree and is cleaned with
- * `node_modules`.
+ * config variant.
  *
  * The variant key is part of the path because this state is drained
  * destructively: {@link computeAffectedFiles} consumes the affected set and
@@ -89,7 +87,7 @@ export function builderStatePath(
 	projectId: string,
 ): string {
 	const suffix = mode === "only" ? "typeaware" : "full";
-	return statePath(cwd, `tsbuildinfo-${suffix}`, `${key}-${projectId}`);
+	return statePath(cwd, "tsbuildinfo", suffix, key, projectId);
 }
 
 /**

--- a/src/lint-cli/affected.ts
+++ b/src/lint-cli/affected.ts
@@ -8,6 +8,7 @@ import type * as TypeScript from "typescript";
 
 import { CACHE_KEY_LENGTH } from "./cache-key.ts";
 import { toPosix } from "./paths.ts";
+import { stateDirectory, statePath } from "./state.ts";
 import type { TypeAwareMode } from "./types.ts";
 import { loadTypescript } from "./typescript.ts";
 
@@ -88,7 +89,7 @@ export function builderStatePath(
 	projectId: string,
 ): string {
 	const suffix = mode === "only" ? "typeaware" : "full";
-	return path.join(builderStateDirectory(cwd), `tsbuildinfo-${suffix}-${key}-${projectId}`);
+	return statePath(cwd, `tsbuildinfo-${suffix}`, `${key}-${projectId}`);
 }
 
 /**
@@ -144,7 +145,7 @@ export function computeAffectedFiles(
 
 		// Every project's state lands in this one directory, so create it once
 		// here rather than once per builder.
-		fs.mkdirSync(builderStateDirectory(cwd), { recursive: true });
+		fs.mkdirSync(stateDirectory(cwd), { recursive: true });
 
 		const affected = new Set<string>();
 		let warmProjects = 0;
@@ -175,16 +176,6 @@ export function computeAffectedFiles(
 		warnOnce(`type-aware cache invalidation failed: ${message}`);
 		return undefined;
 	}
-}
-
-/**
- * The directory every builder state file lives in.
- *
- * @param cwd - The consumer project root.
- * @returns The absolute path to the runner's cache directory.
- */
-function builderStateDirectory(cwd: string): string {
-	return path.join(cwd, "node_modules", ".cache", "isentinel-lint");
 }
 
 /**

--- a/src/lint-cli/config-hash.ts
+++ b/src/lint-cli/config-hash.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type * as TypeScript from "typescript";
 
 import { ALL_CACHE_FILES, cacheFileFor } from "./constants.ts";
+import { readState, statePath, writeState } from "./state.ts";
 import { loadTypescript } from "./typescript.ts";
 
 /**
@@ -53,7 +54,7 @@ interface ClosureResolver {
  * @returns The absolute path to the stored-hash file.
  */
 export function configHashStatePath(cwd: string, key: string): string {
-	return path.join(cwd, "node_modules", ".cache", "isentinel-lint", `config-hash-${key}`);
+	return statePath(cwd, "config-hash", key);
 }
 
 /**
@@ -132,13 +133,13 @@ export function applyConfigDriftBust(
 		return { busted: false, firstRun: false };
 	}
 
-	const statePath = configHashStatePath(cwd, key);
-	const stored = safeReadUtf8(statePath);
+	const file = configHashStatePath(cwd, key);
+	const stored = readState<string>(file);
 	if (stored === hash) {
 		return { busted: false, firstRun: false };
 	}
 
-	writeHash(statePath, hash);
+	writeState(file, hash);
 	if (stored === undefined) {
 		return { busted: false, firstRun: true };
 	}
@@ -298,9 +299,4 @@ function discoverConfigClosure(
 	}
 
 	return files;
-}
-
-function writeHash(statePath: string, hash: string): void {
-	fs.mkdirSync(path.dirname(statePath), { recursive: true });
-	fs.writeFileSync(statePath, hash);
 }

--- a/src/lint-cli/config-hash.ts
+++ b/src/lint-cli/config-hash.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import type * as TypeScript from "typescript";
 
 import { ALL_CACHE_FILES, cacheFileFor } from "./constants.ts";
-import { readState, statePath, writeState } from "./state.ts";
+import { readFileIfPresent, statePath, swapState } from "./state.ts";
 import { loadTypescript } from "./typescript.ts";
 
 /**
@@ -44,8 +44,7 @@ interface ClosureResolver {
 }
 
 /**
- * Resolve the persisted config-hash file for a config variant. Stored alongside
- * the builder state so it is cleaned with `node_modules`, and keyed like
+ * Resolve the persisted config-hash file for a config variant, keyed like
  * `packageHashStatePath`: the stored hash is consumed once, so a shared file
  * would let the first variant to run absorb the drift for all of them.
  *
@@ -133,15 +132,9 @@ export function applyConfigDriftBust(
 		return { busted: false, firstRun: false };
 	}
 
-	const file = configHashStatePath(cwd, key);
-	const stored = readState<string>(file);
-	if (stored === hash) {
-		return { busted: false, firstRun: false };
-	}
-
-	writeState(file, hash);
-	if (stored === undefined) {
-		return { busted: false, firstRun: true };
+	const swap = swapState(configHashStatePath(cwd, key), hash);
+	if (swap !== "changed") {
+		return { busted: false, firstRun: swap === "first" };
 	}
 
 	for (const base of ALL_CACHE_FILES) {
@@ -149,14 +142,6 @@ export function applyConfigDriftBust(
 	}
 
 	return { busted: true, firstRun: false };
-}
-
-function safeReadUtf8(filePath: string): string | undefined {
-	try {
-		return fs.readFileSync(filePath, "utf8");
-	} catch {
-		return undefined;
-	}
 }
 
 /**
@@ -289,7 +274,7 @@ function discoverConfigClosure(
 			break;
 		}
 
-		const content = safeReadUtf8(file);
+		const content = readFileIfPresent(file);
 		if (content === undefined) {
 			continue;
 		}

--- a/src/lint-cli/hybrid-status.ts
+++ b/src/lint-cli/hybrid-status.ts
@@ -53,7 +53,14 @@ export function readHybridStatus(cwd: string): HybridStatus | undefined {
  * @param oxlint - Whether the config enabled hybrid mode.
  */
 export function writeHybridStatus(cwd: string, oxlint: boolean): void {
-	if (!fs.existsSync(path.resolve(cwd, "node_modules"))) {
+	let installed: boolean;
+	try {
+		installed = fs.existsSync(path.resolve(cwd, "node_modules"));
+	} catch {
+		return;
+	}
+
+	if (!installed) {
 		return;
 	}
 

--- a/src/lint-cli/hybrid-status.ts
+++ b/src/lint-cli/hybrid-status.ts
@@ -2,10 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
-import { readState, statePath, writeState } from "./state.ts";
-
-/** File recording whether the resolved ESLint config runs in hybrid mode. */
-const STATUS_FILE = "hybrid-status";
+import { readState, statePath, touchState, writeState } from "./state.ts";
 
 /**
  * The persisted hybrid status: whether the resolved ESLint config enabled the
@@ -25,17 +22,29 @@ export interface HybridStatus {
  * @returns The absolute status-file path.
  */
 export function hybridStatusPath(cwd: string): string {
-	return statePath(cwd, STATUS_FILE);
+	return statePath(cwd, "hybrid-status");
+}
+
+/**
+ * Read the persisted hybrid status, or `undefined` when the file is missing,
+ * unreadable or malformed (the CLI then treats the status as unknown).
+ *
+ * @param cwd - The project root.
+ * @returns The parsed status, or `undefined`.
+ */
+export function readHybridStatus(cwd: string): HybridStatus | undefined {
+	const stored = readState<HybridStatus>(hybridStatusPath(cwd));
+	return typeof stored?.oxlint === "boolean" ? stored : undefined;
 }
 
 /**
  * Passively record whether the resolved ESLint config runs in hybrid mode.
- * Called from the factory on every config evaluation, which is why
- * {@link writeState} is write-if-changed and mtime-refreshing: the file must
- * not churn as editors and both lint passes re-evaluate the config, yet its
- * mtime must stay ahead of the config's or the CLI re-runs its ~3s probe every
- * lint. Every failure is swallowed — config evaluation must never throw for
- * this, and the CLI treats a missing or stale file as "unknown" and re-probes.
+ * Called from the factory on every config evaluation, so an unchanged status is
+ * touched rather than rewritten: the file must not churn as editors and both
+ * lint passes re-evaluate the config, yet its mtime must stay ahead of the
+ * config's or the CLI re-runs its ~3s probe every lint. Every failure is
+ * swallowed — config evaluation must never throw for this, and the CLI treats a
+ * missing or stale file as "unknown" and re-probes.
  *
  * Skipped entirely when `node_modules` is absent (nothing installed, so no
  * cache home and no CLI to read it).
@@ -48,19 +57,13 @@ export function writeHybridStatus(cwd: string, oxlint: boolean): void {
 		return;
 	}
 
-	writeState<HybridStatus>(hybridStatusPath(cwd), { oxlint });
-}
+	const filePath = hybridStatusPath(cwd);
+	if (readHybridStatus(cwd)?.oxlint === oxlint) {
+		touchState(filePath);
+		return;
+	}
 
-/**
- * Read the persisted hybrid status, or `undefined` when the file is missing,
- * unreadable or malformed (the CLI then treats the status as unknown).
- *
- * @param cwd - The project root.
- * @returns The parsed status, or `undefined`.
- */
-export function readHybridStatus(cwd: string): HybridStatus | undefined {
-	const stored = readState<HybridStatus>(hybridStatusPath(cwd));
-	return typeof stored?.oxlint === "boolean" ? { oxlint: stored.oxlint } : undefined;
+	writeState(filePath, { oxlint } satisfies HybridStatus);
 }
 
 /**

--- a/src/lint-cli/hybrid-status.ts
+++ b/src/lint-cli/hybrid-status.ts
@@ -2,12 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
-/**
- * Directory (relative to the project root) where the CLI keeps its cache
- * artifacts. Lives under `node_modules/.cache` so it is discarded with the
- * dependency tree and never committed.
- */
-const CACHE_DIRECTORY = path.join("node_modules", ".cache", "isentinel-lint");
+import { readState, statePath, writeState } from "./state.ts";
 
 /** File recording whether the resolved ESLint config runs in hybrid mode. */
 const STATUS_FILE = "hybrid-status";
@@ -30,16 +25,17 @@ export interface HybridStatus {
  * @returns The absolute status-file path.
  */
 export function hybridStatusPath(cwd: string): string {
-	return path.resolve(cwd, CACHE_DIRECTORY, STATUS_FILE);
+	return statePath(cwd, STATUS_FILE);
 }
 
 /**
  * Passively record whether the resolved ESLint config runs in hybrid mode.
- * Called from the factory on every config evaluation, so it is write-if-changed
- * (read first, skip identical content) to avoid churning the file when editors
- * and both lint passes re-evaluate the config. Every failure is swallowed:
- * config evaluation must never throw for this, and the CLI treats a missing or
- * stale file as "unknown" and re-probes.
+ * Called from the factory on every config evaluation, which is why
+ * {@link writeState} is write-if-changed and mtime-refreshing: the file must
+ * not churn as editors and both lint passes re-evaluate the config, yet its
+ * mtime must stay ahead of the config's or the CLI re-runs its ~3s probe every
+ * lint. Every failure is swallowed — config evaluation must never throw for
+ * this, and the CLI treats a missing or stale file as "unknown" and re-probes.
  *
  * Skipped entirely when `node_modules` is absent (nothing installed, so no
  * cache home and no CLI to read it).
@@ -48,38 +44,11 @@ export function hybridStatusPath(cwd: string): string {
  * @param oxlint - Whether the config enabled hybrid mode.
  */
 export function writeHybridStatus(cwd: string, oxlint: boolean): void {
-	try {
-		if (!fs.existsSync(path.resolve(cwd, "node_modules"))) {
-			return;
-		}
-
-		const filePath = hybridStatusPath(cwd);
-		const content = `${JSON.stringify({ oxlint })}\n`;
-
-		let existing: string | undefined;
-		try {
-			existing = fs.readFileSync(filePath, "utf8");
-		} catch {
-			existing = undefined;
-		}
-
-		if (existing === content) {
-			// Content is unchanged, but refresh the mtime so the CLI freshness
-			// check (status mtime >= config mtime) keeps passing after the config
-			// is touched. Without this the mtime freezes at first write and every
-			// later lint needlessly re-runs the ~3s probe. The passive factory
-			// write thus keeps the status perpetually fresh.
-			const now = Date.now() / 1000;
-			fs.utimesSync(filePath, now, now);
-			return;
-		}
-
-		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(filePath, content);
-	} catch {
-		// Best-effort: the CLI re-probes when the status is missing or
-		// unreadable.
+	if (!fs.existsSync(path.resolve(cwd, "node_modules"))) {
+		return;
 	}
+
+	writeState<HybridStatus>(hybridStatusPath(cwd), { oxlint });
 }
 
 /**
@@ -90,27 +59,8 @@ export function writeHybridStatus(cwd: string, oxlint: boolean): void {
  * @returns The parsed status, or `undefined`.
  */
 export function readHybridStatus(cwd: string): HybridStatus | undefined {
-	let raw: string;
-	try {
-		raw = fs.readFileSync(hybridStatusPath(cwd), "utf8");
-	} catch {
-		return undefined;
-	}
-
-	try {
-		const parsed = JSON.parse(raw) as unknown;
-		if (
-			typeof parsed === "object" &&
-			parsed !== null &&
-			typeof (parsed as Record<string, unknown>)["oxlint"] === "boolean"
-		) {
-			return { oxlint: (parsed as HybridStatus).oxlint };
-		}
-	} catch {
-		return undefined;
-	}
-
-	return undefined;
+	const stored = readState<HybridStatus>(hybridStatusPath(cwd));
+	return typeof stored?.oxlint === "boolean" ? { oxlint: stored.oxlint } : undefined;
 }
 
 /**

--- a/src/lint-cli/ignored.ts
+++ b/src/lint-cli/ignored.ts
@@ -38,8 +38,8 @@ export interface IgnoredFilesContext {
 }
 
 /**
- * Resolve the persisted ignore-set file for a config variant. Stored beside the
- * config hash it is keyed by, so `node_modules` removal clears both together.
+ * Resolve the persisted ignore-set file for a config variant, keyed by the same
+ * variant as the config hash it stores.
  *
  * @param cwd - The consumer project root.
  * @param key - The config-variant key from `resolveCacheKey`.
@@ -101,7 +101,7 @@ export function resolveIgnoredFiles({
 		return EMPTY;
 	}
 
-	writeState<IgnoredState>(stateFile, { hash: configHash, ignored });
+	writeState(stateFile, { hash: configHash, ignored } satisfies IgnoredState);
 	return new Set(ignored);
 }
 

--- a/src/lint-cli/ignored.ts
+++ b/src/lint-cli/ignored.ts
@@ -7,14 +7,7 @@ import process from "node:process";
 
 import { normalizePath } from "./cache.ts";
 import { resolveIgnoredHelper } from "./resolve.ts";
-
-/**
- * Schema version of the persisted ignore set. The config hash only says the
- * config itself is unchanged, so it cannot catch a CLI upgrade that changed the
- * stored shape — a stale file would then be accepted and every lookup would
- * silently miss. Bump this whenever {@link IgnoredState} changes meaning.
- */
-const IGNORED_STATE_VERSION = 1;
+import { readState, statePath, writeState } from "./state.ts";
 
 /** The persisted form of a resolved ignore set. */
 interface IgnoredState {
@@ -22,8 +15,6 @@ interface IgnoredState {
 	hash: string;
 	/** The ignored targets, as {@link normalizePath} keys. */
 	ignored: Array<string>;
-	/** The {@link IGNORED_STATE_VERSION} the file was written by. */
-	version: number;
 }
 
 /** Reused for every miss, so callers never allocate on the no-op path. */
@@ -55,7 +46,7 @@ export interface IgnoredFilesContext {
  * @returns The absolute path to the stored ignore-set file.
  */
 export function ignoredStatePath(cwd: string, key: string): string {
-	return path.join(cwd, "node_modules", ".cache", "isentinel-lint", `ignored-${key}`);
+	return statePath(cwd, "ignored", key);
 }
 
 /**
@@ -95,9 +86,9 @@ export function resolveIgnoredFiles({
 		return EMPTY;
 	}
 
-	const statePath = ignoredStatePath(cwd, key);
-	const stored = readState(statePath);
-	if (stored?.hash === configHash && stored.version === IGNORED_STATE_VERSION) {
+	const stateFile = ignoredStatePath(cwd, key);
+	const stored = readState<IgnoredState>(stateFile);
+	if (stored?.hash === configHash) {
 		return new Set(stored.ignored);
 	}
 
@@ -110,7 +101,7 @@ export function resolveIgnoredFiles({
 		return EMPTY;
 	}
 
-	writeState(statePath, { hash: configHash, ignored, version: IGNORED_STATE_VERSION });
+	writeState<IgnoredState>(stateFile, { hash: configHash, ignored });
 	return new Set(ignored);
 }
 
@@ -147,17 +138,4 @@ function queryIgnoredFiles(cwd: string, targets: Array<string>): Array<string> |
 	} finally {
 		fs.rmSync(outFile, { force: true });
 	}
-}
-
-function readState(statePath: string): IgnoredState | undefined {
-	try {
-		return JSON.parse(fs.readFileSync(statePath, "utf8")) as IgnoredState;
-	} catch {
-		return undefined;
-	}
-}
-
-function writeState(statePath: string, state: IgnoredState): void {
-	fs.mkdirSync(path.dirname(statePath), { recursive: true });
-	fs.writeFileSync(statePath, JSON.stringify(state));
 }

--- a/src/lint-cli/package-hash.ts
+++ b/src/lint-cli/package-hash.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { CACHE_FILE_DEFAULT, CACHE_FILE_TYPE_AWARE, cacheFileFor } from "./constants.ts";
-import { readState, statePath, writeState } from "./state.ts";
+import { readFileIfPresent, statePath, swapState } from "./state.ts";
 import { findWorkspaceRoot } from "./workspace.ts";
 
 /**
@@ -38,7 +38,6 @@ export interface PackageJsonBustOutcome {
 
 /**
  * Resolve the persisted package.json resolution-hash file for a config variant.
- * Stored alongside the builder state so it is cleaned with `node_modules`.
  *
  * The variant key is part of the path because the stored hash is consumed once:
  * after the first run that sees a new hash, every later run finds
@@ -106,15 +105,9 @@ export function applyPackageJsonBust(cwd: string, key: string): PackageJsonBustO
 		return { busted: false, firstRun: false };
 	}
 
-	const file = packageHashStatePath(cwd, key);
-	const stored = readState<string>(file);
-	if (stored === hash) {
-		return { busted: false, firstRun: false };
-	}
-
-	writeState(file, hash);
-	if (stored === undefined) {
-		return { busted: false, firstRun: true };
+	const swap = swapState(packageHashStatePath(cwd, key), hash);
+	if (swap !== "changed") {
+		return { busted: false, firstRun: swap === "first" };
 	}
 
 	fs.rmSync(path.resolve(cwd, cacheFileFor(CACHE_FILE_TYPE_AWARE, key)), { force: true });
@@ -130,10 +123,8 @@ export function applyPackageJsonBust(cwd: string, key: string): PackageJsonBustO
  * @returns The resolution-field subset, or `undefined`.
  */
 function resolutionSubset(directory: string): Record<string, unknown> | undefined {
-	let raw: string;
-	try {
-		raw = fs.readFileSync(path.join(directory, "package.json"), "utf8");
-	} catch {
+	const raw = readFileIfPresent(path.join(directory, "package.json"));
+	if (raw === undefined) {
 		return undefined;
 	}
 

--- a/src/lint-cli/package-hash.ts
+++ b/src/lint-cli/package-hash.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { CACHE_FILE_DEFAULT, CACHE_FILE_TYPE_AWARE, cacheFileFor } from "./constants.ts";
+import { readState, statePath, writeState } from "./state.ts";
 import { findWorkspaceRoot } from "./workspace.ts";
 
 /**
@@ -50,7 +51,7 @@ export interface PackageJsonBustOutcome {
  * @returns The absolute path to the stored-hash file.
  */
 export function packageHashStatePath(cwd: string, key: string): string {
-	return path.join(cwd, "node_modules", ".cache", "isentinel-lint", `package-json-hash-${key}`);
+	return statePath(cwd, "package-json-hash", key);
 }
 
 /**
@@ -105,13 +106,13 @@ export function applyPackageJsonBust(cwd: string, key: string): PackageJsonBustO
 		return { busted: false, firstRun: false };
 	}
 
-	const statePath = packageHashStatePath(cwd, key);
-	const stored = safeRead(statePath);
+	const file = packageHashStatePath(cwd, key);
+	const stored = readState<string>(file);
 	if (stored === hash) {
 		return { busted: false, firstRun: false };
 	}
 
-	writeHash(statePath, hash);
+	writeState(file, hash);
 	if (stored === undefined) {
 		return { busted: false, firstRun: true };
 	}
@@ -174,17 +175,4 @@ function stableStringify(value: unknown): string {
 	}
 
 	return JSON.stringify(value);
-}
-
-function safeRead(filePath: string): string | undefined {
-	try {
-		return fs.readFileSync(filePath, "utf8");
-	} catch {
-		return undefined;
-	}
-}
-
-function writeHash(statePath: string, hash: string): void {
-	fs.mkdirSync(path.dirname(statePath), { recursive: true });
-	fs.writeFileSync(statePath, hash);
 }

--- a/src/lint-cli/state.ts
+++ b/src/lint-cli/state.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+/**
+ * Directory (relative to the project root) where the CLI keeps its persisted
+ * state. Lives under `node_modules/.cache` so it is discarded with the
+ * dependency tree and never committed.
+ */
+const CACHE_DIRECTORY = path.join("node_modules", ".cache", "isentinel-lint");
+
+/**
+ * Schema version stamped into every state file. A stored shape is only trusted
+ * when it was written by this version, so a CLI upgrade that changes what a
+ * writer stores invalidates the old files instead of silently misreading them —
+ * the config hash cannot catch this, since it only says the *config* is
+ * unchanged. Bump this whenever any persisted state changes meaning.
+ */
+export const STATE_VERSION = 1;
+
+/**
+ * The on-disk envelope every {@link writeState} call produces.
+ *
+ * @template T - The writer's payload type.
+ */
+interface StateEnvelope<T> {
+	/** The writer's own payload. */
+	data: T;
+	/** The {@link STATE_VERSION} the file was written by. */
+	version: number;
+}
+
+/**
+ * The directory every state file lives in.
+ *
+ * @param cwd - The consumer project root.
+ * @returns The absolute path to the runner's cache directory.
+ */
+export function stateDirectory(cwd: string): string {
+	return path.resolve(cwd, CACHE_DIRECTORY);
+}
+
+/**
+ * Resolve one state file inside {@link stateDirectory}.
+ *
+ * @param cwd - The consumer project root.
+ * @param name - The state's base name.
+ * @param key - An optional discriminator appended to the name, usually the
+ *   config-variant key from `resolveCacheKey`. State that is consumed once (a
+ *   stored hash, a drained builder) must be keyed, or the first variant to run
+ *   absorbs the change on behalf of all of them.
+ * @returns The absolute path to the state file.
+ */
+export function statePath(cwd: string, name: string, key?: string): string {
+	return path.join(stateDirectory(cwd), key === undefined ? name : `${name}-${key}`);
+}
+
+/**
+ * Read a state file written by {@link writeState}. Every failure mode — the
+ * file is missing, unreadable, malformed, or was written by another
+ * {@link STATE_VERSION} — degrades to `undefined`, which every caller treats as
+ * "unknown" and recomputes from.
+ *
+ * @template T - The shape this file's writer stores. Asserted, not checked:
+ *   only the schema version is verified, exactly as the per-module casts this
+ *   replaced did.
+ * @param filePath - The state file, from {@link statePath}.
+ * @returns The stored payload, or `undefined`.
+ */
+/* oxlint-disable typescript/no-unnecessary-type-parameters -- T is the caller's assertion about what its own state file holds, which keeps the cast at one call site instead of at every reader. */
+export function readState<T>(filePath: string): T | undefined {
+	const raw = readIfPresent(filePath);
+	if (raw === undefined) {
+		return undefined;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+
+	if (typeof parsed !== "object" || parsed === null) {
+		return undefined;
+	}
+
+	const envelope = parsed as Partial<StateEnvelope<T>>;
+	return envelope.version === STATE_VERSION ? envelope.data : undefined;
+}
+/* oxlint-enable typescript/no-unnecessary-type-parameters */
+
+/**
+ * Persist a state payload, creating the cache directory as needed.
+ *
+ * The write is atomic (temp file plus rename), since `plan()` runs concurrently
+ * across packages in a parallel per-package lint setup and a torn file would be
+ * read back as "unknown" at best. Identical content is not rewritten, but its
+ * mtime is refreshed: the hybrid-status freshness check compares that mtime
+ * against the config's, and the factory rewrites the same content on every
+ * config evaluation.
+ *
+ * Best-effort — a failed write leaves the state unknown, so the next run
+ * recomputes rather than trusting something stale.
+ *
+ * @template T - The shape this file's writer stores.
+ * @param filePath - The state file, from {@link statePath}.
+ * @param data - The payload to store.
+ * @returns True when the state is on disk.
+ */
+/* oxlint-disable typescript/no-unnecessary-type-parameters -- T lets a writer pin the shape it stores at the call site; the payload is otherwise `unknown` and unchecked. */
+export function writeState<T>(filePath: string, data: T): boolean {
+	const content = `${JSON.stringify({ data, version: STATE_VERSION } satisfies StateEnvelope<T>)}\n`;
+	if (readIfPresent(filePath) === content) {
+		try {
+			const now = Date.now() / 1000;
+			fs.utimesSync(filePath, now, now);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	// One writer per process per file, so the pid keeps the temp name
+	// collision-free across parallel package lints sharing a workspace root.
+	const temporary = `${filePath}.${process.pid}.tmp`;
+	try {
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(temporary, content);
+		fs.renameSync(temporary, filePath);
+		return true;
+	} catch {
+		fs.rmSync(temporary, { force: true });
+		return false;
+	}
+}
+
+/* oxlint-enable typescript/no-unnecessary-type-parameters */
+
+function readIfPresent(filePath: string): string | undefined {
+	try {
+		return fs.readFileSync(filePath, "utf8");
+	} catch {
+		return undefined;
+	}
+}

--- a/src/lint-cli/state.ts
+++ b/src/lint-cli/state.ts
@@ -10,13 +10,24 @@ import process from "node:process";
 const CACHE_DIRECTORY = path.join("node_modules", ".cache", "isentinel-lint");
 
 /**
- * Schema version stamped into every state file. A stored shape is only trusted
- * when it was written by this version, so a CLI upgrade that changes what a
- * writer stores invalidates the old files instead of silently misreading them —
- * the config hash cannot catch this, since it only says the *config* is
- * unchanged. Bump this whenever any persisted state changes meaning.
+ * Schema version stamped into every state file {@link writeState} produces. A
+ * stored payload is only trusted when it was written by this version, so a CLI
+ * upgrade that changes what a writer stores invalidates the old files instead
+ * of silently misreading them — the config hash cannot catch this, since it
+ * only says the *config* is unchanged. Bump this whenever any persisted payload
+ * changes meaning. The builder's `.tsbuildinfo` files live in the same
+ * directory but are written by TypeScript, which versions them itself.
  */
 export const STATE_VERSION = 1;
+
+/** How a stored value compared to the one {@link swapState} was given. */
+export type StateSwap =
+	/** The value differed and replaced the stored one. */
+	| "changed"
+	/** No usable state existed, so the value was stored as the baseline. */
+	| "first"
+	/** The stored value already matched; nothing was written. */
+	| "unchanged";
 
 /**
  * The on-disk envelope every {@link writeState} call produces.
@@ -44,15 +55,30 @@ export function stateDirectory(cwd: string): string {
  * Resolve one state file inside {@link stateDirectory}.
  *
  * @param cwd - The consumer project root.
- * @param name - The state's base name.
- * @param key - An optional discriminator appended to the name, usually the
- *   config-variant key from `resolveCacheKey`. State that is consumed once (a
- *   stored hash, a drained builder) must be keyed, or the first variant to run
- *   absorbs the change on behalf of all of them.
+ * @param parts - The file name's hyphen-joined segments, usually a base name
+ *   followed by the config-variant key from `resolveCacheKey`. State that is
+ *   consumed once (a stored hash, a drained builder) must carry that key, or
+ *   the first variant to run absorbs the change on behalf of all of them.
  * @returns The absolute path to the state file.
  */
-export function statePath(cwd: string, name: string, key?: string): string {
-	return path.join(stateDirectory(cwd), key === undefined ? name : `${name}-${key}`);
+export function statePath(cwd: string, ...parts: Array<string>): string {
+	return path.join(stateDirectory(cwd), parts.join("-"));
+}
+
+/**
+ * Read a UTF-8 file, or `undefined` when it cannot be read for any reason.
+ * Shared by every tolerant read in the CLI: state files, and the config-import
+ * closure walk.
+ *
+ * @param filePath - The file to read.
+ * @returns The file's content, or `undefined`.
+ */
+export function readFileIfPresent(filePath: string): string | undefined {
+	try {
+		return fs.readFileSync(filePath, "utf8");
+	} catch {
+		return undefined;
+	}
 }
 
 /**
@@ -67,9 +93,9 @@ export function statePath(cwd: string, name: string, key?: string): string {
  * @param filePath - The state file, from {@link statePath}.
  * @returns The stored payload, or `undefined`.
  */
-/* oxlint-disable typescript/no-unnecessary-type-parameters -- T is the caller's assertion about what its own state file holds, which keeps the cast at one call site instead of at every reader. */
+/* oxlint-disable typescript/no-unnecessary-type-parameters -- T is the reader's assertion about what its own state file holds, which keeps the cast at one call site instead of at every use of the result. */
 export function readState<T>(filePath: string): T | undefined {
-	const raw = readIfPresent(filePath);
+	const raw = readFileIfPresent(filePath);
 	if (raw === undefined) {
 		return undefined;
 	}
@@ -95,32 +121,16 @@ export function readState<T>(filePath: string): T | undefined {
  *
  * The write is atomic (temp file plus rename), since `plan()` runs concurrently
  * across packages in a parallel per-package lint setup and a torn file would be
- * read back as "unknown" at best. Identical content is not rewritten, but its
- * mtime is refreshed: the hybrid-status freshness check compares that mtime
- * against the config's, and the factory rewrites the same content on every
- * config evaluation.
+ * read back as "unknown" at best.
  *
  * Best-effort — a failed write leaves the state unknown, so the next run
  * recomputes rather than trusting something stale.
  *
- * @template T - The shape this file's writer stores.
  * @param filePath - The state file, from {@link statePath}.
  * @param data - The payload to store.
- * @returns True when the state is on disk.
  */
-/* oxlint-disable typescript/no-unnecessary-type-parameters -- T lets a writer pin the shape it stores at the call site; the payload is otherwise `unknown` and unchecked. */
-export function writeState<T>(filePath: string, data: T): boolean {
-	const content = `${JSON.stringify({ data, version: STATE_VERSION } satisfies StateEnvelope<T>)}\n`;
-	if (readIfPresent(filePath) === content) {
-		try {
-			const now = Date.now() / 1000;
-			fs.utimesSync(filePath, now, now);
-			return true;
-		} catch {
-			return false;
-		}
-	}
-
+export function writeState(filePath: string, data: unknown): void {
+	const content = `${JSON.stringify({ data, version: STATE_VERSION } satisfies StateEnvelope<unknown>)}\n`;
 	// One writer per process per file, so the pid keeps the temp name
 	// collision-free across parallel package lints sharing a workspace root.
 	const temporary = `${filePath}.${process.pid}.tmp`;
@@ -128,19 +138,45 @@ export function writeState<T>(filePath: string, data: T): boolean {
 		fs.mkdirSync(path.dirname(filePath), { recursive: true });
 		fs.writeFileSync(temporary, content);
 		fs.renameSync(temporary, filePath);
-		return true;
 	} catch {
 		fs.rmSync(temporary, { force: true });
-		return false;
 	}
 }
 
-/* oxlint-enable typescript/no-unnecessary-type-parameters */
+/**
+ * Compare a value against the stored one and replace it when they differ, the
+ * compare-and-swap every hash-drift bust runs: the caller acts on the outcome
+ * and never on the stored value itself.
+ *
+ * The value is consumed by the swap — once stored, every later run reads back
+ * `"unchanged"` — which is why hash state is keyed per config variant.
+ *
+ * @param filePath - The state file, from {@link statePath}.
+ * @param value - The value this run computed.
+ * @returns How the stored value compared.
+ */
+export function swapState(filePath: string, value: string): StateSwap {
+	const stored = readState<string>(filePath);
+	if (stored === value) {
+		return "unchanged";
+	}
 
-function readIfPresent(filePath: string): string | undefined {
+	writeState(filePath, value);
+	return stored === undefined ? "first" : "changed";
+}
+
+/**
+ * Refresh a state file's mtime without rewriting it, so a reader comparing that
+ * mtime against another file's still sees the state as fresh. Best-effort: a
+ * missing file simply stays missing.
+ *
+ * @param filePath - The state file, from {@link statePath}.
+ */
+export function touchState(filePath: string): void {
 	try {
-		return fs.readFileSync(filePath, "utf8");
+		const now = Date.now() / 1000;
+		fs.utimesSync(filePath, now, now);
 	} catch {
-		return undefined;
+		// The reader treats a missing or stale file as "unknown" and recomputes.
 	}
 }

--- a/src/lint-cli/state.ts
+++ b/src/lint-cli/state.ts
@@ -55,14 +55,15 @@ export function stateDirectory(cwd: string): string {
  * Resolve one state file inside {@link stateDirectory}.
  *
  * @param cwd - The consumer project root.
- * @param parts - The file name's hyphen-joined segments, usually a base name
- *   followed by the config-variant key from `resolveCacheKey`. State that is
- *   consumed once (a stored hash, a drained builder) must carry that key, or
- *   the first variant to run absorbs the change on behalf of all of them.
+ * @param name - The state's base name.
+ * @param parts - Further hyphen-joined segments, usually the config-variant key
+ *   from `resolveCacheKey`. State that is consumed once (a stored hash, a
+ *   drained builder) must carry that key, or the first variant to run absorbs
+ *   the change on behalf of all of them.
  * @returns The absolute path to the state file.
  */
-export function statePath(cwd: string, ...parts: Array<string>): string {
-	return path.join(stateDirectory(cwd), parts.join("-"));
+export function statePath(cwd: string, name: string, ...parts: Array<string>): string {
+	return path.join(stateDirectory(cwd), [name, ...parts].join("-"));
 }
 
 /**
@@ -96,23 +97,7 @@ export function readFileIfPresent(filePath: string): string | undefined {
 /* oxlint-disable typescript/no-unnecessary-type-parameters -- T is the reader's assertion about what its own state file holds, which keeps the cast at one call site instead of at every use of the result. */
 export function readState<T>(filePath: string): T | undefined {
 	const raw = readFileIfPresent(filePath);
-	if (raw === undefined) {
-		return undefined;
-	}
-
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(raw);
-	} catch {
-		return undefined;
-	}
-
-	if (typeof parsed !== "object" || parsed === null) {
-		return undefined;
-	}
-
-	const envelope = parsed as Partial<StateEnvelope<T>>;
-	return envelope.version === STATE_VERSION ? envelope.data : undefined;
+	return raw === undefined ? undefined : parseState<T>(raw);
 }
 /* oxlint-enable typescript/no-unnecessary-type-parameters */
 
@@ -139,7 +124,12 @@ export function writeState(filePath: string, data: unknown): void {
 		fs.writeFileSync(temporary, content);
 		fs.renameSync(temporary, filePath);
 	} catch {
-		fs.rmSync(temporary, { force: true });
+		try {
+			fs.rmSync(temporary, { force: true });
+		} catch {
+			// The cleanup must not throw either: the factory writes the hybrid
+			// status during config evaluation, which must never fail for this.
+		}
 	}
 }
 
@@ -151,18 +141,26 @@ export function writeState(filePath: string, data: unknown): void {
  * The value is consumed by the swap — once stored, every later run reads back
  * `"unchanged"` — which is why hash state is keyed per config variant.
  *
+ * A stored value this {@link STATE_VERSION} cannot read counts as `"changed"`,
+ * so a CLI upgrade invalidates rather than silently adopts what it finds.
+ *
  * @param filePath - The state file, from {@link statePath}.
  * @param value - The value this run computed.
  * @returns How the stored value compared.
  */
 export function swapState(filePath: string, value: string): StateSwap {
-	const stored = readState<string>(filePath);
+	const raw = readFileIfPresent(filePath);
+	const stored = raw === undefined ? undefined : parseState<string>(raw);
 	if (stored === value) {
 		return "unchanged";
 	}
 
 	writeState(filePath, value);
-	return stored === undefined ? "first" : "changed";
+	// A file that exists but does not parse back — corrupt, or written by
+	// another STATE_VERSION — counts as changed, not first. Something was
+	// stored, and nothing can vouch for what the caches keyed to it hold, so
+	// the caller must invalidate rather than adopt them.
+	return raw === undefined ? "first" : "changed";
 }
 
 /**
@@ -180,3 +178,29 @@ export function touchState(filePath: string): void {
 		// The reader treats a missing or stale file as "unknown" and recomputes.
 	}
 }
+
+/**
+ * Parse one state file's content, or `undefined` when it is malformed or
+ * carries another {@link STATE_VERSION}.
+ *
+ * @template T - The shape this file's writer stores (asserted, not checked).
+ * @param raw - The file's content.
+ * @returns The stored payload, or `undefined`.
+ */
+/* oxlint-disable typescript/no-unnecessary-type-parameters -- Mirrors readState's assertion; see its note. */
+function parseState<T>(raw: string): T | undefined {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+
+	if (typeof parsed !== "object" || parsed === null) {
+		return undefined;
+	}
+
+	const envelope = parsed as Partial<StateEnvelope<T>>;
+	return envelope.version === STATE_VERSION ? envelope.data : undefined;
+}
+/* oxlint-enable typescript/no-unnecessary-type-parameters */

--- a/test/lint-cli-state.spec.ts
+++ b/test/lint-cli-state.spec.ts
@@ -4,10 +4,13 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+	readFileIfPresent,
 	readState,
 	STATE_VERSION,
 	stateDirectory,
 	statePath,
+	swapState,
+	touchState,
 	writeState,
 } from "../src/lint-cli/state.ts";
 
@@ -22,7 +25,7 @@ function withTemporaryDirectory(run: (directory: string) => void): void {
 }
 
 describe("statePath", () => {
-	it("keys a name apart per variant, inside the cache directory", () => {
+	it("hyphen-joins its parts inside the cache directory", () => {
 		expect.hasAssertions();
 
 		expect(statePath("/project", "ignored", "aaaa1111")).not.toBe(
@@ -31,7 +34,9 @@ describe("statePath", () => {
 		expect(path.dirname(statePath("/project", "ignored", "aaaa1111"))).toBe(
 			stateDirectory("/project"),
 		);
-		expect(path.basename(statePath("/project", "hybrid-status"))).toBe("hybrid-status");
+		expect(path.basename(statePath("/project", "tsbuildinfo", "full", "key", "id"))).toBe(
+			"tsbuildinfo-full-key-id",
+		);
 	});
 });
 
@@ -41,8 +46,8 @@ describe("readState", () => {
 
 		withTemporaryDirectory((directory) => {
 			const file = statePath(directory, "example", "key");
+			writeState(file, { hash: "abc" });
 
-			expect(writeState(file, { hash: "abc" })).toBe(true);
 			expect(readState<{ hash: string }>(file)).toStrictEqual({ hash: "abc" });
 		});
 	});
@@ -79,7 +84,41 @@ describe("readState", () => {
 });
 
 describe("writeState", () => {
-	it("refreshes the mtime instead of rewriting identical content", () => {
+	it("leaves no temp file behind when the write fails", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			// The cache home as a file makes creating the state directory throw.
+			fs.mkdirSync(path.join(directory, "node_modules"));
+			fs.writeFileSync(path.join(directory, "node_modules", ".cache"), "");
+
+			expect(() => {
+				writeState(statePath(directory, "example"), "payload");
+			}).not.toThrow();
+			expect(fs.readdirSync(directory)).toStrictEqual(["node_modules"]);
+		});
+	});
+});
+
+describe("swapState", () => {
+	it("reports first, unchanged and changed across successive runs", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const file = statePath(directory, "example", "key");
+
+			expect(swapState(file, "one")).toBe("first");
+			expect(swapState(file, "one")).toBe("unchanged");
+			expect(swapState(file, "two")).toBe("changed");
+			// The swap consumes the value, which is why hash state is keyed per
+			// config variant: a second run never sees the same change again.
+			expect(swapState(file, "two")).toBe("unchanged");
+		});
+	});
+});
+
+describe("touchState", () => {
+	it("refreshes an existing mtime and ignores a missing file", () => {
 		expect.hasAssertions();
 
 		withTemporaryDirectory((directory) => {
@@ -88,22 +127,27 @@ describe("writeState", () => {
 			const past = Date.now() / 1000 - 60;
 			fs.utimesSync(file, past, past);
 			const before = fs.statSync(file).mtimeMs;
+			const content = readFileIfPresent(file);
 
-			expect(writeState(file, { oxlint: true })).toBe(true);
+			touchState(file);
+
 			expect(fs.statSync(file).mtimeMs).toBeGreaterThan(before);
+			expect(readFileIfPresent(file)).toBe(content);
+			expect(() => {
+				touchState(statePath(directory, "absent"));
+			}).not.toThrow();
 		});
 	});
+});
 
-	it("leaves no temp file behind and reports a failed write", () => {
+describe("readFileIfPresent", () => {
+	it("returns undefined instead of throwing for an unreadable file", () => {
 		expect.hasAssertions();
 
 		withTemporaryDirectory((directory) => {
-			// The cache home as a file makes creating the state directory throw.
-			fs.mkdirSync(path.join(directory, "node_modules"));
-			fs.writeFileSync(path.join(directory, "node_modules", ".cache"), "");
-
-			expect(writeState(statePath(directory, "example"), "payload")).toBe(false);
-			expect(fs.existsSync(stateDirectory(directory))).toBe(false);
+			expect(readFileIfPresent(path.join(directory, "absent"))).toBeUndefined();
+			// A directory is readable as a path but not as a file.
+			expect(readFileIfPresent(directory)).toBeUndefined();
 		});
 	});
 });

--- a/test/lint-cli-state.spec.ts
+++ b/test/lint-cli-state.spec.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+	readState,
+	STATE_VERSION,
+	stateDirectory,
+	statePath,
+	writeState,
+} from "../src/lint-cli/state.ts";
+
+function withTemporaryDirectory(run: (directory: string) => void): void {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-state-"));
+
+	try {
+		run(directory);
+	} finally {
+		fs.rmSync(directory, { force: true, recursive: true });
+	}
+}
+
+describe("statePath", () => {
+	it("keys a name apart per variant, inside the cache directory", () => {
+		expect.hasAssertions();
+
+		expect(statePath("/project", "ignored", "aaaa1111")).not.toBe(
+			statePath("/project", "ignored", "bbbb2222"),
+		);
+		expect(path.dirname(statePath("/project", "ignored", "aaaa1111"))).toBe(
+			stateDirectory("/project"),
+		);
+		expect(path.basename(statePath("/project", "hybrid-status"))).toBe("hybrid-status");
+	});
+});
+
+describe("readState", () => {
+	it("round-trips a payload through a directory it creates", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const file = statePath(directory, "example", "key");
+
+			expect(writeState(file, { hash: "abc" })).toBe(true);
+			expect(readState<{ hash: string }>(file)).toStrictEqual({ hash: "abc" });
+		});
+	});
+
+	it("returns undefined when the file is missing or malformed", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const file = statePath(directory, "example");
+
+			expect(readState(file)).toBeUndefined();
+
+			fs.mkdirSync(path.dirname(file), { recursive: true });
+			fs.writeFileSync(file, "not json");
+
+			expect(readState(file)).toBeUndefined();
+		});
+	});
+
+	it("rejects state written by another schema version", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const file = statePath(directory, "example");
+			writeState(file, "payload");
+			fs.writeFileSync(file, JSON.stringify({ data: "payload", version: STATE_VERSION + 1 }));
+
+			// A CLI upgrade that changes a stored shape must invalidate the old
+			// file rather than misread it: the config hash only says the config
+			// is unchanged, so nothing else catches this.
+			expect(readState(file)).toBeUndefined();
+		});
+	});
+});
+
+describe("writeState", () => {
+	it("refreshes the mtime instead of rewriting identical content", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const file = statePath(directory, "example");
+			writeState(file, { oxlint: true });
+			const past = Date.now() / 1000 - 60;
+			fs.utimesSync(file, past, past);
+			const before = fs.statSync(file).mtimeMs;
+
+			expect(writeState(file, { oxlint: true })).toBe(true);
+			expect(fs.statSync(file).mtimeMs).toBeGreaterThan(before);
+		});
+	});
+
+	it("leaves no temp file behind and reports a failed write", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			// The cache home as a file makes creating the state directory throw.
+			fs.mkdirSync(path.join(directory, "node_modules"));
+			fs.writeFileSync(path.join(directory, "node_modules", ".cache"), "");
+
+			expect(writeState(statePath(directory, "example"), "payload")).toBe(false);
+			expect(fs.existsSync(stateDirectory(directory))).toBe(false);
+		});
+	});
+});

--- a/test/lint-cli-state.spec.ts
+++ b/test/lint-cli-state.spec.ts
@@ -101,6 +101,22 @@ describe("writeState", () => {
 });
 
 describe("swapState", () => {
+	it("reports changed for state it cannot read back", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			const file = statePath(directory, "example", "key");
+			fs.mkdirSync(path.dirname(file), { recursive: true });
+			fs.writeFileSync(file, JSON.stringify({ data: "one", version: STATE_VERSION + 1 }));
+
+			// A CLI upgrade must invalidate what it finds, not adopt it: the
+			// caches keyed to an unreadable hash cannot be vouched for, so the
+			// caller has to bust rather than treat this as a first run.
+			expect(swapState(file, "one")).toBe("changed");
+			expect(swapState(file, "one")).toBe("unchanged");
+		});
+	});
+
 	it("reports first, unchanged and changed across successive runs", () => {
 		expect.hasAssertions();
 


### PR DESCRIPTION
Closes #609.

Five modules persisted state under `node_modules/.cache/isentinel-lint` and each
spelled the three path segments itself; three carried byte-identical read/write
helpers. Any cross-cutting change needed five coordinated edits, and a partial
one failed silently, because every reader degrades to "unknown".

## What lands

`src/lint-cli/state.ts` owns the cache home and the file format:

- `stateDirectory` / `statePath(cwd, name, ...parts)` — the only place the three
  path segments and the hyphen-joining convention are spelled.
- `readState<T>` / `writeState` — writes are **atomic** (temp file + rename),
  since `plan()` runs concurrently across packages in a parallel per-package
  lint, and every payload is wrapped in a `STATE_VERSION` envelope, so a CLI
  upgrade that changes a stored shape invalidates the old file instead of
  misreading it. `ignored.ts` drops its ad-hoc `version` field in favour of it.
- `swapState` — the compare-and-swap both hash busts open-coded, leaving each
  with only what it hashes and what it deletes. A file that exists but cannot be
  read back (corrupt, or another `STATE_VERSION`) counts as **changed**, not
  first, so an upgrade busts rather than adopting caches it cannot vouch for.
- `touchState` — the mtime refresh the hybrid-status freshness check depends on,
  owned by the module that owns that contract rather than by the generic writer.
- `readFileIfPresent` — the surviving tolerant read, now also used by the config
  closure walk and the `package.json` read.

Each module keeps its documented `*StatePath` export as a one-line wrapper, so
the tests that reference them by name are untouched.

The builder's `.tsbuildinfo` files go through `statePath` for their location
only — TypeScript writes them and versions them itself.

## Notes

- The stale `src/cli/constants-generated.ts` regen (left by c7bbc90e) rides
  along: the generated file is ESLint-ignored, so the pre-commit lint hook
  cannot accept it as a commit of its own.
- New `test/lint-cli-state.spec.ts` covers the envelope round-trip, version
  rejection, the swap outcomes, and that a failed write leaves no temp file.

Full suite green (321 tests), lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved lint CLI state and cache handling for more reliable persistence across runs.
  * Added consistent recovery for missing, invalid, or outdated cached state.
  * Improved detection of configuration, package, and ignored-file changes.
  * Updated supported React ESLint plugin versions to 5.17.1.

* **Tests**
  * Added comprehensive coverage for state storage, cache invalidation, file handling, and timestamp updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->