### PR TITLE
fix(lint-cli): memoise the ignore predicate, not the ignore answers

### DIFF
--- a/src/lint-cli/eslint-install.ts
+++ b/src/lint-cli/eslint-install.ts
@@ -1,0 +1,51 @@
+/**
+ * Locating the ESLint installation a run's config is resolved against.
+ *
+ * The runner and its ignore helper both need it and must agree: the helper
+ * serializes the config's match patterns out of one ESLint's config loader, and
+ * the runner evaluates them with that same ESLint's matcher. Resolving them
+ * separately would let the two drift onto different installations, and a
+ * matcher that disagrees with the one that produced the patterns is exactly the
+ * failure this feature cannot have.
+ */
+import { createRequire } from "node:module";
+import path from "node:path";
+
+/**
+ * A synthetic basename for `createRequire`, which resolves relative to a file
+ * rather than a directory. Spelled so it can never collide with a real consumer
+ * module.
+ */
+const RESOLVE_ANCHOR = "__isentinel-lint__.js";
+
+/** A resolved ESLint installation. */
+export interface EslintInstall {
+	/**
+	 * A require anchored inside the package, for reaching its own files and its
+	 * dependencies.
+	 */
+	requireFrom: NodeJS.Require;
+	/** The package root. */
+	root: string;
+}
+
+/**
+ * Resolve the ESLint the consumer's config will be linted with: their own,
+ * resolved from `cwd`, falling back to the one resolvable from this file (the
+ * hoisted peer dependency) when `cwd` has no `node_modules` of its own — the
+ * case in the fixture-based tests.
+ *
+ * @param cwd - The consumer project root.
+ * @returns The package root and a require anchored in it.
+ * @throws {Error} When ESLint cannot be resolved from either location.
+ */
+export function resolveEslintInstall(cwd: string): EslintInstall {
+	let packageJson: string;
+	try {
+		packageJson = createRequire(path.join(cwd, RESOLVE_ANCHOR)).resolve("eslint/package.json");
+	} catch {
+		packageJson = createRequire(import.meta.url).resolve("eslint/package.json");
+	}
+
+	return { requireFrom: createRequire(packageJson), root: path.dirname(packageJson) };
+}

--- a/src/lint-cli/files.ts
+++ b/src/lint-cli/files.ts
@@ -134,6 +134,33 @@ export function withoutIgnored(files: RepoFiles, ignored: ReadonlySet<string>): 
 }
 
 /**
+ * Restrict explicit lint targets to the ones oxlint could lint. Oxlint only
+ * handles the TS/JS family, and exits non-zero with "No files found to lint"
+ * when every path it was handed resolves to nothing — so a hook run over a
+ * `package.json`-only change would fail on a file oxlint was never going to
+ * lint. A path is kept when its extension is type-aware, when it has no
+ * extension, or when it is an existing directory (either may hold TS/JS files).
+ *
+ * @param cwd - The working directory to resolve targets against.
+ * @param targets - The explicit lint target paths.
+ * @returns The subset oxlint should receive.
+ */
+export function oxlintTargets(cwd: string, targets: Array<string>): Array<string> {
+	return targets.filter((target) => {
+		const extension = path.extname(target).toLowerCase();
+		if (extension === "" || TYPE_AWARE_EXTENSION_SET.has(extension)) {
+			return true;
+		}
+
+		try {
+			return fs.statSync(path.resolve(cwd, target)).isDirectory();
+		} catch {
+			return false;
+		}
+	});
+}
+
+/**
  * Collect the absolute paths of lintable files under `targets`, honouring
  * `.gitignore` (via `git ls-files`) when inside a git repository. Thin wrapper
  * over {@link collectRepoFiles}.

--- a/src/lint-cli/ignored-child.ts
+++ b/src/lint-cli/ignored-child.ts
@@ -1,13 +1,14 @@
 /**
  * Internal helper process for {@link file://./ignored.ts}. Loads the consumer's
- * resolved ESLint config once and writes the ignored subset of a target list to
- * a JSON file.
+ * resolved ESLint config once and writes back what the runner needs to classify
+ * lint targets: the config's match/ignore patterns when they are serializable,
+ * and otherwise the ignored subset of a target list.
  *
- * Run as a child rather than in-process for two reasons: `isPathIgnored` is
- * async while `plan` is synchronous end to end, and loading a consumer's flat
- * config pulls their whole plugin tree (and jiti) into memory — 6-10s and
- * several hundred MB in a large project, neither of which should outlive the
- * one query the runner needs.
+ * Run as a child rather than in-process for two reasons: the config-loading
+ * API is async while `plan` is synchronous end to end, and loading a
+ * consumer's flat config pulls their whole plugin tree (and jiti) into memory
+ * — 6-10s and several hundred MB in a large project, neither of which should
+ * outlive the one query the runner needs.
  *
  * Invoked as `node <this file> <cwd> <outFile>` with the JSON target array on
  * stdin.
@@ -17,6 +18,15 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
+
+import type { IgnoredPayload, PredicateEntry } from "./ignored-predicate.ts";
+
+/**
+ * A synthetic basename for {@link createRequire}, which resolves relative to a
+ * file rather than a directory. Spelled so it can never collide with a real
+ * consumer module.
+ */
+const RESOLVE_ANCHOR = "__isentinel-lint__.js";
 
 /** The subset of the `ESLint` class this helper uses. */
 interface EslintLike {
@@ -28,37 +38,170 @@ interface EslintModule {
 	ESLint: new (options: { cwd: string }) => EslintLike;
 }
 
+/** The subset of the resolved config array this helper reads. */
+interface ConfigArrayLike extends Array<Record<string, unknown>> {
+	basePath: string;
+}
+
+/** The subset of `eslint/lib/config/config-loader.js` this helper uses. */
+interface ConfigLoaderModule {
+	ConfigLoader: new (options: {
+		configFile: false | string | undefined;
+		cwd: string;
+		ignoreEnabled: boolean;
+	}) => {
+		loadConfigArrayForDirectory: (directoryPath: string) => Promise<ConfigArrayLike>;
+	};
+}
+
 /**
- * Load the ESLint the consumer's config will be linted with: their own
- * installation, resolved from `cwd`, falling back to the one resolvable from
- * this file (the hoisted peer dependency) when `cwd` has no `node_modules` of
- * its own — the case in the fixture-based tests.
+ * The keys a {@link PredicateEntry} carries over verbatim. Anything else is
+ * dropped, and its former presence recorded as
+ * {@link PredicateEntry.nonGlobal}.
+ */
+const CARRIED_KEYS = new Set(["basePath", "files", "ignores", "name"]);
+
+/**
+ * Locate the `eslint` installation the consumer's config will be linted with:
+ * their own, resolved from `cwd`, falling back to the one resolvable from this
+ * file (the hoisted peer dependency) when `cwd` has no `node_modules` of its
+ * own — the case in the fixture-based tests.
+ *
+ * @param cwd - The consumer project root.
+ * @returns The absolute path to ESLint's `package.json`.
+ * @throws {Error} When ESLint cannot be resolved from either location.
+ */
+function resolveEslintPackageJson(cwd: string): string {
+	const requireFrom = createRequire(path.join(cwd, RESOLVE_ANCHOR));
+	try {
+		return requireFrom.resolve("eslint/package.json");
+	} catch {
+		return createRequire(import.meta.url).resolve("eslint/package.json");
+	}
+}
+
+/**
+ * Whether a `files`/`ignores` value is made purely of glob strings. Flat config
+ * also permits function matchers, and `files` may nest one level for AND
+ * matching; a function anywhere leaves the config with no form as data.
+ *
+ * @param value - The `files` or `ignores` value to test.
+ * @returns True when every matcher is a string.
+ */
+function isGlobList(value: unknown): value is Array<Array<string> | string> {
+	return Array.isArray(value) && value.flat(1).every((matcher) => typeof matcher === "string");
+}
+
+/**
+ * Reduce one resolved config object to its match keys, or `undefined` when a
+ * matcher is a function rather than a glob.
+ *
+ * @param config - One entry of the resolved config array.
+ * @returns The serializable entry, or `undefined` when it cannot be serialized.
+ */
+function serializeEntry(config: Record<string, unknown>): PredicateEntry | undefined {
+	const entry: PredicateEntry = {};
+
+	const { files, ignores } = config;
+	if (files !== undefined) {
+		if (!isGlobList(files)) {
+			return undefined;
+		}
+
+		entry.files = files;
+	}
+
+	if (ignores !== undefined) {
+		if (!isGlobList(ignores)) {
+			return undefined;
+		}
+
+		entry.ignores = ignores as Array<string>;
+	}
+
+	if (typeof config["basePath"] === "string") {
+		entry.basePath = config["basePath"];
+	}
+
+	if (typeof config["name"] === "string") {
+		entry.name = config["name"];
+	}
+
+	if (Object.keys(config).some((key) => !CARRIED_KEYS.has(key))) {
+		entry.nonGlobal = true;
+	}
+
+	return entry;
+}
+
+/**
+ * Serialize the resolved config's match and ignore patterns, which the runner
+ * can then evaluate itself for any path — including files that did not exist
+ * when this ran.
+ *
+ * Reaching the config array means reaching past the `eslint` package's exports
+ * map: no public API returns it, and `calculateConfigForFile` strips exactly
+ * the `files`/`ignores` keys this needs. That coupling is contained by the
+ * caller — an `undefined` return here falls back to the per-target query below,
+ * which is the behaviour this replaced.
+ *
+ * @param cwd - The consumer project root.
+ * @returns The serialized predicate, or `undefined` when it is unavailable.
+ */
+async function queryPredicate(cwd: string): Promise<IgnoredPayload | undefined> {
+	let configArray: ConfigArrayLike;
+	try {
+		const requireFrom = createRequire(path.join(cwd, RESOLVE_ANCHOR));
+		const root = path.dirname(resolveEslintPackageJson(cwd));
+		const { ConfigLoader } = requireFrom(
+			path.join(root, "lib", "config", "config-loader.js"),
+		) as ConfigLoaderModule;
+		const loader = new ConfigLoader({ configFile: undefined, cwd, ignoreEnabled: true });
+		// `loadConfigArrayForDirectory` resolves the config for the *parent* of
+		// what it is given, so the placeholder makes it `cwd` itself.
+		configArray = await loader.loadConfigArrayForDirectory(path.join(cwd, "__placeholder__"));
+	} catch {
+		return undefined;
+	}
+
+	const entries: Array<PredicateEntry> = [];
+	for (const config of configArray) {
+		const entry = serializeEntry(config);
+		if (entry === undefined) {
+			// A function matcher, which no file can carry across a process
+			// boundary. One is enough to sink the whole array.
+			return undefined;
+		}
+
+		entries.push(entry);
+	}
+
+	return { basePath: configArray.basePath, entries, mode: "predicate" };
+}
+
+/**
+ * Load the ESLint the consumer's config will be linted with.
  *
  * @param cwd - The consumer project root.
  * @returns The `eslint` module namespace.
  * @rejects {Error} When ESLint cannot be resolved from either location.
  */
 async function loadEslint(cwd: string): Promise<EslintModule> {
-	// A synthetic basename: `createRequire` resolves relative to a *file*, and
-	// this one is spelled so it can never collide with a real consumer module.
-	const requireFrom = createRequire(path.join(cwd, "__isentinel-lint__.js"));
-	let entry: string;
-	try {
-		entry = requireFrom.resolve("eslint");
-	} catch {
-		entry = createRequire(import.meta.url).resolve("eslint");
-	}
-
-	return (await import(pathToFileURL(entry).href)) as EslintModule;
+	const root = path.dirname(resolveEslintPackageJson(cwd));
+	const requireFrom = createRequire(path.join(root, RESOLVE_ANCHOR));
+	return (await import(pathToFileURL(requireFrom.resolve("eslint")).href)) as EslintModule;
 }
 
-async function main(): Promise<void> {
-	const [cwd, outFile] = process.argv.slice(2);
-	if (cwd === undefined || outFile === undefined) {
-		throw new Error("usage: node ignored-child <cwd> <outFile> (targets on stdin)");
-	}
-
-	const targets = JSON.parse(fs.readFileSync(0, "utf8")) as Array<string>;
+/**
+ * Ask ESLint about each target in turn — correct for the targets that exist
+ * right now, and the fallback whenever the config's patterns cannot be
+ * serialized.
+ *
+ * @param cwd - The consumer project root.
+ * @param targets - The target files to classify.
+ * @returns The ignored subset of `targets`.
+ */
+async function queryAnswers(cwd: string, targets: Array<string>): Promise<IgnoredPayload> {
 	const { ESLint } = await loadEslint(cwd);
 	const eslint = new ESLint({ cwd });
 
@@ -69,7 +212,19 @@ async function main(): Promise<void> {
 		}
 	}
 
-	fs.writeFileSync(outFile, JSON.stringify(ignored));
+	return { ignored, mode: "answers" };
+}
+
+async function main(): Promise<void> {
+	const [cwd, outFile] = process.argv.slice(2);
+	if (cwd === undefined || outFile === undefined) {
+		throw new Error("usage: node ignored-child <cwd> <outFile> (targets on stdin)");
+	}
+
+	const targets = JSON.parse(fs.readFileSync(0, "utf8")) as Array<string>;
+	const payload = (await queryPredicate(cwd)) ?? (await queryAnswers(cwd, targets));
+
+	fs.writeFileSync(outFile, JSON.stringify(payload));
 }
 
 void main().catch(() => {

--- a/src/lint-cli/ignored-child.ts
+++ b/src/lint-cli/ignored-child.ts
@@ -1,8 +1,8 @@
 /**
  * Internal helper process for {@link file://./ignored.ts}. Loads the consumer's
  * resolved ESLint config once and writes back what the runner needs to classify
- * lint targets: the config's match/ignore patterns when they are serializable,
- * and otherwise the ignored subset of a target list.
+ * lint targets: the config's match patterns when they are serializable, and
+ * otherwise the ignored subset of a target list.
  *
  * Run as a child rather than in-process for two reasons: the config-loading
  * API is async while `plan` is synchronous end to end, and loading a
@@ -14,19 +14,12 @@
  * stdin.
  */
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 
+import { resolveEslintInstall } from "./eslint-install.ts";
 import type { IgnoredPayload, PredicateEntry } from "./ignored-predicate.ts";
-
-/**
- * A synthetic basename for {@link createRequire}, which resolves relative to a
- * file rather than a directory. Spelled so it can never collide with a real
- * consumer module.
- */
-const RESOLVE_ANCHOR = "__isentinel-lint__.js";
 
 /** The subset of the `ESLint` class this helper uses. */
 interface EslintLike {
@@ -41,6 +34,7 @@ interface EslintModule {
 /** The subset of the resolved config array this helper reads. */
 interface ConfigArrayLike extends Array<Record<string, unknown>> {
 	basePath: string;
+	getConfigStatus: (filePath: string) => string;
 }
 
 /** The subset of `eslint/lib/config/config-loader.js` this helper uses. */
@@ -55,29 +49,55 @@ interface ConfigLoaderModule {
 }
 
 /**
- * The keys a {@link PredicateEntry} carries over verbatim. Anything else is
- * dropped, and its former presence recorded as
- * {@link PredicateEntry.nonGlobal}.
+ * The config keys that leave a `files`-less config able to say something about
+ * a path, mirroring `META_FIELDS` in `@eslint/config-array`: a config carrying
+ * `ignores` and nothing else outside this set is a global ignore, and one with
+ * any further key only excludes files from itself.
  */
-const CARRIED_KEYS = new Set(["basePath", "files", "ignores", "name"]);
+const META_KEYS = new Set(["basePath", "name"]);
 
 /**
- * Locate the `eslint` installation the consumer's config will be linted with:
- * their own, resolved from `cwd`, falling back to the one resolvable from this
- * file (the hoisted peer dependency) when `cwd` has no `node_modules` of its
- * own — the case in the fixture-based tests.
+ * Load the consumer's resolved config array.
+ *
+ * Reaching it means reaching past the `eslint` package's exports map: no public
+ * API returns it, and `calculateConfigForFile` strips exactly the
+ * `files`/`ignores` keys this needs. Only that coupling is caught here — a
+ * config that throws on load is a broken project, not a missing capability, and
+ * is left to fail the helper outright rather than be retried through a second,
+ * equally doomed config load.
  *
  * @param cwd - The consumer project root.
- * @returns The absolute path to ESLint's `package.json`.
- * @throws {Error} When ESLint cannot be resolved from either location.
+ * @returns The config array, or `undefined` when the loader is unreachable.
+ * @rejects {Error} When the consumer's config fails to load.
  */
-function resolveEslintPackageJson(cwd: string): string {
-	const requireFrom = createRequire(path.join(cwd, RESOLVE_ANCHOR));
+async function loadConfigArray(cwd: string): Promise<ConfigArrayLike | undefined> {
+	let loader;
 	try {
-		return requireFrom.resolve("eslint/package.json");
+		const { requireFrom, root } = resolveEslintInstall(cwd);
+		const { ConfigLoader } = requireFrom(
+			path.join(root, "lib", "config", "config-loader.js"),
+		) as ConfigLoaderModule;
+		loader = new ConfigLoader({ configFile: undefined, cwd, ignoreEnabled: true });
 	} catch {
-		return createRequire(import.meta.url).resolve("eslint/package.json");
+		return undefined;
 	}
+
+	// `loadConfigArrayForDirectory` resolves the config for the *parent* of what
+	// it is given, so the placeholder makes it `cwd` itself.
+	return loader.loadConfigArrayForDirectory(path.join(cwd, "__placeholder__"));
+}
+
+/**
+ * Whether a config ignores paths for the whole run rather than just for itself.
+ *
+ * @param config - One entry of the resolved config array.
+ * @returns True when `ignores` is the config's only substantive key.
+ */
+function isGlobalIgnore(config: Record<string, unknown>): boolean {
+	return (
+		config["ignores"] !== undefined &&
+		Object.keys(config).filter((key) => !META_KEYS.has(key)).length === 1
+	);
 }
 
 /**
@@ -93,16 +113,18 @@ function isGlobList(value: unknown): value is Array<Array<string> | string> {
 }
 
 /**
- * Reduce one resolved config object to its match keys, or `undefined` when a
- * matcher is a function rather than a glob.
+ * Reduce one config to its match keys.
  *
  * @param config - One entry of the resolved config array.
- * @returns The serializable entry, or `undefined` when it cannot be serialized.
+ * @returns The entry, or `undefined` when a matcher is a function.
  */
-function serializeEntry(config: Record<string, unknown>): PredicateEntry | undefined {
+function serializeEntry({
+	basePath,
+	files,
+	ignores,
+}: Record<string, unknown>): PredicateEntry | undefined {
 	const entry: PredicateEntry = {};
 
-	const { files, ignores } = config;
 	if (files !== undefined) {
 		if (!isGlobList(files)) {
 			return undefined;
@@ -116,93 +138,65 @@ function serializeEntry(config: Record<string, unknown>): PredicateEntry | undef
 			return undefined;
 		}
 
-		entry.ignores = ignores as Array<string>;
+		entry.ignores = ignores;
 	}
 
-	if (typeof config["basePath"] === "string") {
-		entry.basePath = config["basePath"];
-	}
-
-	if (typeof config["name"] === "string") {
-		entry.name = config["name"];
-	}
-
-	if (Object.keys(config).some((key) => !CARRIED_KEYS.has(key))) {
-		entry.nonGlobal = true;
+	if (typeof basePath === "string") {
+		entry.basePath = basePath;
 	}
 
 	return entry;
 }
 
 /**
- * Serialize the resolved config's match and ignore patterns, which the runner
- * can then evaluate itself for any path — including files that did not exist
- * when this ran.
+ * Reduce the resolved config array to the entries that decide whether ESLint
+ * lints a path at all, or `undefined` when a matcher is a function rather than
+ * a glob and so cannot cross a process boundary.
  *
- * Reaching the config array means reaching past the `eslint` package's exports
- * map: no public API returns it, and `calculateConfigForFile` strips exactly
- * the `files`/`ignores` keys this needs. That coupling is contained by the
- * caller — an `undefined` return here falls back to the per-target query below,
- * which is the behaviour this replaced.
+ * Only two kinds of entry can make that decision: one with `files`, which can
+ * match a path, and a bare global ignore, which can veto it. A `files`-less
+ * config with other keys alongside its `ignores` merely narrows which configs
+ * merge into the one ESLint lints with, which nothing here reads — so it is
+ * dropped rather than carried, and with it the risk of a stripped `rules` key
+ * silently promoting it into a global ignore.
  *
- * @param cwd - The consumer project root.
- * @returns The serialized predicate, or `undefined` when it is unavailable.
+ * @param configArray - The resolved config array.
+ * @returns The serializable entries, or `undefined` when one is a function.
  */
-async function queryPredicate(cwd: string): Promise<IgnoredPayload | undefined> {
-	let configArray: ConfigArrayLike;
-	try {
-		const requireFrom = createRequire(path.join(cwd, RESOLVE_ANCHOR));
-		const root = path.dirname(resolveEslintPackageJson(cwd));
-		const { ConfigLoader } = requireFrom(
-			path.join(root, "lib", "config", "config-loader.js"),
-		) as ConfigLoaderModule;
-		const loader = new ConfigLoader({ configFile: undefined, cwd, ignoreEnabled: true });
-		// `loadConfigArrayForDirectory` resolves the config for the *parent* of
-		// what it is given, so the placeholder makes it `cwd` itself.
-		configArray = await loader.loadConfigArrayForDirectory(path.join(cwd, "__placeholder__"));
-	} catch {
-		return undefined;
-	}
-
+function serializeEntries(configArray: ConfigArrayLike): Array<PredicateEntry> | undefined {
 	const entries: Array<PredicateEntry> = [];
+
 	for (const config of configArray) {
+		if (config["files"] === undefined && !isGlobalIgnore(config)) {
+			continue;
+		}
+
 		const entry = serializeEntry(config);
 		if (entry === undefined) {
-			// A function matcher, which no file can carry across a process
-			// boundary. One is enough to sink the whole array.
 			return undefined;
 		}
 
 		entries.push(entry);
 	}
 
-	return { basePath: configArray.basePath, entries, mode: "predicate" };
+	return entries;
 }
 
 /**
- * Load the ESLint the consumer's config will be linted with.
- *
- * @param cwd - The consumer project root.
- * @returns The `eslint` module namespace.
- * @rejects {Error} When ESLint cannot be resolved from either location.
- */
-async function loadEslint(cwd: string): Promise<EslintModule> {
-	const root = path.dirname(resolveEslintPackageJson(cwd));
-	const requireFrom = createRequire(path.join(root, RESOLVE_ANCHOR));
-	return (await import(pathToFileURL(requireFrom.resolve("eslint")).href)) as EslintModule;
-}
-
-/**
- * Ask ESLint about each target in turn — correct for the targets that exist
- * right now, and the fallback whenever the config's patterns cannot be
- * serialized.
+ * The last-resort classification: load ESLint itself and ask it per target.
+ * Only reached when no config array could be built, so nothing cheaper is
+ * already in hand.
  *
  * @param cwd - The consumer project root.
  * @param targets - The target files to classify.
  * @returns The ignored subset of `targets`.
+ * @rejects {Error} When ESLint cannot be resolved or its config fails to load.
  */
-async function queryAnswers(cwd: string, targets: Array<string>): Promise<IgnoredPayload> {
-	const { ESLint } = await loadEslint(cwd);
+async function queryEslint(cwd: string, targets: Array<string>): Promise<Array<string>> {
+	const { requireFrom } = resolveEslintInstall(cwd);
+	const { ESLint } = (await import(
+		pathToFileURL(requireFrom.resolve("eslint")).href
+	)) as EslintModule;
 	const eslint = new ESLint({ cwd });
 
 	const ignored: Array<string> = [];
@@ -212,7 +206,48 @@ async function queryAnswers(cwd: string, targets: Array<string>): Promise<Ignore
 		}
 	}
 
-	return { ignored, mode: "answers" };
+	return ignored;
+}
+
+/**
+ * The target list, read only by the paths that classify it — the predicate
+ * never looks at it, and it is the larger of the two inputs.
+ *
+ * @returns The target files, absolute.
+ */
+function readTargets(): Array<string> {
+	return JSON.parse(fs.readFileSync(0, "utf8")) as Array<string>;
+}
+
+/**
+ * The best answer this helper can give: the config's patterns when they are
+ * data, the ignored subset of the target list when they are not.
+ *
+ * Both fallbacks reuse whatever the step before them already paid for. A config
+ * that holds a function matcher still classifies targets here, off the array
+ * already loaded, rather than loading the config a second time through `ESLint`
+ * — which only the case of no reachable config loader at all has to fall back
+ * to.
+ *
+ * @param cwd - The consumer project root.
+ * @returns The payload to write back.
+ * @rejects {Error} When the consumer's config fails to load.
+ */
+async function resolvePayload(cwd: string): Promise<IgnoredPayload> {
+	const configArray = await loadConfigArray(cwd);
+	if (configArray === undefined) {
+		return { ignored: await queryEslint(cwd, readTargets()), mode: "answers" };
+	}
+
+	const entries = serializeEntries(configArray);
+	if (entries === undefined) {
+		const ignored = readTargets().filter(
+			(target) => configArray.getConfigStatus(target) !== "matched",
+		);
+		return { ignored, mode: "answers" };
+	}
+
+	return { basePath: configArray.basePath, entries, mode: "predicate" };
 }
 
 async function main(): Promise<void> {
@@ -221,10 +256,7 @@ async function main(): Promise<void> {
 		throw new Error("usage: node ignored-child <cwd> <outFile> (targets on stdin)");
 	}
 
-	const targets = JSON.parse(fs.readFileSync(0, "utf8")) as Array<string>;
-	const payload = (await queryPredicate(cwd)) ?? (await queryAnswers(cwd, targets));
-
-	fs.writeFileSync(outFile, JSON.stringify(payload));
+	fs.writeFileSync(outFile, JSON.stringify(await resolvePayload(cwd)));
 }
 
 void main().catch(() => {

--- a/src/lint-cli/ignored-predicate.ts
+++ b/src/lint-cli/ignored-predicate.ts
@@ -1,36 +1,26 @@
+// cspell:words unconfigured
 /**
- * The serialized form of a resolved config's match/ignore patterns, and the
- * in-process evaluation of it. Produced by {@link file://./ignored-child.ts},
- * consumed by {@link file://./ignored.ts}.
+ * The serialized form of a resolved config's match patterns, and the in-process
+ * evaluation of it. Produced by {@link file://./ignored-child.ts}, consumed by
+ * {@link file://./ignored.ts}.
  *
  * The patterns are evaluated with the same `@eslint/config-array` the
  * consumer's ESLint uses, not a re-implementation: the matcher is the part
  * that has to agree exactly, since a file wrongly classified as ignored is
  * dropped from the dirty count and can skip a typed pass that had work to do.
  */
-import { createRequire } from "node:module";
-import path from "node:path";
+import { resolveEslintInstall } from "./eslint-install.ts";
 
 /**
  * One resolved config object, reduced to what decides matching and ignoring.
  */
 export interface PredicateEntry {
-	/** The config's name, kept only so errors name the offending entry. */
-	name?: string;
 	/** The config's own base path, when it declared one. */
 	basePath?: string;
 	/** The config's `files`, which may nest arrays for AND matching. */
 	files?: Array<Array<string> | string>;
 	/** The config's `ignores`. */
-	ignores?: Array<string>;
-	/**
-	 * Set when the config carried keys beyond the match ones. A config with
-	 * `ignores` and nothing else is a *global* ignore; one with any further key
-	 * only excludes files from itself. Dropping `rules` and friends on the way
-	 * out would silently promote the second kind into the first, so this marks
-	 * the difference the dropped keys used to carry.
-	 */
-	nonGlobal?: boolean;
+	ignores?: Array<Array<string> | string>;
 }
 
 /** What the helper writes back, and what the ignore-set state stores. */
@@ -52,33 +42,9 @@ interface ConfigArrayLike {
 interface ConfigArrayModule {
 	ConfigArray: new (
 		configs: Array<PredicateEntry>,
-		options: { basePath: string; schema: Record<string, unknown> },
+		options: { basePath: string },
 	) => ConfigArrayLike;
 }
-
-/**
- * The whole schema for {@link PredicateEntry.nonGlobal}: it carries no value
- * worth merging or checking, so both halves collapse to a constant.
- *
- * @returns A value the schema is satisfied by.
- */
-function acceptMarker(): true {
-	return true;
-}
-
-/**
- * Teaches the array's schema about {@link PredicateEntry.nonGlobal}, which is
- * ours rather than ESLint's: an unknown key throws when a matched config is
- * merged, which is exactly what classifying a file does.
- */
-const PREDICATE_SCHEMA = {
-	nonGlobal: { merge: acceptMarker, validate: acceptMarker },
-};
-
-/**
- * One built array per payload, so repeated calls in a process rebuild nothing.
- */
-const arrayCache = new WeakMap<object, ConfigArrayLike | undefined>();
 
 /**
  * Classify lint targets against a stored payload.
@@ -88,6 +54,10 @@ const arrayCache = new WeakMap<object, ConfigArrayLike | undefined>();
  * dirty files rather than skipping work. A `"predicate"` payload knows the
  * config itself and classifies any path, including files added since it was
  * stored.
+ *
+ * A path counts as ignored when its status is anything but `"matched"`: a file
+ * no config's `files` covers is `"unconfigured"` rather than `"ignored"`, and
+ * ESLint declines to lint it just the same.
  *
  * @param cwd - The consumer project root, used to resolve the matcher.
  * @param payload - The stored payload.
@@ -101,15 +71,14 @@ export function classifyIgnored(
 	targets: Array<string>,
 ): Array<string> | undefined {
 	if (payload.mode === "answers") {
-		return payload.ignored;
-	}
-
-	const configArray = buildConfigArray(cwd, payload);
-	if (configArray === undefined) {
-		return undefined;
+		const wanted = new Set(targets);
+		return payload.ignored.filter((file) => wanted.has(file));
 	}
 
 	try {
+		const { ConfigArray } = loadConfigArrayModule(cwd);
+		const configArray = new ConfigArray(payload.entries, { basePath: payload.basePath });
+		configArray.normalizeSync();
 		return targets.filter((target) => configArray.getConfigStatus(target) !== "matched");
 	} catch {
 		return undefined;
@@ -118,56 +87,12 @@ export function classifyIgnored(
 
 /**
  * Load the matcher out of the consumer's own ESLint installation, so the
- * patterns are evaluated by the same version that produced them. Falls back to
- * the ESLint resolvable from this file — the hoisted peer dependency, which is
- * what the fixture tests run against.
+ * patterns are evaluated by the same version that produced them.
  *
  * @param cwd - The consumer project root.
  * @returns The `@eslint/config-array` module namespace.
  * @throws {Error} When neither ESLint nor its config-array can be resolved.
  */
 function loadConfigArrayModule(cwd: string): ConfigArrayModule {
-	// A synthetic basename: `createRequire` resolves relative to a *file*, and
-	// this one is spelled so it can never collide with a real consumer module.
-	const requireFrom = createRequire(path.join(cwd, "__isentinel-lint__.js"));
-	let eslintPackageJson: string;
-	try {
-		eslintPackageJson = requireFrom.resolve("eslint/package.json");
-	} catch {
-		eslintPackageJson = createRequire(import.meta.url).resolve("eslint/package.json");
-	}
-
-	return createRequire(eslintPackageJson)("@eslint/config-array") as ConfigArrayModule;
-}
-
-/**
- * Rebuild the ignore predicate from stored patterns, memoised per payload.
- *
- * @param cwd - The consumer project root, used to resolve the matcher.
- * @param payload - The stored predicate payload.
- * @returns The normalized config array, or `undefined` when it cannot be built.
- */
-function buildConfigArray(
-	cwd: string,
-	payload: Extract<IgnoredPayload, { mode: "predicate" }>,
-): ConfigArrayLike | undefined {
-	const cached = arrayCache.get(payload);
-	if (cached !== undefined || arrayCache.has(payload)) {
-		return cached;
-	}
-
-	let configArray: ConfigArrayLike | undefined;
-	try {
-		const { ConfigArray } = loadConfigArrayModule(cwd);
-		configArray = new ConfigArray(payload.entries, {
-			basePath: payload.basePath,
-			schema: PREDICATE_SCHEMA,
-		});
-		configArray.normalizeSync();
-	} catch {
-		configArray = undefined;
-	}
-
-	arrayCache.set(payload, configArray);
-	return configArray;
+	return resolveEslintInstall(cwd).requireFrom("@eslint/config-array") as ConfigArrayModule;
 }

--- a/src/lint-cli/ignored-predicate.ts
+++ b/src/lint-cli/ignored-predicate.ts
@@ -1,0 +1,173 @@
+/**
+ * The serialized form of a resolved config's match/ignore patterns, and the
+ * in-process evaluation of it. Produced by {@link file://./ignored-child.ts},
+ * consumed by {@link file://./ignored.ts}.
+ *
+ * The patterns are evaluated with the same `@eslint/config-array` the
+ * consumer's ESLint uses, not a re-implementation: the matcher is the part
+ * that has to agree exactly, since a file wrongly classified as ignored is
+ * dropped from the dirty count and can skip a typed pass that had work to do.
+ */
+import { createRequire } from "node:module";
+import path from "node:path";
+
+/**
+ * One resolved config object, reduced to what decides matching and ignoring.
+ */
+export interface PredicateEntry {
+	/** The config's name, kept only so errors name the offending entry. */
+	name?: string;
+	/** The config's own base path, when it declared one. */
+	basePath?: string;
+	/** The config's `files`, which may nest arrays for AND matching. */
+	files?: Array<Array<string> | string>;
+	/** The config's `ignores`. */
+	ignores?: Array<string>;
+	/**
+	 * Set when the config carried keys beyond the match ones. A config with
+	 * `ignores` and nothing else is a *global* ignore; one with any further key
+	 * only excludes files from itself. Dropping `rules` and friends on the way
+	 * out would silently promote the second kind into the first, so this marks
+	 * the difference the dropped keys used to carry.
+	 */
+	nonGlobal?: boolean;
+}
+
+/** What the helper writes back, and what the ignore-set state stores. */
+export type IgnoredPayload =
+	/** The config's patterns, which classify any path at all. */
+	| { basePath: string; entries: Array<PredicateEntry>; mode: "predicate" }
+	/** The ignored subset of one target list, valid only for those targets. */
+	| { ignored: Array<string>; mode: "answers" };
+
+/** The subset of `ConfigArray` this module uses. */
+interface ConfigArrayLike {
+	getConfigStatus: (filePath: string) => string;
+	normalizeSync: () => void;
+}
+
+/**
+ * The subset of the `@eslint/config-array` module namespace this module uses.
+ */
+interface ConfigArrayModule {
+	ConfigArray: new (
+		configs: Array<PredicateEntry>,
+		options: { basePath: string; schema: Record<string, unknown> },
+	) => ConfigArrayLike;
+}
+
+/**
+ * The whole schema for {@link PredicateEntry.nonGlobal}: it carries no value
+ * worth merging or checking, so both halves collapse to a constant.
+ *
+ * @returns A value the schema is satisfied by.
+ */
+function acceptMarker(): true {
+	return true;
+}
+
+/**
+ * Teaches the array's schema about {@link PredicateEntry.nonGlobal}, which is
+ * ours rather than ESLint's: an unknown key throws when a matched config is
+ * merged, which is exactly what classifying a file does.
+ */
+const PREDICATE_SCHEMA = {
+	nonGlobal: { merge: acceptMarker, validate: acceptMarker },
+};
+
+/**
+ * One built array per payload, so repeated calls in a process rebuild nothing.
+ */
+const arrayCache = new WeakMap<object, ConfigArrayLike | undefined>();
+
+/**
+ * Classify lint targets against a stored payload.
+ *
+ * An `"answers"` payload only knows the targets it was computed from, so
+ * anything else is reported not-ignored — the safe direction, which over-counts
+ * dirty files rather than skipping work. A `"predicate"` payload knows the
+ * config itself and classifies any path, including files added since it was
+ * stored.
+ *
+ * @param cwd - The consumer project root, used to resolve the matcher.
+ * @param payload - The stored payload.
+ * @param targets - The absolute target paths to classify.
+ * @returns The ignored subset of `targets`, or `undefined` when the payload
+ *   could not be evaluated.
+ */
+export function classifyIgnored(
+	cwd: string,
+	payload: IgnoredPayload,
+	targets: Array<string>,
+): Array<string> | undefined {
+	if (payload.mode === "answers") {
+		return payload.ignored;
+	}
+
+	const configArray = buildConfigArray(cwd, payload);
+	if (configArray === undefined) {
+		return undefined;
+	}
+
+	try {
+		return targets.filter((target) => configArray.getConfigStatus(target) !== "matched");
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Load the matcher out of the consumer's own ESLint installation, so the
+ * patterns are evaluated by the same version that produced them. Falls back to
+ * the ESLint resolvable from this file — the hoisted peer dependency, which is
+ * what the fixture tests run against.
+ *
+ * @param cwd - The consumer project root.
+ * @returns The `@eslint/config-array` module namespace.
+ * @throws {Error} When neither ESLint nor its config-array can be resolved.
+ */
+function loadConfigArrayModule(cwd: string): ConfigArrayModule {
+	// A synthetic basename: `createRequire` resolves relative to a *file*, and
+	// this one is spelled so it can never collide with a real consumer module.
+	const requireFrom = createRequire(path.join(cwd, "__isentinel-lint__.js"));
+	let eslintPackageJson: string;
+	try {
+		eslintPackageJson = requireFrom.resolve("eslint/package.json");
+	} catch {
+		eslintPackageJson = createRequire(import.meta.url).resolve("eslint/package.json");
+	}
+
+	return createRequire(eslintPackageJson)("@eslint/config-array") as ConfigArrayModule;
+}
+
+/**
+ * Rebuild the ignore predicate from stored patterns, memoised per payload.
+ *
+ * @param cwd - The consumer project root, used to resolve the matcher.
+ * @param payload - The stored predicate payload.
+ * @returns The normalized config array, or `undefined` when it cannot be built.
+ */
+function buildConfigArray(
+	cwd: string,
+	payload: Extract<IgnoredPayload, { mode: "predicate" }>,
+): ConfigArrayLike | undefined {
+	const cached = arrayCache.get(payload);
+	if (cached !== undefined || arrayCache.has(payload)) {
+		return cached;
+	}
+
+	let configArray: ConfigArrayLike | undefined;
+	try {
+		const { ConfigArray } = loadConfigArrayModule(cwd);
+		configArray = new ConfigArray(payload.entries, {
+			basePath: payload.basePath,
+			schema: PREDICATE_SCHEMA,
+		});
+		configArray.normalizeSync();
+	} catch {
+		configArray = undefined;
+	}
+
+	arrayCache.set(payload, configArray);
+	return configArray;
+}

--- a/src/lint-cli/ignored.ts
+++ b/src/lint-cli/ignored.ts
@@ -6,15 +6,17 @@ import path from "node:path";
 import process from "node:process";
 
 import { normalizePath } from "./cache.ts";
+import { classifyIgnored } from "./ignored-predicate.ts";
+import type { IgnoredPayload } from "./ignored-predicate.ts";
 import { resolveIgnoredHelper } from "./resolve.ts";
 import { readState, statePath, writeState } from "./state.ts";
 
 /** The persisted form of a resolved ignore set. */
 interface IgnoredState {
-	/** The config hash the set was computed against. */
+	/** The config hash the payload was computed against. */
 	hash: string;
-	/** The ignored targets, as {@link normalizePath} keys. */
-	ignored: Array<string>;
+	/** What the helper returned: the config's patterns, or bare answers. */
+	payload: IgnoredPayload;
 }
 
 /** Reused for every miss, so callers never allocate on the no-op path. */
@@ -67,10 +69,17 @@ export function ignoredStatePath(cwd: string, key: string): string {
  * every file re-lints anyway — and the ignore set still sizes that re-lint's
  * workers, which is why it is computed then rather than deferred.
  *
- * Targets absent from a stored set are treated as not-ignored. That is the safe
- * direction — it can only over-count dirty files, never skip a pass that had
- * work to do — but it does mean a newly added ignored file keeps the typed pass
- * awake until the next config change.
+ * What is memoised is the config's *patterns*, not its answers about one
+ * target list. Storing answers made the memo a partial function over a file
+ * list that kept moving: every file added after the last config change was
+ * absent from the set, counted not-ignored, and floored the typed pass's dirty
+ * count above zero forever. Patterns depend on the config alone, which is what
+ * the key already says, so new files classify with no helper spawn at all.
+ *
+ * A config whose `files`/`ignores` hold function matchers cannot be
+ * serialized; the helper falls back to answering per target, and that payload
+ * keeps the old residual — targets absent from it read as not-ignored, which
+ * over-counts dirty files rather than skipping work.
  *
  * @param context - The cwd, variant key, config hash, targets and mutate flag.
  * @returns The ignored subset of `targets`, or an empty set when unavailable.
@@ -89,37 +98,50 @@ export function resolveIgnoredFiles({
 	const stateFile = ignoredStatePath(cwd, key);
 	const stored = readState<IgnoredState>(stateFile);
 	if (stored?.hash === configHash) {
-		return new Set(stored.ignored);
+		return toSet(classifyIgnored(cwd, stored.payload, targets));
 	}
 
 	if (!mutate) {
 		return EMPTY;
 	}
 
-	const ignored = queryIgnoredFiles(cwd, targets)?.map((file) => normalizePath(file));
-	if (ignored === undefined) {
+	const payload = queryIgnoredFiles(cwd, targets);
+	if (payload === undefined) {
 		return EMPTY;
 	}
 
-	writeState(stateFile, { hash: configHash, ignored } satisfies IgnoredState);
-	return new Set(ignored);
+	writeState(stateFile, { hash: configHash, payload } satisfies IgnoredState);
+	return toSet(classifyIgnored(cwd, payload, targets));
 }
 
 /**
- * Spawn the helper and read back the ignored subset. Every failure mode (no
+ * Reduce a classification to the normalized keys the file lists are filtered
+ * by.
+ *
+ * @param ignored - The ignored targets, or `undefined` when unavailable.
+ * @returns The ignored set, empty when there is nothing to filter by.
+ */
+function toSet(ignored: Array<string> | undefined): ReadonlySet<string> {
+	return ignored === undefined || ignored.length === 0
+		? EMPTY
+		: new Set(ignored.map((file) => normalizePath(file)));
+}
+
+/**
+ * Spawn the helper and read back its payload. Every failure mode (no
  * resolvable ESLint, a config that throws, a malformed result) degrades to
- * `undefined`, which the caller treats as "no filtering" — the behaviour before
- * this existed.
+ * `undefined`, which the caller treats as "no filtering" — the behaviour
+ * before this existed.
  *
  * The result comes back through a scratch file rather than stdout: loading a
  * consumer's config evaluates their plugins, and anything one of those prints
  * would land in the middle of the JSON.
  *
  * @param cwd - The consumer project root.
- * @param targets - The target files to classify.
- * @returns The ignored targets, or `undefined` when the query failed.
+ * @param targets - The target files the fallback path classifies.
+ * @returns The helper's payload, or `undefined` when the query failed.
  */
-function queryIgnoredFiles(cwd: string, targets: Array<string>): Array<string> | undefined {
+function queryIgnoredFiles(cwd: string, targets: Array<string>): IgnoredPayload | undefined {
 	// One query per process at a time, so the pid is collision-free even when
 	// the consumer lints several packages in parallel.
 	const outFile = path.join(os.tmpdir(), `isentinel-lint-ignored-${process.pid}.json`);
@@ -131,8 +153,10 @@ function queryIgnoredFiles(cwd: string, targets: Array<string>): Array<string> |
 			maxBuffer: 64 * 1024 * 1024,
 			stdio: ["pipe", "ignore", "ignore"],
 		});
-		const parsed = JSON.parse(fs.readFileSync(outFile, "utf8")) as unknown;
-		return Array.isArray(parsed) ? (parsed as Array<string>) : undefined;
+		const parsed = JSON.parse(fs.readFileSync(outFile, "utf8")) as { mode?: unknown };
+		return parsed.mode === "answers" || parsed.mode === "predicate"
+			? (parsed as IgnoredPayload)
+			: undefined;
 	} catch {
 		return undefined;
 	} finally {

--- a/src/lint-cli/ignored.ts
+++ b/src/lint-cli/ignored.ts
@@ -11,8 +11,23 @@ import type { IgnoredPayload } from "./ignored-predicate.ts";
 import { resolveIgnoredHelper } from "./resolve.ts";
 import { readState, statePath, writeState } from "./state.ts";
 
+/** A target list split by whether ESLint would lint it. */
+interface Classification {
+	/** The targets ESLint declines to lint. */
+	ignored: Array<string>;
+	/** The rest. */
+	linted: Array<string>;
+}
+
 /** The persisted form of a resolved ignore set. */
 interface IgnoredState {
+	/**
+	 * Every target the payload has already been asked about, as {@link
+	 * normalizePath} keys. Purely derived — the payload can recompute it — but
+	 * matching a path against a real flat config costs ~300µs, so a project of
+	 * any size would pay whole seconds of it on every run.
+	 */
+	classified: Classification;
 	/** The config hash the payload was computed against. */
 	hash: string;
 	/** What the helper returned: the config's patterns, or bare answers. */
@@ -76,6 +91,13 @@ export function ignoredStatePath(cwd: string, key: string): string {
  * count above zero forever. Patterns depend on the config alone, which is what
  * the key already says, so new files classify with no helper spawn at all.
  *
+ * The answers are still stored, but now as a cache *derived* from the patterns
+ * rather than as the source of truth: a target the cache does not cover is
+ * matched against the patterns rather than assumed not-ignored, which is the
+ * whole difference. It exists because that match costs ~300µs per path, so a
+ * few thousand targets would otherwise add a second to every run — the cost the
+ * memo exists to avoid, charged a little at a time.
+ *
  * A config whose `files`/`ignores` hold function matchers cannot be
  * serialized; the helper falls back to answering per target, and that payload
  * keeps the old residual — targets absent from it read as not-ignored, which
@@ -97,34 +119,106 @@ export function resolveIgnoredFiles({
 
 	const stateFile = ignoredStatePath(cwd, key);
 	const stored = readState<IgnoredState>(stateFile);
-	if (stored?.hash === configHash) {
-		return toSet(classifyIgnored(cwd, stored.payload, targets));
-	}
+	const fresh = stored?.hash === configHash ? stored : undefined;
 
-	if (!mutate) {
-		return EMPTY;
-	}
-
-	const payload = queryIgnoredFiles(cwd, targets);
+	let payload = fresh?.payload;
 	if (payload === undefined) {
+		if (!mutate) {
+			return EMPTY;
+		}
+
+		payload = queryIgnoredFiles(cwd, targets);
+		if (payload === undefined) {
+			return EMPTY;
+		}
+	}
+
+	const classified = classifyTargets(cwd, payload, targets, fresh?.classified);
+	if (classified === undefined) {
 		return EMPTY;
 	}
 
-	writeState(stateFile, { hash: configHash, payload } satisfies IgnoredState);
-	return toSet(classifyIgnored(cwd, payload, targets));
+	if (mutate && !sameClassification(classified, fresh?.classified)) {
+		writeState(stateFile, { classified, hash: configHash, payload } satisfies IgnoredState);
+	}
+
+	return new Set(classified.ignored);
 }
 
 /**
- * Reduce a classification to the normalized keys the file lists are filtered
- * by.
+ * Split the targets by whether ESLint would lint them, asking the payload only
+ * about the ones the stored classification does not already cover — which after
+ * the first run means only the files added since it.
  *
- * @param ignored - The ignored targets, or `undefined` when unavailable.
- * @returns The ignored set, empty when there is nothing to filter by.
+ * The result covers exactly the current targets, so storing it also drops the
+ * entries for files that have gone away.
+ *
+ * @param cwd - The consumer project root.
+ * @param payload - The patterns (or answers) to classify against.
+ * @param targets - The absolute target paths this run cares about.
+ * @param cached - The stored classification, when one applies to this payload.
+ * @returns The split, or `undefined` when the payload could not be evaluated.
  */
-function toSet(ignored: Array<string> | undefined): ReadonlySet<string> {
-	return ignored === undefined || ignored.length === 0
-		? EMPTY
-		: new Set(ignored.map((file) => normalizePath(file)));
+function classifyTargets(
+	cwd: string,
+	payload: IgnoredPayload,
+	targets: Array<string>,
+	cached: Classification | undefined,
+): Classification | undefined {
+	const known = new Map<string, boolean>();
+	const cachedIgnored = cached?.ignored ?? [];
+	const cachedLinted = cached?.linted ?? [];
+	for (const file of cachedIgnored) {
+		known.set(file, true);
+	}
+
+	for (const file of cachedLinted) {
+		known.set(file, false);
+	}
+
+	const byKey = new Map(targets.map((target) => [normalizePath(target), target]));
+	const unknown = [...byKey].filter(([key]) => !known.has(key));
+	if (unknown.length > 0) {
+		const ignored = classifyIgnored(
+			cwd,
+			payload,
+			unknown.map(([, target]) => target),
+		);
+		if (ignored === undefined) {
+			return undefined;
+		}
+
+		const ignoredKeys = new Set(ignored.map((file) => normalizePath(file)));
+		for (const [key] of unknown) {
+			known.set(key, ignoredKeys.has(key));
+		}
+	}
+
+	const classified: Classification = { ignored: [], linted: [] };
+	for (const key of byKey.keys()) {
+		(known.get(key) === true ? classified.ignored : classified.linted).push(key);
+	}
+
+	return classified;
+}
+
+/**
+ * Whether a classification is the one already on disk, so an unchanged run can
+ * skip rewriting it.
+ *
+ * @param classified - The classification this run computed.
+ * @param cached - The stored classification, when one applies.
+ * @returns True when the two cover the same targets.
+ */
+function sameClassification(
+	classified: Classification,
+	cached: Classification | undefined,
+): boolean {
+	return (
+		cached !== undefined &&
+		cached.ignored.length === classified.ignored.length &&
+		cached.linted.length === classified.linted.length
+	);
 }
 
 /**
@@ -153,6 +247,9 @@ function queryIgnoredFiles(cwd: string, targets: Array<string>): IgnoredPayload 
 			maxBuffer: 64 * 1024 * 1024,
 			stdio: ["pipe", "ignore", "ignore"],
 		});
+		// Trusted as far as its tag: the writer is our own child, and anything it
+		// got wrong past that throws where the payload is used, which is caught
+		// the same way as a failed spawn.
 		const parsed = JSON.parse(fs.readFileSync(outFile, "utf8")) as { mode?: unknown };
 		return parsed.mode === "answers" || parsed.mode === "predicate"
 			? (parsed as IgnoredPayload)

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -19,7 +19,7 @@ import {
 import { computeWorkerCount, resolveWorkerLimits } from "./concurrency.ts";
 import { applyConfigDriftBust, computeConfigHash } from "./config-hash.ts";
 import { cacheFileFor } from "./constants.ts";
-import { collectRepoFiles, withoutIgnored } from "./files.ts";
+import { collectRepoFiles, oxlintTargets, withoutIgnored } from "./files.ts";
 import type { RepoFiles } from "./files.ts";
 import { resolveOxlintRun } from "./hybrid.ts";
 import { resolveIgnoredFiles } from "./ignored.ts";
@@ -91,6 +91,8 @@ export interface RunPlan {
 	ci: boolean;
 	/** Whether the oxlint child runs. */
 	oxlint: boolean;
+	/** The paths the oxlint child receives (see `oxlintTargets`). */
+	oxlintPaths: Array<string>;
 	/**
 	 * A stderr warning about the oxlint decision (non-hybrid config drop or an
 	 * undeterminable hybrid status), or `undefined`.
@@ -160,16 +162,23 @@ export function plan(
 ): RunPlan {
 	const ci = isCi(environment);
 	const key = resolveCacheKey(environment);
-	const runOxlint = !options.eslint;
 	const runEslint = !options.oxlint;
 	const oxlintTypeAware = resolveOxlintTypeAware(options);
 	const agentsFormatterPath = options.agents ? resolveAgentsFormatter() : "";
+
+	// Targets oxlint cannot lint (a `package.json`-only commit, say) are dropped,
+	// and oxlint is skipped outright when nothing survives — handed only such
+	// paths it exits non-zero on "No files found to lint", failing a hook over a
+	// file it was never going to lint. The default target `.` always survives.
+	const oxlintPaths = oxlintTargets(cwd, options.paths);
+	const runOxlint = !options.eslint && oxlintPaths.length > 0;
 
 	if (!runEslint) {
 		return {
 			agentsFormatterPath,
 			ci,
 			oxlint: runOxlint,
+			oxlintPaths,
 			oxlintReason: undefined,
 			oxlintTypeAware,
 			passes: [],
@@ -253,6 +262,7 @@ export function plan(
 		agentsFormatterPath,
 		ci,
 		oxlint: oxlintDecision.run,
+		oxlintPaths,
 		oxlintReason: oxlintDecision.reason,
 		oxlintTypeAware,
 		passes,
@@ -284,7 +294,7 @@ export function compose(runPlan: RunPlan, options: LintCliOptions): CommandPlan 
 		commands.push(
 			composeOxlintCommand(options, {
 				oxlintTypeAware: runPlan.oxlintTypeAware,
-				paths: options.paths,
+				paths: runPlan.oxlintPaths,
 			}),
 		);
 	}

--- a/src/lint-cli/state.ts
+++ b/src/lint-cli/state.ts
@@ -18,7 +18,7 @@ const CACHE_DIRECTORY = path.join("node_modules", ".cache", "isentinel-lint");
  * changes meaning. The builder's `.tsbuildinfo` files live in the same
  * directory but are written by TypeScript, which versions them itself.
  */
-export const STATE_VERSION = 1;
+export const STATE_VERSION = 2;
 
 /** How a stored value compared to the one {@link swapState} was given. */
 export type StateSwap =

--- a/test/lint-cli-ignored.spec.ts
+++ b/test/lint-cli-ignored.spec.ts
@@ -1,0 +1,120 @@
+// cspell:words unconfigured
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { normalizePath } from "../src/lint-cli/cache.ts";
+import type { IgnoredPayload } from "../src/lint-cli/ignored-predicate.ts";
+import { ignoredStatePath, resolveIgnoredFiles } from "../src/lint-cli/ignored.ts";
+import { readState } from "../src/lint-cli/state.ts";
+
+/** The config-variant key these fixtures store their ignore set under. */
+const KEY = "ignored-test";
+
+/** The config hash these fixtures memoise against; its value never matters. */
+const HASH = "config-hash";
+
+/**
+ * A config whose ignore patterns are plain globs, so the helper can hand the
+ * runner the patterns themselves. `.mjs` so ESLint loads it without a
+ * TypeScript loader in the fixture's bare `node_modules`.
+ */
+const GLOB_CONFIG =
+	'export default [{ files: ["**/*.{ts,mjs}"], rules: {} }, { ignores: ["generated/**"] }];\n';
+
+/**
+ * The same config with a *function* matcher, which cannot cross a process
+ * boundary — the case that has to degrade to per-target answers.
+ */
+const FUNCTION_CONFIG =
+	'export default [{ files: ["**/*.{ts,mjs}"], rules: {} }, ' +
+	"{ ignores: [filePath => filePath.endsWith('.generated.ts')] }];\n";
+
+function withFixture(config: string, run: (directory: string) => void): void {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-ignored-"));
+
+	try {
+		fs.writeFileSync(path.join(directory, "eslint.config.mjs"), config);
+		fs.mkdirSync(path.join(directory, "src"));
+		fs.writeFileSync(path.join(directory, "src/a.ts"), "export const a = 1;\n");
+		run(fs.realpathSync(directory));
+	} finally {
+		fs.rmSync(directory, { force: true, recursive: true });
+	}
+}
+
+function resolve(directory: string, targets: Array<string>, mutate: boolean): ReadonlySet<string> {
+	return resolveIgnoredFiles({
+		key: KEY,
+		configHash: HASH,
+		cwd: directory,
+		mutate,
+		targets: targets.map((target) => path.join(directory, target)),
+	});
+}
+
+function has(ignored: ReadonlySet<string>, directory: string, relative: string): boolean {
+	return ignored.has(normalizePath(path.join(directory, relative)));
+}
+
+function storedMode(directory: string): string | undefined {
+	return readState<{ payload: IgnoredPayload }>(ignoredStatePath(directory, KEY))?.payload.mode;
+}
+
+describe("resolveIgnoredFiles", () => {
+	it("classifies files added after the set was stored, without re-spawning", () => {
+		expect.hasAssertions();
+
+		withFixture(GLOB_CONFIG, (directory) => {
+			const first = resolve(directory, ["src/a.ts"], true);
+
+			expect(has(first, directory, "src/a.ts")).toBe(false);
+			expect(storedMode(directory)).toBe("predicate");
+
+			// Read-only mode never spawns the helper, so anything classified here
+			// came from the stored patterns — including a path that did not exist
+			// when they were stored.
+			const second = resolve(directory, ["src/a.ts", "generated/b.ts"], false);
+
+			expect(has(second, directory, "generated/b.ts")).toBe(true);
+			expect(has(second, directory, "src/a.ts")).toBe(false);
+		});
+	});
+
+	it("treats a file no config matches as ignored", () => {
+		expect.hasAssertions();
+
+		withFixture(GLOB_CONFIG, (directory) => {
+			// `getConfigStatus` calls this "unconfigured" rather than "ignored",
+			// but ESLint declines to lint it either way, so it must not count as
+			// dirty.
+			const ignored = resolve(directory, ["src/a.ts", "notes.txt"], true);
+
+			expect(has(ignored, directory, "notes.txt")).toBe(true);
+		});
+	});
+
+	it("falls back to per-target answers when a matcher is a function", () => {
+		expect.hasAssertions();
+
+		withFixture(FUNCTION_CONFIG, (directory) => {
+			const ignored = resolve(directory, ["src/a.ts", "src/b.generated.ts"], true);
+
+			expect(storedMode(directory)).toBe("answers");
+			expect(has(ignored, directory, "src/b.generated.ts")).toBe(true);
+			expect(has(ignored, directory, "src/a.ts")).toBe(false);
+		});
+	});
+
+	it("reports nothing when the stored hash does not match and the run may not mutate", () => {
+		expect.hasAssertions();
+
+		withFixture(GLOB_CONFIG, (directory) => {
+			const ignored = resolve(directory, ["generated/b.ts"], false);
+
+			expect(ignored.size).toBe(0);
+			expect(storedMode(directory)).toBeUndefined();
+		});
+	});
+});

--- a/test/lint-cli-ignored.spec.ts
+++ b/test/lint-cli-ignored.spec.ts
@@ -19,9 +19,15 @@ const HASH = "config-hash";
  * A config whose ignore patterns are plain globs, so the helper can hand the
  * runner the patterns themselves. `.mjs` so ESLint loads it without a
  * TypeScript loader in the fixture's bare `node_modules`.
+ *
+ * The third entry is the one that has to survive serialization intact:
+ * `ignores` beside another key only excludes files from *that* config, so
+ * `src/b.ts` is still linted. Carrying it over as a bare `{ignores}` would
+ * silently promote it into a global ignore.
  */
 const GLOB_CONFIG =
-	'export default [{ files: ["**/*.{ts,mjs}"], rules: {} }, { ignores: ["generated/**"] }];\n';
+	'export default [{ files: ["**/*.{ts,mjs}"], rules: {} }, { ignores: ["generated/**"] }, ' +
+	'{ ignores: ["src/b.ts"], rules: {} }];\n';
 
 /**
  * The same config with a *function* matcher, which cannot cross a process
@@ -54,6 +60,29 @@ function resolve(directory: string, targets: Array<string>, mutate: boolean): Re
 	});
 }
 
+/**
+ * Resolve the way a real run does: the helper may spawn, state may be written.
+ *
+ * @param directory - The fixture project root.
+ * @param targets - Fixture-relative target paths.
+ * @returns The ignored set.
+ */
+function resolveAndStore(directory: string, targets: Array<string>): ReadonlySet<string> {
+	return resolve(directory, targets, true);
+}
+
+/**
+ * Resolve the way `--print` does. This never spawns the helper and never
+ * writes, so anything it classifies came from what is already stored.
+ *
+ * @param directory - The fixture project root.
+ * @param targets - Fixture-relative target paths.
+ * @returns The ignored set.
+ */
+function resolveReadOnly(directory: string, targets: Array<string>): ReadonlySet<string> {
+	return resolve(directory, targets, false);
+}
+
 function has(ignored: ReadonlySet<string>, directory: string, relative: string): boolean {
 	return ignored.has(normalizePath(path.join(directory, relative)));
 }
@@ -67,18 +96,27 @@ describe("resolveIgnoredFiles", () => {
 		expect.hasAssertions();
 
 		withFixture(GLOB_CONFIG, (directory) => {
-			const first = resolve(directory, ["src/a.ts"], true);
-
-			expect(has(first, directory, "src/a.ts")).toBe(false);
+			expect(has(resolveAndStore(directory, ["src/a.ts"]), directory, "src/a.ts")).toBe(
+				false,
+			);
 			expect(storedMode(directory)).toBe("predicate");
 
-			// Read-only mode never spawns the helper, so anything classified here
-			// came from the stored patterns — including a path that did not exist
-			// when they were stored.
-			const second = resolve(directory, ["src/a.ts", "generated/b.ts"], false);
+			const second = resolveReadOnly(directory, ["src/a.ts", "generated/b.ts"]);
 
 			expect(has(second, directory, "generated/b.ts")).toBe(true);
 			expect(has(second, directory, "src/a.ts")).toBe(false);
+		});
+	});
+
+	it("keeps a config's own ignores from becoming a global ignore", () => {
+		expect.hasAssertions();
+
+		withFixture(GLOB_CONFIG, (directory) => {
+			// `src/b.ts` is ignored *by one config*, which only excludes it from
+			// that config's rules. ESLint still lints it.
+			const ignored = resolveAndStore(directory, ["src/a.ts", "src/b.ts"]);
+
+			expect(has(ignored, directory, "src/b.ts")).toBe(false);
 		});
 	});
 
@@ -89,7 +127,7 @@ describe("resolveIgnoredFiles", () => {
 			// `getConfigStatus` calls this "unconfigured" rather than "ignored",
 			// but ESLint declines to lint it either way, so it must not count as
 			// dirty.
-			const ignored = resolve(directory, ["src/a.ts", "notes.txt"], true);
+			const ignored = resolveAndStore(directory, ["src/a.ts", "notes.txt"]);
 
 			expect(has(ignored, directory, "notes.txt")).toBe(true);
 		});
@@ -99,11 +137,17 @@ describe("resolveIgnoredFiles", () => {
 		expect.hasAssertions();
 
 		withFixture(FUNCTION_CONFIG, (directory) => {
-			const ignored = resolve(directory, ["src/a.ts", "src/b.generated.ts"], true);
+			const ignored = resolveAndStore(directory, ["src/a.ts", "src/b.generated.ts"]);
 
 			expect(storedMode(directory)).toBe("answers");
 			expect(has(ignored, directory, "src/b.generated.ts")).toBe(true);
 			expect(has(ignored, directory, "src/a.ts")).toBe(false);
+
+			// The residual the answers payload keeps: a file it was never asked
+			// about reads as not-ignored rather than being matched.
+			const later = resolveReadOnly(directory, ["src/c.generated.ts"]);
+
+			expect(has(later, directory, "src/c.generated.ts")).toBe(false);
 		});
 	});
 
@@ -111,7 +155,7 @@ describe("resolveIgnoredFiles", () => {
 		expect.hasAssertions();
 
 		withFixture(GLOB_CONFIG, (directory) => {
-			const ignored = resolve(directory, ["generated/b.ts"], false);
+			const ignored = resolveReadOnly(directory, ["generated/b.ts"]);
 
 			expect(ignored.size).toBe(0);
 			expect(storedMode(directory)).toBeUndefined();

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -788,6 +788,29 @@ describe("composeCommands --print", () => {
 		});
 	});
 
+	it("drops oxlint when no target is a file it can lint", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(printLines(["package.json"], directory)).toStrictEqual([
+				`ESLINT_TYPE_AWARE=off eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_FAST)} ` +
+					"--no-warn-ignored --concurrency off package.json",
+				`ESLINT_TYPE_AWARE=only eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_TYPE_AWARE)} ` +
+					"--no-warn-ignored --concurrency off package.json",
+			]);
+		});
+	});
+
+	it("passes oxlint only the targets it can lint", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(printLines(["package.json", "src/index.ts", "docs"], directory)[0]).toBe(
+				"oxlint --type-aware src/index.ts docs",
+			);
+		});
+	});
+
 	it("composes the sequential full-config fix pass", () => {
 		expect.hasAssertions();
 


### PR DESCRIPTION
Closes #610.

`resolveIgnoredFiles` stored the ignored *subset of one target list* against the
config hash, which made the memo a partial function over a file list that kept
moving. Every file added after the last config change was absent from the stored
set, counted not-ignored, and floored the typed pass's dirty count above zero
until the config changed again — #598's failure mode reached by another route,
with "touch the config" as the only escape.

The helper now hands back the resolved config's `files`/`ignores` patterns, and
the runner evaluates them itself. The memo then legitimately depends on the
config hash alone, and files added later classify with no spawn at all.

## Not picomatch

The issue suggested evaluating the patterns with `picomatch`. This uses the same
`@eslint/config-array` the consumer's own ESLint uses instead, resolved out of
their installation. A file wrongly classified as ignored is dropped from the
dirty count and can skip a typed pass that had work to do, so the matcher is the
one part that has to agree with ESLint exactly rather than approximately.

Measured on this repo: ~4s to load the config, 0.4ms to rebuild the predicate
from its 14KB of stored patterns, 0 mismatches against
`new ESLint({cwd}).isPathIgnored()` over 76 real paths (38 of them ignored).

Two things that fall out of using the real matcher:

- The equivalence is `getConfigStatus(p) !== "matched"`, **not** `isFileIgnored`.
  A file no config's `files` matches is `"unconfigured"` rather than `"ignored"`,
  and `isFileIgnored` says false where ESLint declines to lint it — `hk.pkl` and
  friends. Using `isFileIgnored` mismatched 2/76.
- Serializing drops `rules` and everything else, but global-ignore detection is
  "has `ignores` and no other non-meta key" — so `{ignores, rules}` would
  silently become a global ignore on the way back in. `nonGlobal` marks the
  difference the dropped keys used to carry, with a one-key schema so the array
  accepts it.

## Internals, and the way back out

No public API returns a consumer's resolved config array: the exports map hides
`lib/config/config-loader.js`, `use-at-your-own-risk` has only `builtinRules` and
`shouldUseFlatConfig`, and `calculateConfigForFile` strips exactly the
`files`/`ignores` keys this needs. The child reaches the loader by absolute path.

That is contained: the child already degrades every failure to "no filtering",
and both a missing loader and a function matcher (which cannot be serialized at
all) fall back to the previous per-target query. An ESLint reshuffle costs the
old residual, not a break. Both fallbacks are tested.

`STATE_VERSION` is bumped, so stored ignore sets from before this invalidate
rather than being misread.

## Test plan

- `pnpm test` (325 passed), `pnpm typecheck`, `pnpm lint`
- New `test/lint-cli-ignored.spec.ts`: a path that did not exist when the memo
  was written classifies as ignored in read-only mode (which cannot spawn); a
  file no config matches counts as ignored; a function matcher degrades to
  answers mode
- Real `isentinel-lint` run against this repo exercising the *built*
  `dist/lint-ignored.mjs`: writes a v2 predicate payload with 110 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved ESLint ignored-file detection for newly added and changing files.
  * Added support for reusable ignore-pattern evaluation, with automatic fallback for function-based configurations.
* **Bug Fixes**
  * Corrected classification of files that do not match the ESLint configuration.
  * Ensured outdated cached results are recomputed instead of reused.
* **Chores**
  * Updated persisted state handling to support the latest ignore-resolution format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->