### PR TITLE
feat: add `eslint` subpath export

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ import isentinel from "@isentinel/eslint-config";
 export default isentinel();
 ```
 
+`@isentinel/eslint-config/eslint` is an explicit alias of the root export, for
+symmetry with `@isentinel/eslint-config/oxlint`:
+
+```ts
+// eslint.config.ts
+import { isentinel } from "@isentinel/eslint-config/eslint";
+
+export default isentinel();
+```
+
 #### Optional: TypeScript Config Support
 
 If you want to use `eslint.config.ts` instead of `.js`, install `jiti` v2.0.0 or

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
 	"exports": {
 		".": "./dist/index.mjs",
 		"./cli": "./dist/cli.mjs",
+		"./eslint": {
+			"types": "./dist/index.d.mts",
+			"default": "./dist/index.mjs"
+		},
 		"./formatter-agents": "./dist/formatter-agents.mjs",
 		"./oxlint": {
 			"types": "./dist/oxlint.d.mts",


### PR DESCRIPTION
Closes #624

Adds `@isentinel/eslint-config/eslint`, for symmetry with the existing `/oxlint` export.

It's an alias of the root export rather than its own tsdown entry: `src/index.ts` is already just a re-export of `src/eslint/index.ts`, so a separate entry would duplicate the whole ~533 kB config bundle in `dist/` for byte-identical output.

- `package.json` — new `"./eslint"` entry in `exports`
- `README.md` — short note documenting the alias

`pnpm build` passes, publint reports no issues, `check-dist` still clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing the ESLint configuration through the `@isentinel/eslint-config/eslint` path.

* **Documentation**
  * Updated setup guidance with an example using the new import path.
  * Clarified that the `/eslint` path is an alias of the root export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->