### PR TITLE
perf(lint-cli): spawn oxlint and the fast pass before the TS builder

### DIFF
--- a/src/lint-cli/lib/exec/execute.ts
+++ b/src/lint-cli/lib/exec/execute.ts
@@ -1,18 +1,28 @@
+import ansis from "ansis";
 import concurrently from "concurrently";
 import { spawn } from "node:child_process";
 import process from "node:process";
+import { Writable } from "node:stream";
 
 import type { ChildCommand, ToolLabel } from "../cli/types.ts";
 import { resolveLocalBin } from "./resolve.ts";
 import { buildShellCommand } from "./shell.ts";
 
 /** Prefix colour per child label for `concurrently`; kept visually distinct. */
-const PREFIX_COLOR: Record<ToolLabel, string> = {
+const PREFIX_COLOR: Record<ToolLabel, "blue" | "cyan" | "magenta"> = {
 	eslint: "blue",
 	fast: "blue",
 	oxc: "magenta",
 	typed: "cyan",
 };
+
+/** An output stream whose writes are withheld until it is released. */
+interface HeldOutput {
+	/** Flush what was withheld and let every later write through. */
+	release: () => void;
+	/** The stream to hand `concurrently`. */
+	stream: Writable;
+}
 
 /**
  * Run the composed children and aggregate their exit codes.
@@ -34,21 +44,84 @@ export async function execute(
 	cwd: string,
 	sequential: boolean,
 ): Promise<number> {
-	return sequential ? runSequential(commands, cwd) : runConcurrent(commands, cwd);
+	return sequential ? runSequential(commands, cwd) : startGroup(commands, cwd);
 }
 
 /**
- * Run every command concurrently to completion and aggregate their exit codes.
+ * Run a staged set of children: spawn `commands` now, then resolve the rest and
+ * spawn those too, all of them concurrent. `resolveDeferred` is the expensive
+ * planning step (the TypeScript builder) that the eager children exist to run
+ * alongside — it blocks this process, but they are already OS processes and
+ * keep linting throughout.
+ *
+ * The deferred children go into their own `concurrently` group, because a group
+ * spawns every command the moment it is created. Their output is withheld until
+ * the eager group has flushed: `group: true` orders output by declaration and
+ * the deferred children are declared last, so this reproduces the ordering an
+ * unstaged run would have had rather than letting two lint reports interleave.
+ *
+ * As with {@link execute}, every child runs to completion and the returned code
+ * is non-zero when any of them exited non-zero.
+ *
+ * @param commands - The children to spawn immediately.
+ * @param cwd - The working directory.
+ * @param resolveDeferred - Plans the remaining children; called once, after the
+ *   eager ones have spawned. May return an empty list.
+ * @returns The aggregated exit code.
+ */
+export async function executeStaged(
+	commands: Array<ChildCommand>,
+	cwd: string,
+	resolveDeferred: () => Array<ChildCommand>,
+): Promise<number> {
+	const eager = startGroup(commands, cwd);
+	const deferred = resolveDeferred();
+	if (deferred.length === 0) {
+		return eager;
+	}
+
+	const held = createHeldOutput();
+	const later = startGroup(deferred, cwd, held.stream);
+
+	const eagerCode = await eager;
+	held.release();
+	const deferredCode = await later;
+
+	return eagerCode === 0 ? deferredCode : eagerCode;
+}
+
+/**
+ * Announce a child on stderr once it has been spawned. `concurrently` groups
+ * child output, so a slow child holds back everything declared after it and the
+ * terminal looks idle until the first one exits; these lines are the only
+ * signal that the run is alive. They go to stderr so they never contaminate a
+ * piped report.
+ *
+ * @param command - The child that was spawned.
+ */
+function announce(command: ChildCommand): void {
+	const prefix = ansis[PREFIX_COLOR[command.label]](`[${command.label}]`);
+	process.stderr.write(`${prefix} spawned ${command.bin}\n`);
+}
+
+/**
+ * Start every command as one `concurrently` group and announce the children.
  * Unlike the previous `killOthersOn: ["failure"]` behaviour, an ordinary lint
  * failure in one child no longer kills its siblings — each runs to the end so
- * the user keeps every result. The returned code is non-zero when any child
- * exited non-zero.
+ * the user keeps every result. The resolved code is non-zero when any child
+ * exited non-zero; the promise never rejects.
  *
  * @param commands - The child commands to run.
  * @param cwd - The working directory.
+ * @param outputStream - Where the group writes its child output; defaults to
+ *   stdout. A staged run passes a held stream (see {@link createHeldOutput}).
  * @returns The aggregated exit code.
  */
-async function runConcurrent(commands: Array<ChildCommand>, cwd: string): Promise<number> {
+async function startGroup(
+	commands: Array<ChildCommand>,
+	cwd: string,
+	outputStream?: Writable,
+): Promise<number> {
 	const { result } = concurrently(
 		commands.map((command) => {
 			return {
@@ -66,8 +139,17 @@ async function runConcurrent(commands: Array<ChildCommand>, cwd: string): Promis
 		{
 			cwd,
 			group: true,
+			outputStream,
 		},
 	);
+
+	// `concurrently` starts every child synchronously before returning (no
+	// `maxProcesses` cap), so these lines report real spawns rather than intent.
+	// Everything above runs before this function's first `await`, which is what
+	// lets a staged caller keep working while the group it just started lints.
+	for (const command of commands) {
+		announce(command);
+	}
 
 	try {
 		await result;
@@ -87,6 +169,7 @@ async function spawnChild(command: ChildCommand, cwd: string): Promise<number> {
 			env: { ...process.env, ...command.env },
 			stdio: "inherit",
 		});
+		announce(command);
 		child.on("error", () => {
 			resolve(1);
 		});
@@ -106,4 +189,47 @@ async function runSequential(commands: Array<ChildCommand>, cwd: string): Promis
 	}
 
 	return exitCode;
+}
+
+/**
+ * A stream that swallows writes into memory until {@link HeldOutput.release} is
+ * called, then replays them to stdout and passes everything after them straight
+ * through.
+ *
+ * `concurrently` writes child output to whichever stream it is given, on its
+ * own schedule; this is the only handle on *when* that output surfaces, which a
+ * staged run needs so a group started late cannot cut into a group started
+ * early.
+ *
+ * @returns The stream and its release trigger.
+ */
+function createHeldOutput(): HeldOutput {
+	const withheld: Array<string> = [];
+	let released = false;
+
+	const stream = new Writable({
+		decodeStrings: false,
+		write(chunk: unknown, _encoding, callback) {
+			const text = String(chunk);
+			if (released) {
+				process.stdout.write(text);
+			} else {
+				withheld.push(text);
+			}
+
+			callback();
+		},
+	});
+
+	return {
+		release: () => {
+			released = true;
+			for (const text of withheld) {
+				process.stdout.write(text);
+			}
+
+			withheld.length = 0;
+		},
+		stream,
+	};
 }

--- a/src/lint-cli/lib/plan/compose.ts
+++ b/src/lint-cli/lib/plan/compose.ts
@@ -1,6 +1,7 @@
 import type { ChildCommand, LintCliOptions } from "../cli/types.ts";
 import { composeEslintCommand, composeOxlintCommand } from "./command.ts";
 import type { RunPlan } from "./plan.ts";
+import type { PassPlan } from "./sizing.ts";
 
 /** The stderr notice emitted when a lint target resolves outside the cwd. */
 const OUTSIDE_CWD_NOTICE =
@@ -16,6 +17,52 @@ export interface CommandPlan {
 	 * pass).
 	 */
 	notice: string | undefined;
+}
+
+/**
+ * Turn planned ESLint passes into child commands, collecting the notices of the
+ * ones that auto-skipped. Pure, and split out of {@link compose} because a
+ * staged run composes its passes in two goes: the type-aware pass is only sized
+ * once its siblings are already linting, and nothing else about the run is
+ * re-derived when it is.
+ *
+ * @param passes - The planned passes to compose, in run order.
+ * @param runPlan - The run they belong to, for the settings every child shares.
+ *   Its own `passes` are ignored in favour of the argument.
+ * @param options - The parsed CLI options (paths and per-tool args).
+ * @returns The composed commands and skip notices.
+ */
+export function composePasses(
+	passes: Array<PassPlan>,
+	runPlan: RunPlan,
+	options: LintCliOptions,
+): CommandPlan {
+	const commands: Array<ChildCommand> = [];
+	const notices: Array<string> = [];
+
+	for (const pass of passes) {
+		if (!pass.shouldRun) {
+			if (pass.skipReason !== undefined) {
+				notices.push(pass.skipReason);
+			}
+
+			continue;
+		}
+
+		commands.push(
+			composeEslintCommand(options, {
+				agentsFormatterPath: runPlan.agentsFormatterPath,
+				cacheLocation: pass.cacheFile,
+				ci: runPlan.ci,
+				concurrency: pass.concurrency,
+				eslintLabel: pass.descriptor.label,
+				paths: options.paths,
+				typeAwareEnv: pass.descriptor.typeAwareEnv,
+			}),
+		);
+	}
+
+	return { commands, notice: notices.length > 0 ? notices.join("") : undefined };
 }
 
 /**
@@ -47,26 +94,10 @@ export function compose(runPlan: RunPlan, options: LintCliOptions): CommandPlan 
 		);
 	}
 
-	for (const pass of runPlan.passes) {
-		if (!pass.shouldRun) {
-			if (pass.skipReason !== undefined) {
-				notices.push(pass.skipReason);
-			}
-
-			continue;
-		}
-
-		commands.push(
-			composeEslintCommand(options, {
-				agentsFormatterPath: runPlan.agentsFormatterPath,
-				cacheLocation: pass.cacheFile,
-				ci: runPlan.ci,
-				concurrency: pass.concurrency,
-				eslintLabel: pass.descriptor.label,
-				paths: options.paths,
-				typeAwareEnv: pass.descriptor.typeAwareEnv,
-			}),
-		);
+	const passPlan = composePasses(runPlan.passes, runPlan, options);
+	commands.push(...passPlan.commands);
+	if (passPlan.notice !== undefined) {
+		notices.push(passPlan.notice);
 	}
 
 	return { commands, notice: notices.length > 0 ? notices.join("") : undefined };

--- a/src/lint-cli/lib/plan/plan.ts
+++ b/src/lint-cli/lib/plan/plan.ts
@@ -12,14 +12,16 @@ import { collectRepoFiles, oxlintTargets, withoutIgnored } from "../files/collec
 import { resolveIgnoredFiles } from "../files/ignored.ts";
 import { resolveOxlintRun } from "../hybrid/gate.ts";
 import { resolveWorkerLimits } from "./concurrency.ts";
+import type { PassDescriptor } from "./passes.ts";
 import { selectPasses } from "./passes.ts";
-import type { PassPlan } from "./sizing.ts";
+import type { PassPlan, SizingInputs } from "./sizing.ts";
 import { sizePasses } from "./sizing.ts";
 
 /**
- * A composed run as plain data: all I/O and mutation happen once in
- * {@link plan} to build it, then `compose` turns it into child commands with no
- * further I/O.
+ * A composed run as plain data: the I/O and mutation behind it happen in
+ * {@link plan}, then `compose` turns it into child commands with no further
+ * I/O. A staged run leaves one step outstanding — see {@link StagedPlan} — but
+ * this value is complete for the passes it carries.
  */
 export interface RunPlan {
 	/**
@@ -49,18 +51,66 @@ export interface RunPlan {
 }
 
 /**
+ * A run planned in two stages, so the children that need nothing from the
+ * TypeScript builder stop waiting behind it.
+ *
+ * Sizing a type-aware pass means running the incremental builder over the whole
+ * program — seconds on a real project, and unconditional even when it reports
+ * nothing affected. Everything else the planner does is cheap. Splitting the
+ * plan lets the oxlint child and the syntactic pass spawn first and lint while
+ * the builder runs, with the type-aware child joining once its own sizing is
+ * known.
+ */
+export interface StagedPlan {
+	/** The part of the run that is ready to spawn now. */
+	eager: RunPlan;
+	/**
+	 * Size the passes held back from {@link StagedPlan.eager}: runs the
+	 * TypeScript builder and folds its invalidation into the type-aware cache.
+	 * `undefined` when nothing was held back, which is also the whole plan for
+	 * `--print` and `--fix`.
+	 *
+	 * Call once, and only after the eager children have spawned — it mutates
+	 * the type-aware cache the child it plans is about to read.
+	 */
+	resolveDeferred: (() => Array<PassPlan>) | undefined;
+}
+
+/** What the staging decision needs to know beyond the descriptors. */
+interface StagingInputs {
+	/** Whether the run selected more than one pass. */
+	multiPass: boolean;
+	/** Whether an oxlint child survived the hybrid gate. */
+	oxlint: boolean;
+	/** Whether a lint target resolved outside the cwd. */
+	targetsOutsideCwd: boolean;
+}
+
+/** How the selected passes split across the two spawn stages. */
+interface StagedDescriptors {
+	/** Passes whose dirty count needs the builder; sized after the spawn. */
+	deferred: Array<PassDescriptor>;
+	/** Passes sized now, so their children spawn before the builder runs. */
+	eager: Array<PassDescriptor>;
+}
+
+/**
  * Plan the run: collect the repo file list once, apply the package.json and
- * mtime busts and TypeScript builder invalidation, size each pass and decide
- * which run. All I/O and mutation happen here, exactly once. When `mutate` is
- * false (`--print`) the whole mutation step is skipped — no builder, no cache
- * deletion, no state writes and no auto-skip — while still sizing from the
- * on-disk caches. The returned value is plain data.
+ * mtime busts, size each pass and decide which run. Every cache bust and every
+ * deletion happens here, before anything spawns, so no child ever lints against
+ * a cache that is about to vanish. When `mutate` is false (`--print`) the whole
+ * mutation step is skipped — no builder, no cache deletion, no state writes and
+ * no auto-skip — while still sizing from the on-disk caches.
+ *
+ * The one step that may outlive this call is the TypeScript builder behind a
+ * type-aware pass's dirty count; see {@link StagedPlan}. The returned eager
+ * half is plain data.
  *
  * @param options - The parsed CLI options.
  * @param run - The run context (cwd, variant key, environment, mutate).
- * @returns The run plan.
+ * @returns The staged run plan.
  */
-export function plan(options: LintCliOptions, run: RunContext): RunPlan {
+export function plan(options: LintCliOptions, run: RunContext): StagedPlan {
 	const { ci, cwd, environment, mutate } = run;
 	const runEslint = !options.oxlint;
 	const oxlintTypeAware = resolveOxlintTypeAware(options);
@@ -75,14 +125,17 @@ export function plan(options: LintCliOptions, run: RunContext): RunPlan {
 
 	if (!runEslint) {
 		return {
-			agentsFormatterPath,
-			ci,
-			oxlint: runOxlint,
-			oxlintPaths,
-			oxlintReason: undefined,
-			oxlintTypeAware,
-			passes: [],
-			targetsOutsideCwd: false,
+			eager: {
+				agentsFormatterPath,
+				ci,
+				oxlint: runOxlint,
+				oxlintPaths,
+				oxlintReason: undefined,
+				oxlintTypeAware,
+				passes: [],
+				targetsOutsideCwd: false,
+			},
+			resolveDeferred: undefined,
 		};
 	}
 
@@ -142,26 +195,85 @@ export function plan(options: LintCliOptions, run: RunContext): RunPlan {
 	const ignored = resolveIgnoredFiles(run, configHash, files.lintable);
 	const sizingFiles = withoutIgnored(files, ignored);
 
-	const passes = sizePasses(descriptors, run, {
+	const inputs: SizingInputs = {
 		clearedCaches,
 		files: sizingFiles,
 		limits,
+		multiPass: descriptors.length > 1,
 		newestBustMtime,
 		options,
+	};
+
+	const staged = stageDescriptors(descriptors, options, run, {
+		multiPass: inputs.multiPass,
+		oxlint: oxlintDecision.run,
+		targetsOutsideCwd: sizingFiles.targetsOutsideCwd,
 	});
 
 	return {
-		agentsFormatterPath,
-		ci,
-		oxlint: oxlintDecision.run,
-		oxlintPaths,
-		oxlintReason: oxlintDecision.reason,
-		oxlintTypeAware,
-		passes,
-		targetsOutsideCwd: files.targetsOutsideCwd,
+		eager: {
+			agentsFormatterPath,
+			ci,
+			oxlint: oxlintDecision.run,
+			oxlintPaths,
+			oxlintReason: oxlintDecision.reason,
+			oxlintTypeAware,
+			passes: sizePasses(staged.eager, run, inputs),
+			targetsOutsideCwd: files.targetsOutsideCwd,
+		},
+		resolveDeferred:
+			staged.deferred.length > 0 ? () => sizePasses(staged.deferred, run, inputs) : undefined,
 	};
 }
 
 function resolveOxlintTypeAware(options: LintCliOptions): boolean {
 	return !options.eslint && options.oxlintTypeAware && options.typeAware !== "off";
+}
+
+/**
+ * Split the selected passes into the ones that can be sized now and the ones
+ * worth holding back until their siblings are already linting. Only a pass that
+ * runs the TypeScript builder is ever held back — that is the whole cost being
+ * moved off the critical path.
+ *
+ * Everything else stays eager, and four cases opt out of staging entirely:
+ *
+ * - `--print` (`mutate` false) runs no builder anyway and must stay one pure
+ *   snapshot printed in a single go;
+ * - `--fix` runs its children one at a time, so a later spawn buys nothing and
+ *   there is no reason to reopen the write race the sequential path prevents;
+ * - a run with no eager child at all, where holding the builder-backed pass
+ *   back would only delay the whole run;
+ * - a run whose one eager child could end up alone, because the type-aware pass
+ *   it was staged alongside auto-skipped. A lone child gets inherited stdio
+ *   (colour, no prefix), and staging would have already committed it to the
+ *   prefixed, piped harness for no gain.
+ *
+ * @param descriptors - The selected passes, in run order.
+ * @param options - The parsed CLI options.
+ * @param run - The run context.
+ * @param staging - The oxlint decision and the auto-skip inputs.
+ * @returns The two stages, each in run order.
+ */
+function stageDescriptors(
+	descriptors: Array<PassDescriptor>,
+	options: LintCliOptions,
+	run: RunContext,
+	staging: StagingInputs,
+): StagedDescriptors {
+	const eager = descriptors.filter((descriptor) => descriptor.invalidation === "none");
+	const deferred = descriptors.filter((descriptor) => descriptor.invalidation !== "none");
+	const unstaged: StagedDescriptors = { deferred: [], eager: descriptors };
+
+	if (!run.mutate || options.fix || deferred.length === 0) {
+		return unstaged;
+	}
+
+	const eagerChildren = (staging.oxlint ? 1 : 0) + eager.length;
+	const mayAutoSkip = staging.multiPass && !staging.targetsOutsideCwd;
+	if (eagerChildren === 0 || (eagerChildren === 1 && mayAutoSkip)) {
+		return unstaged;
+	}
+
+	return { deferred, eager };
 }

--- a/src/lint-cli/lib/plan/sizing.ts
+++ b/src/lint-cli/lib/plan/sizing.ts
@@ -50,6 +50,14 @@ export interface SizingInputs {
 	files: RepoFiles;
 	/** The resolved worker limits. */
 	limits: WorkerLimits;
+	/**
+	 * Whether the run selected more than one pass, which is what lets the typed
+	 * pass auto-skip. Carried here rather than derived from the descriptor list
+	 * because staging sizes the passes in two calls: the typed pass is sized
+	 * alone, after its siblings have spawned, and would otherwise read as the
+	 * only pass of the run.
+	 */
+	multiPass: boolean;
 	/** The newest cache-bust mtime (see `maxMtimeMs`). */
 	newestBustMtime: number | undefined;
 	/** The parsed CLI options. */
@@ -58,8 +66,6 @@ export interface SizingInputs {
 
 /** Everything one pass is sized against. */
 interface SizePassContext extends SizingInputs {
-	/** Whether more than one pass was selected (the typed pass may skip). */
-	multiPass: boolean;
 	/** The run context. */
 	run: RunContext;
 }
@@ -74,6 +80,11 @@ interface SizePassContext extends SizingInputs {
  * mtime/checksum and touches nothing. Callers see neither path — they get the
  * planned passes.
  *
+ * Callable more than once per run: a staged run sizes the builder-free passes
+ * up front and the builder-backed ones after their siblings have spawned. The
+ * inputs are the same value both times, so nothing is recomputed — only the
+ * builder work moves.
+ *
  * @param descriptors - The passes to size, in run order.
  * @param run - The run context.
  * @param inputs - The file lists, limits and bust results to size against.
@@ -84,8 +95,7 @@ export function sizePasses(
 	run: RunContext,
 	inputs: SizingInputs,
 ): Array<PassPlan> {
-	const multiPass = descriptors.length > 1;
-	return descriptors.map((descriptor) => sizePass(descriptor, { ...inputs, multiPass, run }));
+	return descriptors.map((descriptor) => sizePass(descriptor, { ...inputs, run }));
 }
 
 /**

--- a/src/lint-cli/lib/run.ts
+++ b/src/lint-cli/lib/run.ts
@@ -4,9 +4,9 @@ import process from "node:process";
 import { parseArguments } from "./cli/options.ts";
 import { CliError } from "./cli/types.ts";
 import { resolveRunContext } from "./context.ts";
-import { execute } from "./exec/execute.ts";
+import { execute, executeStaged } from "./exec/execute.ts";
 import { formatCommandLine } from "./exec/shell.ts";
-import { compose } from "./plan/compose.ts";
+import { compose, composePasses } from "./plan/compose.ts";
 import { plan } from "./plan/plan.ts";
 
 /**
@@ -26,7 +26,8 @@ export async function runLint(
 	const options = parseArguments(argv, environment);
 
 	const run = resolveRunContext(cwd, environment, !options.print);
-	const { commands, notice } = compose(plan(options, run), options);
+	const staged = plan(options, run);
+	const { commands, notice } = compose(staged.eager, options);
 
 	if (options.print) {
 		for (const command of commands) {
@@ -56,7 +57,24 @@ export async function runLint(
 		process.stderr.write(notice);
 	}
 
-	// `--fix` must be sequential: two children writing the same files at once
-	// would race. A lone child gains nothing from the concurrently harness.
-	return execute(commands, cwd, options.fix || commands.length <= 1);
+	const { resolveDeferred } = staged;
+	if (resolveDeferred === undefined) {
+		// `--fix` must be sequential: two children writing the same files at once
+		// would race. A lone child gains nothing from the concurrently harness.
+		return execute(commands, cwd, options.fix || commands.length <= 1);
+	}
+
+	// A staged run is concurrent by construction (the planner only stages when
+	// at least one other child is already linting), so it never takes the
+	// sequential path. The type-aware pass is planned — TypeScript builder and
+	// all — only once the children above are running, and its notice is emitted
+	// as soon as it is known rather than held to the end of the run.
+	return executeStaged(commands, cwd, () => {
+		const later = composePasses(resolveDeferred(), staged.eager, options);
+		if (later.notice !== undefined) {
+			process.stderr.write(later.notice);
+		}
+
+		return later.commands;
+	});
 }

--- a/test/lint-cli-helpers.ts
+++ b/test/lint-cli-helpers.ts
@@ -1,9 +1,11 @@
 import { parseArguments } from "../src/lint-cli/lib/cli/options.ts";
 import { resolveRunContext } from "../src/lint-cli/lib/context.ts";
 import type { RunContext } from "../src/lint-cli/lib/context.ts";
-import { compose } from "../src/lint-cli/lib/plan/compose.ts";
+import { compose, composePasses } from "../src/lint-cli/lib/plan/compose.ts";
 import type { CommandPlan } from "../src/lint-cli/lib/plan/compose.ts";
 import { plan } from "../src/lint-cli/lib/plan/plan.ts";
+import type { StagedPlan } from "../src/lint-cli/lib/plan/plan.ts";
+import type { PassPlan } from "../src/lint-cli/lib/plan/sizing.ts";
 import { withoutGitEnvironment } from "./without-git.ts";
 
 /** How a fixture run differs from the defaults. */
@@ -15,6 +17,18 @@ export interface ComposeInDirectoryOptions {
 	 * state. Defaults to false, which is what `--print` does.
 	 */
 	mutate?: boolean;
+}
+
+/**
+ * Every pass a staged plan runs, in run order, resolving the deferred stage
+ * (TypeScript builder and all) as the executor would. Staging is a spawn-timing
+ * detail; a test asserting on what a run *does* wants the whole list.
+ *
+ * @param staged - The staged plan.
+ * @returns The planned passes, eager stage first.
+ */
+export function allPasses(staged: StagedPlan): Array<PassPlan> {
+	return [...staged.eager.passes, ...(staged.resolveDeferred?.() ?? [])];
 }
 
 /**
@@ -52,6 +66,24 @@ export function composeInDirectory(
 ): CommandPlan {
 	return withoutGitEnvironment(() => {
 		const options = parseArguments(argv, environment);
-		return compose(plan(options, runContext(directory, { environment, mutate })), options);
+		const staged = plan(options, runContext(directory, { environment, mutate }));
+		const eager = compose(staged.eager, options);
+		if (staged.resolveDeferred === undefined) {
+			return eager;
+		}
+
+		// A staged run composes its type-aware pass separately, after the eager
+		// children would have spawned. Tests assert on the whole run, so flatten
+		// the two stages back into one plan the way the terminal sees them.
+		const deferred = composePasses(staged.resolveDeferred(), staged.eager, options);
+		return {
+			commands: [...eager.commands, ...deferred.commands],
+			notice: joinNotices(eager.notice, deferred.notice),
+		};
 	});
+}
+
+function joinNotices(...notices: Array<string | undefined>): string | undefined {
+	const present = notices.filter((notice) => notice !== undefined);
+	return present.length > 0 ? present.join("") : undefined;
 }

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -24,7 +24,7 @@ import type { CommandPlan } from "../src/lint-cli/lib/plan/compose.ts";
 import { plan } from "../src/lint-cli/lib/plan/plan.ts";
 import type { PassPlan } from "../src/lint-cli/lib/plan/sizing.ts";
 import { computeAffectedFiles } from "../src/lint-cli/lib/typescript/affected.ts";
-import { composeInDirectory, runContext } from "./lint-cli-helpers.ts";
+import { allPasses, composeInDirectory, runContext } from "./lint-cli-helpers.ts";
 import { withoutGitEnvironment } from "./without-git.ts";
 
 /**
@@ -634,7 +634,7 @@ describe("plan mutation", () => {
 			return plan(parseArguments([], {}), runContext(directory));
 		});
 
-		expect(runPlan.passes.map((pass) => pass.descriptor.label)).toStrictEqual([
+		expect(allPasses(runPlan).map((pass) => pass.descriptor.label)).toStrictEqual([
 			"fast",
 			"typed",
 		]);
@@ -642,9 +642,10 @@ describe("plan mutation", () => {
 		expect(builderStateFiles(directory, buildInfo)).toHaveLength(0);
 		expect(fs.existsSync(cacheFile)).toBe(true);
 
-		// The mutating plan, by contrast, runs the builder.
+		// The mutating plan, by contrast, runs the builder — once its deferred
+		// stage is resolved, which is where a staged run moved it to.
 		withoutGitEnvironment(() => {
-			return plan(parseArguments([], {}), runContext(directory, { mutate: true }));
+			return allPasses(plan(parseArguments([], {}), runContext(directory, { mutate: true })));
 		});
 
 		expect(builderStateFiles(directory, buildInfo)).toHaveLength(1);
@@ -666,7 +667,7 @@ describe("plan mutation", () => {
 		const runPlan = withoutGitEnvironment(() => {
 			return plan(parseArguments([], {}), runContext(directory, { mutate: true }));
 		});
-		const typed = runPlan.passes.find((pass) => pass.descriptor.label === "typed");
+		const typed = allPasses(runPlan).find((pass) => pass.descriptor.label === "typed");
 
 		expect(typed!.shouldRun).toBe(false);
 		expect(typed!.skipReason).toMatch(/skipping the type-aware/);
@@ -1026,7 +1027,7 @@ describe("computeConfigHash discovery", () => {
 
 describe("config drift sizing", () => {
 	function typedPass(runPlan: ReturnType<typeof plan>): PassPlan | undefined {
-		return runPlan.passes.find((pass) => pass.descriptor.label === "typed");
+		return allPasses(runPlan).find((pass) => pass.descriptor.label === "typed");
 	}
 
 	it("un-skips the typed pass when a module the config imports changed", () => {

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -35,7 +35,7 @@ import type {
 import { CliError } from "../src/lint-cli/lib/cli/types.ts";
 import { resolveCacheKey } from "../src/lint-cli/lib/context.ts";
 import type { RunContext } from "../src/lint-cli/lib/context.ts";
-import { execute } from "../src/lint-cli/lib/exec/execute.ts";
+import { execute, executeStaged } from "../src/lint-cli/lib/exec/execute.ts";
 import { buildShellCommand, formatCommandLine } from "../src/lint-cli/lib/exec/shell.ts";
 import { collectRepoFiles, oxlintTargets } from "../src/lint-cli/lib/files/collect.ts";
 import type { RepoFiles } from "../src/lint-cli/lib/files/collect.ts";
@@ -952,33 +952,36 @@ describe("compose --print", () => {
 
 describe("plan", () => {
 	it("returns the default fast + typed passes as data", () => {
-		expect.assertions(4);
+		expect.assertions(5);
 
 		const directory = temporaryDirectory();
-		const runPlan = withoutGitEnvironment(() => {
+		const staged = withoutGitEnvironment(() => {
 			return plan(parseArguments([], {}), runContext(directory));
 		});
 
-		expect(runPlan.oxlint).toBe(true);
-		expect(runPlan.oxlintTypeAware).toBe(true);
-		expect(runPlan.passes.map((pass) => pass.descriptor.label)).toStrictEqual([
+		expect(staged.eager.oxlint).toBe(true);
+		expect(staged.eager.oxlintTypeAware).toBe(true);
+		expect(staged.eager.passes.map((pass) => pass.descriptor.label)).toStrictEqual([
 			"fast",
 			"typed",
 		]);
 		// A read-only plan never auto-skips the typed pass.
-		expect(runPlan.passes.every((pass) => pass.shouldRun)).toBe(true);
+		expect(staged.eager.passes.every((pass) => pass.shouldRun)).toBe(true);
+		// ...nor stages one: --print runs no builder to move off the path.
+		expect(staged.resolveDeferred).toBeUndefined();
 	});
 
 	it("plans no ESLint passes for an oxlint-only run", () => {
-		expect.assertions(2);
+		expect.assertions(3);
 
 		const directory = temporaryDirectory();
-		const runPlan = withoutGitEnvironment(() => {
+		const staged = withoutGitEnvironment(() => {
 			return plan(parseArguments(["--oxlint"], {}), runContext(directory));
 		});
 
-		expect(runPlan.oxlint).toBe(true);
-		expect(runPlan.passes).toStrictEqual([]);
+		expect(staged.eager.oxlint).toBe(true);
+		expect(staged.eager.passes).toStrictEqual([]);
+		expect(staged.resolveDeferred).toBeUndefined();
 	});
 
 	it("collapses to a single pass for the explicit modes", () => {
@@ -995,8 +998,96 @@ describe("plan", () => {
 			);
 		});
 
-		expect(fast.passes.map((pass) => pass.descriptor.label)).toStrictEqual(["fast"]);
-		expect(full.passes.map((pass) => pass.descriptor.label)).toStrictEqual(["eslint"]);
+		expect(fast.eager.passes.map((pass) => pass.descriptor.label)).toStrictEqual(["fast"]);
+		expect(full.eager.passes.map((pass) => pass.descriptor.label)).toStrictEqual(["eslint"]);
+	});
+});
+
+describe("plan staging", () => {
+	function stagedLabels(
+		argv: Array<string>,
+		directory: string,
+		environment: NodeJS.ProcessEnv = {},
+	): { deferred: Array<string>; eager: Array<string> } {
+		const staged = withoutGitEnvironment(() => {
+			return plan(
+				parseArguments(argv, environment),
+				runContext(directory, { environment, mutate: true }),
+			);
+		});
+
+		return {
+			deferred: (staged.resolveDeferred?.() ?? []).map((pass) => pass.descriptor.label),
+			eager: staged.eager.passes.map((pass) => pass.descriptor.label),
+		};
+	}
+
+	/**
+	 * A fixture whose oxlint child survives the hybrid gate: a fresh status
+	 * file and no `eslint.config.*` to make it look stale.
+	 *
+	 * @returns The fixture directory.
+	 */
+	function hybridDirectory(): string {
+		const directory = temporaryDirectory();
+		fs.mkdirSync(path.join(directory, "node_modules"));
+		writeHybridStatus(directory, true);
+		return directory;
+	}
+
+	it("holds the typed pass back from a default run", () => {
+		expect.assertions(2);
+
+		const { deferred, eager } = stagedLabels([], hybridDirectory());
+
+		expect(eager).toStrictEqual(["fast"]);
+		expect(deferred).toStrictEqual(["typed"]);
+	});
+
+	it("holds a lone typed or full pass back behind the oxlint child", () => {
+		expect.assertions(4);
+
+		const only = stagedLabels(["--type-aware=only"], hybridDirectory());
+		const ci = stagedLabels([], hybridDirectory(), { CI: "true" });
+
+		expect(only.eager).toStrictEqual([]);
+		expect(only.deferred).toStrictEqual(["typed"]);
+		expect(ci.eager).toStrictEqual([]);
+		expect(ci.deferred).toStrictEqual(["eslint"]);
+	});
+
+	it("never stages --print or --fix", () => {
+		expect.assertions(2);
+
+		const directory = hybridDirectory();
+		const printed = withoutGitEnvironment(() => {
+			return plan(parseArguments([], {}), runContext(directory));
+		});
+
+		expect(printed.resolveDeferred).toBeUndefined();
+		expect(stagedLabels(["--fix"], directory).deferred).toStrictEqual([]);
+	});
+
+	it("never stages a run whose eager half could end up a lone child", () => {
+		expect.assertions(2);
+
+		// --eslint drops the oxlint child, leaving the fast pass alone; the typed
+		// pass may still auto-skip, which would strip the run back to one child.
+		const split = stagedLabels(["--eslint"], hybridDirectory());
+
+		expect(split.eager).toStrictEqual(["fast", "typed"]);
+		expect(split.deferred).toStrictEqual([]);
+	});
+
+	it("never stages a run with nothing to lint alongside the builder", () => {
+		expect.assertions(2);
+
+		// --eslint drops oxlint and =only leaves no syntactic pass, so the typed
+		// child is the whole run: holding it back would only delay it.
+		const only = stagedLabels(["--eslint", "--type-aware=only"], hybridDirectory());
+
+		expect(only.eager).toStrictEqual(["typed"]);
+		expect(only.deferred).toStrictEqual([]);
 	});
 });
 
@@ -1233,6 +1324,76 @@ describe("execute", () => {
 		expect(code).toBe(1);
 		expect(fs.existsSync(eslintMarker)).toBe(true);
 		expect(fs.existsSync(oxcMarker)).toBe(true);
+	}, 15_000);
+});
+
+describe("executeStaged", () => {
+	it("spawns the eager children before it resolves the deferred ones", async () => {
+		expect.assertions(3);
+
+		const directory = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-staged-"));
+		onTestFinished(() => {
+			fs.rmSync(directory, { force: true, recursive: true });
+		});
+		const oxcMarker = path.join(directory, "oxc-ran");
+		const eslintMarker = path.join(directory, "eslint-ran");
+
+		// oxlint writes its marker immediately; the resolver below asserts the
+		// file exists, which can only hold if the child really started first.
+		writeFakeToolBin(
+			directory,
+			"oxlint",
+			`const fs=require("node:fs");setTimeout(()=>{fs.writeFileSync(${JSON.stringify(
+				oxcMarker,
+			)},"ran");process.exit(0);},250);`,
+		);
+		writeFakeToolBin(
+			directory,
+			"eslint",
+			`const fs=require("node:fs");fs.writeFileSync(${JSON.stringify(
+				eslintMarker,
+			)},"ran");process.exit(1);`,
+		);
+
+		let oxcDoneAtResolve = true;
+		const code = await executeStaged(
+			[{ args: [], bin: "oxlint", env: {}, label: "oxc" }],
+			directory,
+			() => {
+				oxcDoneAtResolve = fs.existsSync(oxcMarker);
+				return [{ args: [], bin: "eslint", env: {}, label: "typed" }];
+			},
+		);
+
+		// oxlint only writes its marker after 250ms, so the resolver running
+		// before it appeared — and the marker existing afterwards — is the
+		// eager child linting through the deferred planning step.
+		expect(oxcDoneAtResolve).toBe(false);
+		expect(fs.existsSync(oxcMarker)).toBe(true);
+		expect(code).toBe(1);
+	}, 15_000);
+
+	it("skips the deferred group when the resolver plans nothing", async () => {
+		expect.assertions(2);
+
+		const directory = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-staged-"));
+		onTestFinished(() => {
+			fs.rmSync(directory, { force: true, recursive: true });
+		});
+		writeFakeToolBin(directory, "oxlint", "process.exit(0);");
+
+		let resolverCalls = 0;
+		const code = await executeStaged(
+			[{ args: [], bin: "oxlint", env: {}, label: "oxc" }],
+			directory,
+			() => {
+				resolverCalls += 1;
+				return [];
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(resolverCalls).toBe(1);
 	}, 15_000);
 });
 


### PR DESCRIPTION
`isentinel-lint` did all of its planning I/O before spawning anything, so every child waited behind `computeAffectedFiles` — a full TypeScript incremental program construction. Profiled on this repo (341 lintable files, caches warm):

| phase | ms |
|---|---|
| node boot + module load | 150 |
| `collectRepoFiles` (git) | 92 |
| `computeConfigHash` | 368 |
| `resolveIgnoredFiles` (memo hit) | 198 |
| **`computeAffectedFiles` (TS builder)** | **2329** |

That 2.3s is unconditional — the measured run returned `affected=0, firstRun=false`, i.e. it built a whole program to learn nothing had changed. 98% of it is the single `createEmitAndSemanticDiagnosticsBuilderProgram` call.

Neither the oxlint child nor the syntactic fast pass reads that result. Only the type-aware pass sizes from it (`sizing.ts`, via `applyTypeAwareInvalidation`).

## What changed

`plan()` returns a staged plan — the eager children, plus a closure that sizes the builder-backed passes. The builder now runs while oxlint and the fast pass are already linting.

**Time to first spawn: ~2.9s → ~0.7s.**

## What deliberately did not move

Every bust (`CONFIG_DRIFT`, `PACKAGE_RESOLUTION`), `sweepStaleCaches()`, the hybrid gate and `resolveIgnoredFiles` still run up front, in the same order, before anything spawns. A child must never lint against a cache a later bust is about to delete, and the ignore set feeds both passes'"'"' sizing. Only the builder-backed sizing is deferred.

Staging is refused in four cases: `--print` (mutates nothing, must stay pure — verified byte-identical output across four flag variants), `--fix` (sequential), no eager child at all, and a lone eager child that the typed pass'"'"'s auto-skip could leave by itself — that child keeps its inherited stdio rather than being committed to the piped harness for no gain.

## Output ordering

`concurrently()` spawns every command synchronously when called, so the deferred child cannot join the first group, and two independent groups would each stream their own index-0 child live and interleave mid-report.

The deferred group therefore gets a held `Writable`, released only once the eager group has settled. Since `group: true` flushes by declaration order and the typed child was always declared last, this reproduces the existing ordering exactly rather than approximating it.

`multiPass` moved into `SizingInputs`: the typed pass sized alone in the deferred stage would otherwise read as the run'"'"'s only pass and never auto-skip.

## Also

Children announce themselves on stderr as they spawn — the only signal a run is alive during the planning work that remains.

## Testing

- `test/lint-cli.spec.ts` + `test/lint-cli-invalidation.spec.ts`: **147 passing**, up from 138. New coverage for the staging split, the four refusal cases, and `executeStaged` (including that an eager child is provably still running when the resolver is called).
- Full suite via pre-commit hook: 510 passing, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved lint execution by starting ready checks sooner while preparing later checks in the background.
  - Added clearer notifications when lint commands start.
  - Improved output ordering so results remain grouped and easier to follow.
  - Added staged handling for type-aware and multi-pass lint checks.

- **Bug Fixes**
  - Prevented later lint output from appearing before earlier checks finish.
  - Preserved expected behavior for fix, print, and oxlint-only runs.

- **Tests**
  - Added coverage for staged execution, ordering, deferred checks, and planning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->