### PR TITLE
fix(lint-cli): skip oxlint when no target is a file it can lint

### DIFF
--- a/src/lint-cli/files.ts
+++ b/src/lint-cli/files.ts
@@ -134,6 +134,33 @@ export function withoutIgnored(files: RepoFiles, ignored: ReadonlySet<string>): 
 }
 
 /**
+ * Restrict explicit lint targets to the ones oxlint could lint. Oxlint only
+ * handles the TS/JS family, and exits non-zero with "No files found to lint"
+ * when every path it was handed resolves to nothing — so a hook run over a
+ * `package.json`-only change would fail on a file oxlint was never going to
+ * lint. A path is kept when its extension is type-aware, when it has no
+ * extension, or when it is an existing directory (either may hold TS/JS files).
+ *
+ * @param cwd - The working directory to resolve targets against.
+ * @param targets - The explicit lint target paths.
+ * @returns The subset oxlint should receive.
+ */
+export function oxlintTargets(cwd: string, targets: Array<string>): Array<string> {
+	return targets.filter((target) => {
+		const extension = path.extname(target).toLowerCase();
+		if (extension === "" || TYPE_AWARE_EXTENSION_SET.has(extension)) {
+			return true;
+		}
+
+		try {
+			return fs.statSync(path.resolve(cwd, target)).isDirectory();
+		} catch {
+			return false;
+		}
+	});
+}
+
+/**
  * Collect the absolute paths of lintable files under `targets`, honouring
  * `.gitignore` (via `git ls-files`) when inside a git repository. Thin wrapper
  * over {@link collectRepoFiles}.

--- a/src/lint-cli/run.ts
+++ b/src/lint-cli/run.ts
@@ -19,7 +19,7 @@ import {
 import { computeWorkerCount, resolveWorkerLimits } from "./concurrency.ts";
 import { applyConfigDriftBust, computeConfigHash } from "./config-hash.ts";
 import { cacheFileFor } from "./constants.ts";
-import { collectRepoFiles, withoutIgnored } from "./files.ts";
+import { collectRepoFiles, oxlintTargets, withoutIgnored } from "./files.ts";
 import type { RepoFiles } from "./files.ts";
 import { resolveOxlintRun } from "./hybrid.ts";
 import { resolveIgnoredFiles } from "./ignored.ts";
@@ -91,6 +91,8 @@ export interface RunPlan {
 	ci: boolean;
 	/** Whether the oxlint child runs. */
 	oxlint: boolean;
+	/** The paths the oxlint child receives (see `oxlintTargets`). */
+	oxlintPaths: Array<string>;
 	/**
 	 * A stderr warning about the oxlint decision (non-hybrid config drop or an
 	 * undeterminable hybrid status), or `undefined`.
@@ -160,16 +162,23 @@ export function plan(
 ): RunPlan {
 	const ci = isCi(environment);
 	const key = resolveCacheKey(environment);
-	const runOxlint = !options.eslint;
 	const runEslint = !options.oxlint;
 	const oxlintTypeAware = resolveOxlintTypeAware(options);
 	const agentsFormatterPath = options.agents ? resolveAgentsFormatter() : "";
+
+	// Targets oxlint cannot lint (a `package.json`-only commit, say) are dropped,
+	// and oxlint is skipped outright when nothing survives — handed only such
+	// paths it exits non-zero on "No files found to lint", failing a hook over a
+	// file it was never going to lint. The default target `.` always survives.
+	const oxlintPaths = oxlintTargets(cwd, options.paths);
+	const runOxlint = !options.eslint && oxlintPaths.length > 0;
 
 	if (!runEslint) {
 		return {
 			agentsFormatterPath,
 			ci,
 			oxlint: runOxlint,
+			oxlintPaths,
 			oxlintReason: undefined,
 			oxlintTypeAware,
 			passes: [],
@@ -253,6 +262,7 @@ export function plan(
 		agentsFormatterPath,
 		ci,
 		oxlint: oxlintDecision.run,
+		oxlintPaths,
 		oxlintReason: oxlintDecision.reason,
 		oxlintTypeAware,
 		passes,
@@ -284,7 +294,7 @@ export function compose(runPlan: RunPlan, options: LintCliOptions): CommandPlan 
 		commands.push(
 			composeOxlintCommand(options, {
 				oxlintTypeAware: runPlan.oxlintTypeAware,
-				paths: options.paths,
+				paths: runPlan.oxlintPaths,
 			}),
 		);
 	}

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -788,6 +788,29 @@ describe("composeCommands --print", () => {
 		});
 	});
 
+	it("drops oxlint when no target is a file it can lint", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(printLines(["package.json"], directory)).toStrictEqual([
+				`ESLINT_TYPE_AWARE=off eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_FAST)} ` +
+					"--no-warn-ignored --concurrency off package.json",
+				`ESLINT_TYPE_AWARE=only eslint --cache --cache-location ${keyedCacheFile(CACHE_FILE_TYPE_AWARE)} ` +
+					"--no-warn-ignored --concurrency off package.json",
+			]);
+		});
+	});
+
+	it("passes oxlint only the targets it can lint", () => {
+		expect.hasAssertions();
+
+		withTemporaryDirectory((directory) => {
+			expect(printLines(["package.json", "src/index.ts", "docs"], directory)[0]).toBe(
+				"oxlint --type-aware src/index.ts docs",
+			);
+		});
+	});
+
 	it("composes the sequential full-config fix pass", () => {
 		expect.hasAssertions();
 


### PR DESCRIPTION
## Problem

`isentinel-lint package.json` exits 1:

```
[oxc] No files found to lint. Please check your paths and ignore patterns.
```

oxlint only lints the TS/JS family, and exits non-zero when every path it was handed resolves to nothing. The CLI passes its target list verbatim to both engines, so a commit touching only `package.json` (or only Markdown, or only YAML) fails the hk `lint` step on a file oxlint was never going to lint. ESLint already tolerated this via `--no-warn-ignored`.

## Fix

`oxlintTargets(cwd, targets)` in `files.ts` filters explicit targets to those oxlint could lint — extension in `TYPE_AWARE_EXTENSIONS`, no extension, or an existing directory. `plan` drops the oxlint child outright when nothing survives (the default target `.` always survives), and `compose` hands oxlint the filtered list. The hybrid `eslint --print-config` probe short-circuits too, so a data-file-only run spawns one less child.

`--no-ignore` was considered and rejected: it disables ignore-file filtering, which neither makes oxlint lint a `.json` file nor changes the exit-on-empty behaviour, and would drag gitignored output into the normal `oxlint .` path.

## Tests

Two cases in `test/lint-cli.spec.ts`: `package.json` alone composes ESLint-only; a mixed list gives oxlint only `src/index.ts docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)