### PR TITLE
fix(oxlint): anchor root override globs and keep no-useless-coercion in ESLint

### DIFF
--- a/src/oxlint/factory.ts
+++ b/src/oxlint/factory.ts
@@ -47,7 +47,12 @@ import { oxlintTypescript } from "./configs/typescript.ts";
 import { oxlintUnicorn } from "./configs/unicorn.ts";
 import type { ValidateOxlintOptions } from "./redundancy.ts";
 import type { OxlintFactoryOptions, OxlintSettings, TypedOxlintConfigItem } from "./types.ts";
-import { createOxlintConfigs, jsPluginKey, stripUnregisteredPluginRules } from "./utils.ts";
+import {
+	anchorOxlintGlob,
+	createOxlintConfigs,
+	jsPluginKey,
+	stripUnregisteredPluginRules,
+} from "./utils.ts";
 
 /**
  * The preset enables its rules explicitly, so every category is disabled to
@@ -412,6 +417,11 @@ export function isentinel(
 		}
 
 		const { name: _name, plugins: _plugins, settings: _settings, ...override } = config;
+		override.files = override.files.map(anchorOxlintGlob);
+		if (override.excludeFiles !== undefined) {
+			override.excludeFiles = override.excludeFiles.map(anchorOxlintGlob);
+		}
+
 		overrides.push(override);
 	}
 

--- a/src/oxlint/utils.ts
+++ b/src/oxlint/utils.ts
@@ -99,11 +99,6 @@ export function jsPluginKey(entry: ExternalPluginEntry): string {
  * @returns The glob, anchored when it has no path separator.
  */
 export function anchorOxlintGlob(glob: string): string {
-	if (glob.startsWith("!")) {
-		const body = glob.slice(1);
-		return body.includes("/") ? glob : `!./${body}`;
-	}
-
 	return glob.includes("/") ? glob : `./${glob}`;
 }
 

--- a/src/oxlint/utils.ts
+++ b/src/oxlint/utils.ts
@@ -87,6 +87,27 @@ export function jsPluginKey(entry: ExternalPluginEntry): string {
 }
 
 /**
+ * Anchor a slash-less override glob to the config directory.
+ *
+ * ESLint matches a flat-config `files` pattern without a `/` against
+ * root-level entries only, while oxlint matches it gitignore-style at any
+ * depth — a root-only relaxation such as `*` would silently apply to the
+ * whole tree (#617). A leading `./` keeps oxlint's matching anchored without
+ * changing what the pattern matches under ESLint semantics.
+ *
+ * @param glob - An override glob in ESLint `files` semantics.
+ * @returns The glob, anchored when it has no path separator.
+ */
+export function anchorOxlintGlob(glob: string): string {
+	if (glob.startsWith("!")) {
+		const body = glob.slice(1);
+		return body.includes("/") ? glob : `!./${body}`;
+	}
+
+	return glob.includes("/") ? glob : `./${glob}`;
+}
+
+/**
  * Drop every rule whose plugin prefix is not registered on the generated
  * config, mutating the overrides in place. Oxlint fails the whole config build
  * on a rule naming an unknown plugin, so entries left behind by a plugin that

--- a/src/rules/oxlint-mapping.ts
+++ b/src/rules/oxlint-mapping.ts
@@ -46,6 +46,8 @@ export const staysInEslint: Readonly<Record<string, string>> = {
 		"Rules whose meta.docs.requiresTypeChecking is true crash or silently no-op under oxlint's jsPlugin runtime (no type information): sonar/no-ignored-return, sonar/no-incompatible-assertion-types, sonar/no-redundant-optional, sonar/no-try-promise, sonar/prefer-immediate-return, unicorn/no-non-function-verb-prefix, eslint-plugin/no-property-in-node, jest/no-error-equal, jest/no-unnecessary-assertion, jest/unbound-method, jest/valid-expect-with-promise",
 	"unicorn/no-unsafe-string-replacement":
 		"False positives under oxlint's jsPlugin scope analysis (template-literal replacements are not resolved)",
+	"unicorn/no-useless-coercion":
+		"Optionally type-aware: values whose type is only known through TypeScript (a `string`-typed parameter, say) are missed without parser services, so it stays in ESLint (see optionallyTypeAwareRules)",
 };
 
 export const oxlintRuleMapping: Readonly<Record<string, OxlintTarget>> = {
@@ -349,7 +351,6 @@ export const oxlintRuleMapping: Readonly<Record<string, OxlintTarget>> = {
 	"unicorn/no-unreadable-new-expression": "js-plugin",
 	"unicorn/no-unsafe-property-key": "js-plugin",
 	"unicorn/no-unused-properties": "js-plugin",
-	"unicorn/no-useless-coercion": "js-plugin",
 	"unicorn/no-useless-compound-assignment": "js-plugin",
 	"unicorn/no-useless-concat": "js-plugin",
 	"unicorn/no-useless-delete-check": "js-plugin",
@@ -895,6 +896,7 @@ export const optionallyTypeAwareRules: ReadonlySet<string> = new Set([
 	"e18e/prefer-array-to-reversed",
 	"e18e/prefer-array-to-sorted",
 	"e18e/prefer-spread-syntax",
+	"unicorn/no-useless-coercion",
 ]);
 
 /**

--- a/test/__snapshots__/oxlint.spec.ts.snap
+++ b/test/__snapshots__/oxlint.spec.ts.snap
@@ -2333,7 +2333,7 @@ exports[`oxlint config snapshots > should match the default roblox game config 1
     },
     {
       "files": [
-        "*.{,c,m}[jt]s{,x}",
+        "./*.{,c,m}[jt]s{,x}",
         "packages/*/*.{,c,m}[jt]s{,x}",
         "apps/*/*.{,c,m}[jt]s{,x}",
         "libs/*/*.{,c,m}[jt]s{,x}",
@@ -3360,7 +3360,7 @@ exports[`oxlint config snapshots > should match the default roblox game config 1
     },
     {
       "files": [
-        "*",
+        "./*",
         "packages/*/*",
         "apps/*/*",
         "libs/*/*",
@@ -3374,7 +3374,7 @@ exports[`oxlint config snapshots > should match the default roblox game config 1
     },
     {
       "files": [
-        "*",
+        "./*",
         "packages/*/*",
         "apps/*/*",
         "libs/*/*",
@@ -6106,7 +6106,6 @@ exports[`oxlint config snapshots > should match the package config 1`] = `
         "unicorn-js/no-unreadable-new-expression": "error",
         "unicorn-js/no-unsafe-property-key": "error",
         "unicorn-js/no-unused-properties": "error",
-        "unicorn-js/no-useless-coercion": "error",
         "unicorn-js/no-useless-compound-assignment": "error",
         "unicorn-js/no-useless-concat": "error",
         "unicorn-js/no-useless-delete-check": "error",
@@ -6146,7 +6145,7 @@ exports[`oxlint config snapshots > should match the package config 1`] = `
     },
     {
       "files": [
-        "*.{,c,m}[jt]s{,x}",
+        "./*.{,c,m}[jt]s{,x}",
         "packages/*/*.{,c,m}[jt]s{,x}",
         "apps/*/*.{,c,m}[jt]s{,x}",
         "libs/*/*.{,c,m}[jt]s{,x}",
@@ -7356,7 +7355,7 @@ exports[`oxlint config snapshots > should match the package config 1`] = `
     },
     {
       "files": [
-        "*",
+        "./*",
         "packages/*/*",
         "apps/*/*",
         "libs/*/*",
@@ -7370,7 +7369,7 @@ exports[`oxlint config snapshots > should match the package config 1`] = `
     },
     {
       "files": [
-        "*",
+        "./*",
         "packages/*/*",
         "apps/*/*",
         "libs/*/*",

--- a/test/oxlint.spec.ts
+++ b/test/oxlint.spec.ts
@@ -315,9 +315,7 @@ describe("oxlint config snapshots", () => {
 			isInEditor: false,
 		});
 
-		const unanchored = collectOverrideGlobs(config).filter(
-			(glob) => !glob.replace(/^!/, "").includes("/"),
-		);
+		const unanchored = collectOverrideGlobs(config).filter((glob) => !glob.includes("/"));
 
 		expect(unanchored).toEqual([]);
 	});

--- a/test/oxlint.spec.ts
+++ b/test/oxlint.spec.ts
@@ -102,6 +102,22 @@ function disablesBarrelFileForDts(
 	);
 }
 
+/**
+ * Collect every override glob (files and excludeFiles) from a config.
+ *
+ * @param config - The oxlint config to inspect.
+ * @returns Every glob referenced by an override.
+ */
+function collectOverrideGlobs(config: OxlintConfig): Array<string> {
+	const globs: Array<string> = [];
+	const overrides = config.overrides ?? [];
+	for (const override of overrides) {
+		globs.push(...override.files, ...(override.excludeFiles ?? []));
+	}
+
+	return globs;
+}
+
 const baseOptions = {
 	gitignore: false,
 	isAgent: false,
@@ -283,6 +299,27 @@ describe("oxlint config snapshots", () => {
 		});
 
 		expect(serializeOxlintConfig(config)).toMatchSnapshot();
+	});
+
+	it("should anchor slash-less override globs to the config root", ({ expect }) => {
+		expect.hasAssertions();
+
+		// Oxlint matches a slash-less override glob gitignore-style at any
+		// depth, so an unanchored root glob such as `*` would apply a root-only
+		// relaxation to the whole tree (#617). ESLint anchors these to the
+		// config root; a leading `./` makes oxlint do the same.
+		const config = oxlintIsentinel({
+			name: "test/oxlint-anchored-globs",
+			gitignore: false,
+			isAgent: false,
+			isInEditor: false,
+		});
+
+		const unanchored = collectOverrideGlobs(config).filter(
+			(glob) => !glob.replace(/^!/, "").includes("/"),
+		);
+
+		expect(unanchored).toEqual([]);
 	});
 });
 


### PR DESCRIPTION
Fixes the two under-reporting mechanisms behind #617.

## Root cause 1: override glob semantics (the two filename rules)

Oxlint matches a slash-less override glob gitignore-style at any depth, while ESLint anchors it to the config root. The preset's root-only relaxations (`*`, `*.{,c,m}[jt]s{,x}`) therefore applied to the whole tree, silently disabling `sonar/file-name-differ-from-class` and the `name-replacements` filename check everywhere — for native rules just as much as jsPlugin rules (verified with `no-var`).

Fix: `anchorOxlintGlob` prefixes every merged override glob (`files` and `excludeFiles`) with `./` when it has no path separator, which anchors oxlint without changing ESLint-glob meaning. A regression test asserts no override glob is emitted unanchored. Verified against the regenerated hybrid config: both rules fire on nested files, root relaxations still apply at the root.

This disproves the file-scope-loc hypothesis from the issue: sonar's `loc: {line: 0, column: 0}` report renders fine (`1:1`) once the overrides are anchored.

## Root cause 2: type-info gap (`unicorn/no-useless-coercion`)

The rule is optionally type-aware: values typed only through TypeScript (a `string`-typed parameter, say) are missed without parser services, which oxlint jsPlugins never have. Untyped ESLint misses the same case. It moves to `optionallyTypeAwareRules`, so hybrid mode keeps it in ESLint and the `typeAware: "only"` pass runs it with a program.

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)