### PR TITLE
perf(lint-cli): verify the buildinfo instead of rebuilding the program

### DIFF
--- a/src/lint-cli/lib/cache/package-hash.ts
+++ b/src/lint-cli/lib/cache/package-hash.ts
@@ -1,19 +1,20 @@
-// cspell:words typeaware unparseable
+// cspell:words typeaware unparseable buildinfo
 import crypto from "node:crypto";
 import path from "node:path";
 
 import { isRecord } from "../../../guards.ts";
 import { findWorkspaceRoot } from "../files/workspace.ts";
+import { stableStringify } from "../stable-json.ts";
 import { readFileIfPresent } from "../state.ts";
 
 /**
- * Root `package.json` fields whose edits can change the types a consumer's
- * importers see (resolution surface + dependency versions). A change to any of
- * these must invalidate the type-aware caches; unrelated edits (`scripts`,
- * `version`, metadata) must not. `pnpm` (overrides/patchedDependencies) and
+ * `package.json` fields whose edits can change the types a consumer's importers
+ * see (resolution surface + dependency versions). A change to any of these must
+ * invalidate the type-aware caches; unrelated edits (`scripts`, `version`,
+ * metadata) must not. `pnpm` (overrides/patchedDependencies) and
  * `optionalDependencies` can silently swap a resolved version too.
  */
-const RESOLUTION_FIELDS = [
+export const RESOLUTION_FIELDS = [
 	"exports",
 	"imports",
 	"main",
@@ -28,43 +29,26 @@ const RESOLUTION_FIELDS = [
 ] as const;
 
 /**
- * Hash the resolution-relevant fields of the consumer's `package.json` as
- * sorted, stable JSON. When `cwd` sits in a workspace whose root differs, the
- * root `package.json`'s resolution fields fold into the same digest — a hoisted
- * root dependency bump changes the types a sub-package sees even though its own
- * `package.json` text is untouched. Returns `undefined` when there is no
- * readable/parseable local `package.json` (the caller then treats the check as
- * a no-op).
- *
- * @param cwd - The consumer project root.
- * @returns The hex digest, or `undefined` when unavailable.
+ * {@link RESOLUTION_FIELDS} plus `type`, which decides every file's
+ * `impliedFormat` and therefore how its imports resolve. The builder detects a
+ * `type` flip through its own `impliedFormat` comparison, so the mtime/hash
+ * bust never needed it; the buildinfo fast path has no such comparison and must
+ * gate on it (see `computeResolutionGate`).
  */
-export function computePackageJsonHash(cwd: string): string | undefined {
-	const local = resolutionSubset(cwd);
-	if (local === undefined) {
-		return undefined;
-	}
-
-	const combined: Record<string, unknown> = { local };
-	const root = findWorkspaceRoot(cwd);
-	if (root !== cwd) {
-		const rootSubset = resolutionSubset(root);
-		if (rootSubset !== undefined) {
-			combined["root"] = rootSubset;
-		}
-	}
-
-	return crypto.createHash("sha256").update(stableStringify(combined)).digest("hex");
-}
+export const MANIFEST_FIELDS = [...RESOLUTION_FIELDS, "type"] as const;
 
 /**
- * Read a directory's `package.json` and project it down to the resolution
- * fields, or `undefined` when it is absent or unparseable.
+ * Read a directory's `package.json` and project it down to the named fields, or
+ * `undefined` when it is absent or unparseable.
  *
  * @param directory - The directory whose `package.json` to read.
- * @returns The resolution-field subset, or `undefined`.
+ * @param fields - The manifest fields to keep.
+ * @returns The field subset, or `undefined`.
  */
-function resolutionSubset(directory: string): Record<string, unknown> | undefined {
+export function manifestSubset(
+	directory: string,
+	fields: ReadonlyArray<string>,
+): Record<string, unknown> | undefined {
 	const raw = readFileIfPresent(path.join(directory, "package.json"));
 	if (raw === undefined) {
 		return undefined;
@@ -82,7 +66,7 @@ function resolutionSubset(directory: string): Record<string, unknown> | undefine
 	}
 
 	const subset: Record<string, unknown> = {};
-	for (const field of RESOLUTION_FIELDS) {
+	for (const field of fields) {
 		if (Object.hasOwn(parsed, field)) {
 			subset[field] = parsed[field];
 		}
@@ -92,23 +76,31 @@ function resolutionSubset(directory: string): Record<string, unknown> | undefine
 }
 
 /**
- * Serialize a value to JSON with object keys sorted at every depth so the
- * digest is insensitive to key ordering.
+ * Hash the resolution-relevant fields of the consumer's `package.json` as
+ * sorted, stable JSON. When `cwd` sits in a workspace whose root differs, the
+ * root `package.json`'s resolution fields fold into the same digest — a hoisted
+ * root dependency bump changes the types a sub-package sees even though its own
+ * `package.json` text is untouched. Returns `undefined` when there is no
+ * readable/parseable local `package.json` (the caller then treats the check as
+ * a no-op).
  *
- * @param value - The value to stringify.
- * @returns The stable JSON string.
+ * @param cwd - The consumer project root.
+ * @returns The hex digest, or `undefined` when unavailable.
  */
-function stableStringify(value: unknown): string {
-	if (Array.isArray(value)) {
-		return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+export function computePackageJsonHash(cwd: string): string | undefined {
+	const local = manifestSubset(cwd, RESOLUTION_FIELDS);
+	if (local === undefined) {
+		return undefined;
 	}
 
-	if (isRecord(value)) {
-		const entries = Object.keys(value)
-			.sort()
-			.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`);
-		return `{${entries.join(",")}}`;
+	const combined: Record<string, unknown> = { local };
+	const root = findWorkspaceRoot(cwd);
+	if (root !== cwd) {
+		const rootSubset = manifestSubset(root, RESOLUTION_FIELDS);
+		if (rootSubset !== undefined) {
+			combined["root"] = rootSubset;
+		}
 	}
 
-	return JSON.stringify(value);
+	return crypto.createHash("sha256").update(stableStringify(combined)).digest("hex");
 }

--- a/src/lint-cli/lib/files/workspace.ts
+++ b/src/lint-cli/lib/files/workspace.ts
@@ -1,5 +1,11 @@
+// cspell:words unparseable
 import fs from "node:fs";
 import path from "node:path";
+import picomatch from "picomatch";
+
+import { isRecord } from "../../../guards.ts";
+import { toPosix } from "../paths.ts";
+import { readFileIfPresent } from "../state.ts";
 
 /**
  * Markers that identify a repository or pnpm-workspace root. `.git` may be a
@@ -7,6 +13,47 @@ import path from "node:path";
  * both.
  */
 const WORKSPACE_ROOT_MARKERS = [".git", "pnpm-workspace.yaml"] as const;
+
+/**
+ * Workspace manifests {@link findWorkspaceMembers} reads package globs from.
+ */
+const PNPM_WORKSPACE_FILES = ["pnpm-workspace.yaml", "pnpm-workspace.yml"] as const;
+
+/**
+ * Directories the member walk never descends into. Deliberately minimal:
+ * skipping a directory that turns out to hold a workspace member would make
+ * that member's `package.json` invisible to the gate, which is the unsafe
+ * direction. Neither of these can ever be one — pnpm refuses a package under
+ * `node_modules`, and `.git` holds no manifest.
+ */
+const SKIPPED_DIRECTORIES = new Set([".git", "node_modules"]);
+
+/** Matches the top-level `packages:` key of a `pnpm-workspace.yaml`. */
+const PACKAGES_KEY_PATTERN = /^packages\s*:/;
+
+/** Matches one block-sequence item, capturing everything after its `-`. */
+const SEQUENCE_ITEM_PATTERN = /^[\t ]*-[\t ]*(\S.*)$/;
+
+/** Matches a scalar that opens YAML structure rather than a plain value. */
+const YAML_STRUCTURE_PATTERN = /^[&*{[]/;
+
+/** Splits a YAML file into lines, tolerating CRLF. */
+const LINE_PATTERN = /\r?\n/;
+
+/**
+ * Deepest directory level the member walk visits when a pattern uses `**`,
+ * which otherwise has no bounded depth. Every real workspace layout nests
+ * members within a few segments of the root.
+ */
+const GLOBSTAR_DEPTH = 4;
+
+/**
+ * How many directory entries the member walk may look at before giving up.
+ * Exhausting it yields `undefined` rather than a partial list: a partial list
+ * reads as "these are all the members", which would silently drop the very
+ * sibling whose manifest the caller needs to watch.
+ */
+const WALK_BUDGET = 8192;
 
 /**
  * Walk up from `cwd` to the nearest directory that looks like a repository or
@@ -35,4 +82,237 @@ export function findWorkspaceRoot(cwd: string): string {
 
 		current = parent;
 	}
+}
+
+/**
+ * Every workspace member directory reachable from `root`: the directories its
+ * package globs match that actually hold a `package.json`. A repository with no
+ * workspace manifest yields an empty list.
+ *
+ * Returns `undefined` when the member set cannot be established — the globs are
+ * present but unparseable, or the walk outgrew {@link WALK_BUDGET}. Callers
+ * treat that as "unknown" and fall back to whatever they do without the member
+ * list, never as "there are none".
+ *
+ * Negated patterns are dropped rather than applied, so an excluded directory
+ * that still holds a manifest is reported as a member. Over-reporting only
+ * costs an extra manifest read and a gate that churns slightly more often;
+ * under-reporting would hide a real resolution change.
+ *
+ * @param root - The workspace root (see {@link findWorkspaceRoot}).
+ * @returns The absolute member directories, or `undefined` when unknown.
+ */
+export function findWorkspaceMembers(root: string): Array<string> | undefined {
+	const patterns = readWorkspacePatterns(root);
+	if (patterns === undefined) {
+		return undefined;
+	}
+
+	const positive = patterns.filter((pattern) => !pattern.startsWith("!"));
+	if (positive.length === 0) {
+		return [];
+	}
+
+	const isMember = picomatch(positive, { dot: true });
+	const maxDepth = Math.max(...positive.map((pattern) => patternDepth(pattern)));
+	const members: Array<string> = [];
+	let budget = WALK_BUDGET;
+
+	/**
+	 * Visit one directory level, recording members and recursing while the
+	 * deepest pattern can still match below.
+	 *
+	 * @param directory - The absolute directory to scan.
+	 * @param depth - How many segments below the root it sits.
+	 * @returns False when the walk ran out of budget.
+	 */
+	function walk(directory: string, depth: number): boolean {
+		let entries: Array<fs.Dirent>;
+		try {
+			entries = fs.readdirSync(directory, { withFileTypes: true });
+		} catch {
+			return true;
+		}
+
+		for (const entry of entries) {
+			if (!entry.isDirectory() || SKIPPED_DIRECTORIES.has(entry.name)) {
+				continue;
+			}
+
+			budget -= 1;
+			if (budget < 0) {
+				return false;
+			}
+
+			const absolute = path.join(directory, entry.name);
+			const relative = toPosix(path.relative(root, absolute));
+			if (isMember(relative) && fs.existsSync(path.join(absolute, "package.json"))) {
+				members.push(absolute);
+			}
+
+			if (depth < maxDepth && !walk(absolute, depth + 1)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	return walk(root, 1) ? members : undefined;
+}
+
+/**
+ * Reduce one YAML sequence item to its scalar value: strip matching quotes, or
+ * cut an unquoted scalar at its trailing comment. Anything left holding YAML
+ * structure — a nested mapping, a flow collection, an anchor or alias — is
+ * rejected. A leading `*` is an alias, but `*` anywhere later is just a glob.
+ *
+ * @param item - The raw text after the item's `-`.
+ * @returns The scalar, or `undefined` when it is not a plain one.
+ */
+function unquote(item: string): string | undefined {
+	const [first] = item;
+	if (first === '"' || first === "'") {
+		const end = item.indexOf(first, 1);
+		return end === -1 ? undefined : item.slice(1, end);
+	}
+
+	const [head = ""] = item.split(" #", 1);
+	const value = head.trim();
+	if (value === "" || YAML_STRUCTURE_PATTERN.test(value) || value.includes(": ")) {
+		return undefined;
+	}
+
+	return value;
+}
+
+/**
+ * Read a one-line flow sequence (`packages: ["a/*", "b/*"]`), which is JSON as
+ * long as its scalars are double-quoted — the only form worth accepting here,
+ * since anything else is better handled by declining.
+ *
+ * @param inline - The text after the `packages:` key.
+ * @returns The glob patterns, or `undefined` when it is not plain JSON.
+ */
+function parseFlowSequence(inline: string): Array<string> | undefined {
+	let flow: unknown;
+	try {
+		flow = JSON.parse(inline);
+	} catch {
+		return undefined;
+	}
+
+	if (!Array.isArray(flow)) {
+		return undefined;
+	}
+
+	return flow.every((item) => typeof item === "string") ? flow : undefined;
+}
+
+/**
+ * Read the top-level `packages:` sequence out of a `pnpm-workspace.yaml`
+ * without a YAML parser — the key is always at column zero and its items are
+ * plain scalars, in both the block and flow forms pnpm accepts. A file with no
+ * `packages:` key declares no members.
+ *
+ * @param text - The workspace file's content.
+ * @returns The glob patterns, or `undefined` when the key is unparseable.
+ */
+function parsePnpmPackages(text: string): Array<string> | undefined {
+	const lines = text.split(LINE_PATTERN);
+	const index = lines.findIndex((line) => PACKAGES_KEY_PATTERN.test(line));
+	if (index === -1) {
+		return [];
+	}
+
+	const header = lines[index] ?? "";
+	const inline = header.slice(header.indexOf(":") + 1).trim();
+	if (inline.startsWith("[")) {
+		return parseFlowSequence(inline);
+	}
+
+	if (inline !== "" && !inline.startsWith("#")) {
+		return undefined;
+	}
+
+	const items: Array<string> = [];
+	const body = lines.slice(index + 1);
+	for (const line of body) {
+		const trimmed = line.trim();
+		if (trimmed === "" || trimmed.startsWith("#")) {
+			continue;
+		}
+
+		const item = SEQUENCE_ITEM_PATTERN.exec(line)?.[1];
+		if (item === undefined) {
+			break;
+		}
+
+		const scalar = unquote(item);
+		if (scalar === undefined) {
+			return undefined;
+		}
+
+		items.push(scalar);
+	}
+
+	return items;
+}
+
+/**
+ * The package globs a workspace root declares, from `pnpm-workspace.yaml` or
+ * the npm/yarn `workspaces` field. An empty list means "no members";
+ * `undefined` means the declaration exists but could not be read.
+ *
+ * @param root - The directory whose workspace declaration to read.
+ * @returns The glob patterns, or `undefined` when undeterminable.
+ */
+function readWorkspacePatterns(root: string): Array<string> | undefined {
+	for (const name of PNPM_WORKSPACE_FILES) {
+		const raw = readFileIfPresent(path.join(root, name));
+		if (raw !== undefined) {
+			return parsePnpmPackages(raw);
+		}
+	}
+
+	const manifest = readFileIfPresent(path.join(root, "package.json"));
+	if (manifest === undefined) {
+		return [];
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(manifest);
+	} catch {
+		return undefined;
+	}
+
+	if (!isRecord(parsed)) {
+		return undefined;
+	}
+
+	const { workspaces } = parsed;
+	if (workspaces === undefined) {
+		return [];
+	}
+
+	// npm and yarn both accept a bare array of globs; yarn also accepts the
+	// object form, which nests them under `packages`.
+	const globs = isRecord(workspaces) ? workspaces["packages"] : workspaces;
+	if (!Array.isArray(globs)) {
+		return undefined;
+	}
+
+	return globs.every((glob) => typeof glob === "string") ? globs : undefined;
+}
+
+/**
+ * How many directory levels below the root a pattern can match at.
+ *
+ * @param pattern - One workspace package glob.
+ * @returns The deepest level the walk must reach for it.
+ */
+function patternDepth(pattern: string): number {
+	const segments = pattern.split("/").filter((segment) => segment !== "" && segment !== ".");
+	return segments.includes("**") ? GLOBSTAR_DEPTH : Math.max(segments.length, 1);
 }

--- a/src/lint-cli/lib/stable-json.ts
+++ b/src/lint-cli/lib/stable-json.ts
@@ -1,0 +1,24 @@
+import { isRecord } from "../../guards.ts";
+
+/**
+ * Serialize a value to JSON with object keys sorted at every depth so a digest
+ * taken over it is insensitive to key ordering. Shared by every hash in the CLI
+ * that digests a parsed object rather than raw file text.
+ *
+ * @param value - The value to stringify.
+ * @returns The stable JSON string.
+ */
+export function stableStringify(value: unknown): string {
+	if (Array.isArray(value)) {
+		return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+	}
+
+	if (isRecord(value)) {
+		const entries = Object.keys(value)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`);
+		return `{${entries.join(",")}}`;
+	}
+
+	return JSON.stringify(value);
+}

--- a/src/lint-cli/lib/typescript/affected.ts
+++ b/src/lint-cli/lib/typescript/affected.ts
@@ -1,5 +1,5 @@
-// cspell:words tsbuildinfo typeaware buildinfo mtimes normalised stabilise
-// cspell:words unparseable slugified sanitise optimisation unsuffixed
+// cspell:words tsbuildinfo tsgate typeaware buildinfo mtimes normalised
+// cspell:words stabilise unparseable slugified sanitise optimisation unsuffixed
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
@@ -10,7 +10,9 @@ import type { TypeAwareMode } from "../cli/types.ts";
 import { CACHE_KEY_LENGTH } from "../context.ts";
 import type { RunContext } from "../context.ts";
 import { toPosix } from "../paths.ts";
-import { stateDirectory, statePath } from "../state.ts";
+import { stateDirectory, statePath, writeState } from "../state.ts";
+import { isBuildInfoUnchanged } from "./buildinfo.ts";
+import { buildGateValue, computeResolutionGate } from "./gate.ts";
 import { loadTypescript } from "./load.ts";
 
 /** Result of a builder pass over the consumer's program. */
@@ -42,8 +44,15 @@ interface ResolvedProject {
 interface BuilderRun {
 	/** The variant's buildinfo file (see {@link builderStatePath}). */
 	buildInfoPath: string;
+	/** The buildinfo's gate state file (see {@link gateStatePath}). */
+	gatePath: string;
 	/** The resolved project to build (see {@link collectProjects}). */
 	project: ResolvedProject;
+	/**
+	 * The run's resolution digest (see `computeResolutionGate`), or `undefined`
+	 * when it could not be computed — which disables the fast path.
+	 */
+	resolutionGate: string | undefined;
 	/** The resolved TypeScript module. */
 	ts: typeof TypeScript;
 }
@@ -111,12 +120,19 @@ export function computeAffectedFiles(
 		// here rather than once per builder.
 		fs.mkdirSync(stateDirectory(cwd), { recursive: true });
 
+		// One digest for the whole run: the manifests and lockfiles it reads are
+		// the consumer's, not any single project's, and a solution can hold
+		// dozens of projects.
+		const resolutionGate = computeResolutionGate(cwd);
+
 		const affected = new Set<string>();
 		let warmProjects = 0;
 		for (const project of projects) {
 			const result = runBuilder({
 				buildInfoPath: builderStatePath(cwd, mode, key, project.id),
+				gatePath: gateStatePath(cwd, mode, key, project.id),
 				project,
+				resolutionGate,
 				ts,
 			});
 
@@ -173,6 +189,38 @@ function builderStatePath(
 ): string {
 	const suffix = mode === "only" ? "typeaware" : "full";
 	return statePath(cwd, "tsbuildinfo", suffix, key, projectId);
+}
+
+/**
+ * Resolve the gate state paired with one {@link builderStatePath} buildinfo:
+ * the resolution and compiler-option digest that was true when the builder last
+ * made that buildinfo describe the program.
+ *
+ * Written by the builder path only, never by the fast path, and never through
+ * `swapState`. A compare-and-swap here would consume the change at read time
+ * and open a hole with no symptom: an option flip would store the new digest,
+ * fall through to the builder, and — if that builder then threw — leave the
+ * buildinfo un-advanced with a gate that already claims to describe it. Every
+ * later run would fast-path against state nothing ever updated.
+ *
+ * Named apart from the `tsbuildinfo-` prefix rather than suffixed onto it so
+ * anything enumerating a variant's buildinfo files does not pick this up as
+ * one.
+ *
+ * @param cwd - The consumer project root.
+ * @param mode - The active ESLint type-aware mode (never `"off"` here).
+ * @param key - The config-variant key from `resolveCacheKey`.
+ * @param projectId - {@link projectDigest} of the project's tsconfig.
+ * @returns The absolute path to the gate state file.
+ */
+function gateStatePath(
+	cwd: string,
+	mode: TypeAwareMode | undefined,
+	key: string,
+	projectId: string,
+): string {
+	const suffix = mode === "only" ? "typeaware" : "full";
+	return statePath(cwd, "tsgate", suffix, key, projectId);
 }
 
 /**
@@ -350,6 +398,11 @@ function collectAffected(
  * degrades to a source-text hash and every implementation-only edit invalidates
  * all its importers.
  *
+ * The buildinfo is written through a temp file and a rename. It has a second
+ * reader now — {@link isBuildInfoUnchanged} parses it directly — and parallel
+ * per-package lints share this directory, so a half-written file would be read
+ * back as unparseable rather than merely re-emitted by the next builder.
+ *
  * @param builder - The drained builder program.
  * @param buildInfoPath - The variant's buildinfo file.
  */
@@ -359,20 +412,60 @@ function persistBuilderState(
 ): void {
 	const normalizedBuildInfo = path.normalize(buildInfoPath);
 	builder.emit(undefined, (fileName, data) => {
-		if (path.normalize(fileName) === normalizedBuildInfo) {
-			fs.writeFileSync(fileName, data);
+		if (path.normalize(fileName) !== normalizedBuildInfo) {
+			return;
+		}
+
+		const temporary = `${fileName}.${process.pid}.tmp`;
+		try {
+			fs.writeFileSync(temporary, data);
+			fs.renameSync(temporary, fileName);
+		} catch (err) {
+			fs.rmSync(temporary, { force: true });
+			throw err;
 		}
 	});
+}
+
+/**
+ * Record the gate the buildinfo was just persisted under, or remove it when the
+ * gate could not be computed. Removal matters: a leftover value from an earlier
+ * run would describe a resolution surface nothing has re-verified since.
+ *
+ * @param gatePath - The gate state file (see {@link gateStatePath}).
+ * @param gateValue - The gate this run computed, or `undefined`.
+ */
+function writeGateState(gatePath: string, gateValue: string | undefined): void {
+	if (gateValue === undefined) {
+		fs.rmSync(gatePath, { force: true });
+		return;
+	}
+
+	writeState(gatePath, gateValue);
 }
 
 /**
  * Drive the incremental builder: read prior state, drain the affected set
  * without reporting diagnostics, then persist updated state.
  *
- * @param build - The project, its state file, and the run's shared handles.
+ * A warm run whose buildinfo still describes the working tree exactly
+ * ({@link isBuildInfoUnchanged}) short-circuits before any program is
+ * constructed. That is the common case — a lint run where the previous one
+ * already saw every edit — and constructing the program only to learn it costs
+ * over a second on this repo, against under a tenth of that to verify the
+ * buildinfo. The short circuit is strictly read-only: it persists nothing,
+ * which is exactly what the builder does when it finds nothing affected.
+ *
+ * @param build - The project, its state files, and the run's shared handles.
  * @returns The affected result.
  */
-function runBuilder({ buildInfoPath, project, ts }: BuilderRun): AffectedResult {
+function runBuilder({
+	buildInfoPath,
+	gatePath,
+	project,
+	resolutionGate,
+	ts,
+}: BuilderRun): AffectedResult {
 	const firstRun = !fs.existsSync(buildInfoPath);
 
 	// Force the settings the shape-hash BFS depends on:
@@ -380,6 +473,12 @@ function runBuilder({ buildInfoPath, project, ts }: BuilderRun): AffectedResult 
 	//   its emitted `.d.ts` rather than raw source text, so a body-only edit
 	//   (unchanged public surface) does NOT propagate to importers. Without it,
 	//   the hash is the full-text hash and every dependent is invalidated.
+	// - `emitDeclarationOnly: true` drops JS emission, halving the outputs the
+	//   persist produces only to throw away (measured on this repo: 428 files
+	//   and 1.8MB down to 217 and 0.6MB). The shape hash is derived from the
+	//   `.d.ts`, so nothing the BFS reads is lost. It buys no wall-clock time —
+	//   the emit's cost is the declaration work, not the writing — so do not
+	//   read it as a performance setting the fast path can lean on.
 	// - `incremental: true` + `tsBuildInfoFile` persist state in OUR cache dir.
 	// - `composite`/`declarationMap` off, `noEmit` false: see
 	//   {@link persistBuilderState} for why we emit and what happens to it.
@@ -399,11 +498,25 @@ function runBuilder({ buildInfoPath, project, ts }: BuilderRun): AffectedResult 
 		composite: false,
 		declaration: true,
 		declarationMap: false,
-		emitDeclarationOnly: false,
+		emitDeclarationOnly: true,
 		incremental: true,
 		noEmit: false,
 		tsBuildInfoFile: buildInfoPath,
 	};
+
+	const gateValue = buildGateValue(resolutionGate, options);
+	if (
+		!firstRun &&
+		isBuildInfoUnchanged({
+			buildInfoPath,
+			fileNames: project.fileNames,
+			gatePath,
+			gateValue,
+			ts,
+		})
+	) {
+		return { affected: new Set(), firstRun: false };
+	}
 
 	const host = ts.createIncrementalCompilerHost(options, ts.sys);
 	const oldProgram = ts.readBuilderProgram(options, host);
@@ -436,6 +549,12 @@ function runBuilder({ buildInfoPath, project, ts }: BuilderRun): AffectedResult 
 	if (touched) {
 		persistBuilderState(builder, buildInfoPath);
 	}
+
+	// Only now, with the buildinfo known to describe the tree this run saw, is
+	// the gate allowed to move. Writing it earlier (or swapping it on read)
+	// would let a throw between the two leave a gate vouching for a buildinfo
+	// the builder never advanced.
+	writeGateState(gatePath, gateValue);
 
 	return { affected, firstRun };
 }

--- a/src/lint-cli/lib/typescript/affected.ts
+++ b/src/lint-cli/lib/typescript/affected.ts
@@ -501,7 +501,7 @@ function runBuilder({
 		emitDeclarationOnly: true,
 		incremental: true,
 		noEmit: false,
-		tsBuildInfoFile: buildInfoPath,
+		tsBuildInfoFile: toPosix(buildInfoPath),
 	};
 
 	const gateValue = buildGateValue(resolutionGate, options);

--- a/src/lint-cli/lib/typescript/buildinfo.ts
+++ b/src/lint-cli/lib/typescript/buildinfo.ts
@@ -1,0 +1,384 @@
+// cspell:words tsbuildinfo buildinfo unparseable
+import path from "node:path";
+import type * as TypeScript from "typescript";
+
+import { isRecord } from "../../../guards.ts";
+import { toPosix } from "../paths.ts";
+import { readFileIfPresent, readState } from "../state.ts";
+
+/** What {@link isBuildInfoUnchanged} needs to verify one project's state. */
+export interface BuildInfoCheck {
+	/** The variant's `.tsbuildinfo` file. */
+	buildInfoPath: string;
+	/** The absolute root file names the builder would compile. */
+	fileNames: Array<string>;
+	/** The state file holding the gate the builder last persisted under. */
+	gatePath: string;
+	/** The gate this run computed, or `undefined` when it is unknown. */
+	gateValue: string | undefined;
+	/** The resolved TypeScript module. */
+	ts: typeof TypeScript;
+}
+
+/**
+ * The fields of an incremental `.tsbuildinfo` this check reads. Every one is
+ * `unknown`: the file is untrusted input, so the check validates what it needs
+ * and treats any surprise as "cannot verify".
+ */
+interface IncrementalBuildInfo {
+	affectedFilesPendingEmit?: unknown;
+	changeFileSet?: unknown;
+	checkPending?: unknown;
+	fileInfos?: unknown;
+	fileNames?: unknown;
+	options?: unknown;
+	pendingEmit?: unknown;
+	resolvedRoot?: unknown;
+	root?: unknown;
+	version?: unknown;
+}
+
+/** The parts of a usable incremental buildinfo this check reads. */
+interface BuildInfoShape {
+	/** The `fileInfos` entries, positionally paired with the names. */
+	fileInfos: Array<unknown>;
+	/** Every file in the program, relative to the buildinfo's directory. */
+	names: Array<string>;
+	/** The run-length-encoded root file ids (see {@link rootsMatch}). */
+	root: unknown;
+}
+
+/**
+ * TypeScript's own source-text version hash — the exact function that produced
+ * the `fileInfos[].version` values in the buildinfo. It is on the runtime `ts`
+ * object but absent from `typescript.d.ts`, so it is reached through one
+ * narrowing here rather than reimplemented: a local copy would have to track
+ * the compiler's inline-source-map stripping and hash choice, and would fail
+ * silently (never matching, so never taking the fast path) if it ever drifted.
+ */
+type HashFromText = (host: TypeScript.System, text: string) => string;
+
+/**
+ * Whether the program described by an existing `.tsbuildinfo` is exactly the
+ * one this run would compile — the question a full builder pass answers by
+ * constructing a program, which on a large project costs seconds.
+ *
+ * TypeScript decides a file changed (`createBuilderProgramState`) when it is
+ * absent from the old state, when its source-text `version` hash differs, when
+ * its `impliedFormat` differs, when its `referencedMap` entry differs, or when
+ * a file it referenced was deleted; plus, an old-state file that has left the
+ * program and `affectsGlobalScope` invalidates everything. The
+ * semantic-affected iterator is driven solely by that changed set, so nothing
+ * else can produce an affected file — compiler-option drift included.
+ *
+ * This check reproduces the `version` test exactly (using TypeScript's own
+ * hash, over text read through `ts.sys` so encodings and BOMs are handled the
+ * way the compiler handles them) and the membership test for root files. It is
+ * structurally blind to `impliedFormat` drift, `referencedMap` drift and
+ * referenced-file deletion, all of which are resolution effects — the caller's
+ * gate ({@link BuildInfoCheck.gateValue}, see `computeResolutionGate`) covers
+ * those by digesting the manifests and lockfiles that decide resolution, and a
+ * mismatching gate bails to the builder.
+ *
+ * Three residual gaps are accepted rather than covered, because closing them
+ * costs the program construction this check exists to avoid:
+ *
+ * - An in-repo file that is not a root but shadows resolution: an ambient
+ *   `.d.ts` added outside `include`, or a new `index.ts` that outranks a
+ *   sibling of the same name.
+ * - A hand-edited `node_modules` with no lockfile change.
+ * - A pnpm store whose old link directories survive an update, so the paths the
+ *   buildinfo names keep hashing clean. The lockfile hash in the gate moved,
+ *   which is what catches it.
+ *
+ * Returns false — never throws — for every failure mode: a missing, torn,
+ * truncated or foreign-version file, an unreadable source, pending emit work,
+ * an `outFile` buildinfo, or symlinked roots.
+ *
+ * @param check - The buildinfo, its gate, and the roots to compare against.
+ * @returns True when nothing the builder would notice has changed.
+ */
+export function isBuildInfoUnchanged({
+	buildInfoPath,
+	fileNames,
+	gatePath,
+	gateValue,
+	ts,
+}: BuildInfoCheck): boolean {
+	try {
+		const hashFromText = resolveHashFromText(ts);
+		if (hashFromText === undefined) {
+			return false;
+		}
+
+		if (gateValue === undefined || readState<string>(gatePath) !== gateValue) {
+			return false;
+		}
+
+		const raw = readFileIfPresent(buildInfoPath);
+		if (raw === undefined) {
+			return false;
+		}
+
+		const parsed: unknown = JSON.parse(raw);
+		if (!isRecord(parsed)) {
+			return false;
+		}
+
+		const info: IncrementalBuildInfo = parsed;
+		const shape = readShape(info, ts);
+		if (shape === undefined) {
+			return false;
+		}
+
+		const directory = path.dirname(buildInfoPath);
+		return (
+			rootsMatch(shape, directory, fileNames, ts) &&
+			versionsMatch(shape, directory, ts, hashFromText)
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * The compiler's version hash, or `undefined` when this TypeScript predates it
+ * and the caller must take the builder path.
+ *
+ * @param ts - The resolved TypeScript module.
+ * @returns The hash function (see {@link HashFromText}).
+ */
+function resolveHashFromText({
+	getSourceFileVersionAsHashFromText,
+}: typeof TypeScript): HashFromText | undefined {
+	return typeof getSourceFileVersionAsHashFromText === "function"
+		? getSourceFileVersionAsHashFromText
+		: undefined;
+}
+
+/**
+ * Whether a buildinfo list field carries entries. TypeScript omits these fields
+ * entirely when they are empty, so anything present and non-empty is real
+ * pending work.
+ *
+ * @param value - The field's value.
+ * @returns True when the field holds at least one entry.
+ */
+function isNonEmpty(value: unknown): boolean {
+	return Array.isArray(value) ? value.length > 0 : value !== undefined;
+}
+
+/**
+ * Validate the buildinfo's envelope and return its two parallel arrays, or
+ * `undefined` when anything about it disqualifies the fast path: a foreign
+ * compiler version, a non-incremental or `outFile` shape, pending emit or check
+ * work, symlinked roots, or arrays that do not line up.
+ *
+ * Pending work is fatal rather than merely informative: the builder would drain
+ * it and re-persist, so a buildinfo carrying any is not the description of a
+ * settled program.
+ *
+ * @param info - The parsed buildinfo.
+ * @param ts - The resolved TypeScript module.
+ * @returns The file names and file infos, or `undefined` when unusable.
+ */
+function readShape(info: IncrementalBuildInfo, ts: typeof TypeScript): BuildInfoShape | undefined {
+	if (info.version !== ts.version) {
+		return undefined;
+	}
+
+	if (isNonEmpty(info.changeFileSet) || isNonEmpty(info.affectedFilesPendingEmit)) {
+		return undefined;
+	}
+
+	if (info.pendingEmit !== undefined || info.checkPending !== undefined) {
+		return undefined;
+	}
+
+	// A root whose path differs from its resolved path (a symlink) is stored
+	// under the resolved one, so `root` no longer lines up with the config's file
+	// names and the membership comparison below would be meaningless.
+	if (info.resolvedRoot !== undefined) {
+		return undefined;
+	}
+
+	// The `outFile` buildinfo is a different shape entirely: no `referencedMap`,
+	// a `fileInfos` list built from every file rather than the roots, and emit
+	// semantics this check does not model.
+	if (isRecord(info.options) && info.options["outFile"] !== undefined) {
+		return undefined;
+	}
+
+	const { fileInfos, fileNames } = info;
+	if (!Array.isArray(fileNames) || !Array.isArray(fileInfos) || !Array.isArray(info.root)) {
+		return undefined;
+	}
+
+	if (fileNames.length !== fileInfos.length) {
+		return undefined;
+	}
+
+	if (fileNames.some((name) => typeof name !== "string")) {
+		return undefined;
+	}
+
+	return { fileInfos, names: fileNames, root: info.root };
+}
+
+/**
+ * Expand a run-length-encoded file-id list into individual 1-based ids, or
+ * `undefined` when the encoding is not one this understands.
+ *
+ * @param root - The buildinfo's `root` field.
+ * @returns The ids it encodes.
+ */
+function expandRootIds(root: unknown): Array<number> | undefined {
+	if (!Array.isArray(root)) {
+		return undefined;
+	}
+
+	const ids: Array<number> = [];
+	for (const entry of root) {
+		if (typeof entry === "number") {
+			ids.push(entry);
+			continue;
+		}
+
+		if (!Array.isArray(entry)) {
+			return undefined;
+		}
+
+		const [start, end] = entry as Array<unknown>;
+		if (typeof start !== "number" || typeof end !== "number") {
+			return undefined;
+		}
+
+		for (let id = start; id <= end; id += 1) {
+			ids.push(id);
+		}
+	}
+
+	return ids;
+}
+
+/**
+ * Reduce a path to the form both sides of the root comparison are keyed by:
+ * forward slashes, and case-folded only where the filesystem is
+ * case-insensitive.
+ *
+ * @param filePath - The absolute path to canonicalize.
+ * @param ts - The resolved TypeScript module.
+ * @returns The canonical form.
+ */
+function canonical(filePath: string, ts: typeof TypeScript): string {
+	const posix = toPosix(filePath);
+	return ts.sys.useCaseSensitiveFileNames ? posix : posix.toLowerCase();
+}
+
+/**
+ * Whether the buildinfo's root set is exactly the set of files the config
+ * resolves now.
+ *
+ * The comparison uses `root` and not `fileNames`: `fileNames` is every file in
+ * the program — lib files, `node_modules` declarations, transitively imported
+ * sources — so it never equals the config's root list and would reject every
+ * run. `root` stores 1-based ids into `fileNames`, run-length encoded as either
+ * a bare id or a `[start, end]` pair.
+ *
+ * @param shape - The buildinfo's root ids and file names.
+ * @param directory - The directory relative names resolve against.
+ * @param fileNames - The absolute root file names the config resolves.
+ * @param ts - The resolved TypeScript module.
+ * @returns True when both sides hold the same roots.
+ */
+function rootsMatch(
+	{ names, root }: BuildInfoShape,
+	directory: string,
+	fileNames: Array<string>,
+	ts: typeof TypeScript,
+): boolean {
+	const ids = expandRootIds(root);
+	if (ids === undefined) {
+		return false;
+	}
+
+	const stored = new Set<string>();
+	for (const id of ids) {
+		const name = names[id - 1];
+		if (name === undefined) {
+			return false;
+		}
+
+		stored.add(canonical(path.resolve(directory, name), ts));
+	}
+
+	// Both directions: a size check alone would pass a swap of one root for
+	// another, and every root the config lists must be present.
+	if (stored.size !== fileNames.length) {
+		return false;
+	}
+
+	return fileNames.every((name) => stored.has(canonical(path.resolve(name), ts)));
+}
+
+/**
+ * The source-text hash one `fileInfos` entry stores. A file whose version
+ * equals its signature and carries nothing else is serialized as a bare
+ * string; every other file becomes an object holding both.
+ *
+ * @param info - One `fileInfos` entry.
+ * @returns The stored version hash, or `undefined` when the entry is not one.
+ */
+function storedVersion(info: unknown): string | undefined {
+	if (typeof info === "string") {
+		return info;
+	}
+
+	if (!isRecord(info)) {
+		return undefined;
+	}
+
+	const { version } = info;
+	return typeof version === "string" ? version : undefined;
+}
+
+/**
+ * Whether every file the buildinfo describes still hashes to the version stored
+ * for it. A file that has gone missing counts as a mismatch, not an error: the
+ * builder would have reported its dependents affected.
+ *
+ * @param shape - The buildinfo's file names and file infos.
+ * @param directory - The directory relative names resolve against.
+ * @param ts - The resolved TypeScript module.
+ * @param hashFromText - The compiler's own version hash.
+ * @returns True when every stored version still matches the file on disk.
+ */
+function versionsMatch(
+	{ fileInfos, names }: BuildInfoShape,
+	directory: string,
+	ts: typeof TypeScript,
+	hashFromText: HashFromText,
+): boolean {
+	for (const [index, name] of names.entries()) {
+		const version = storedVersion(fileInfos[index]);
+		if (version === undefined) {
+			return false;
+		}
+
+		// `ts.sys.readFile` and not `fs.readFileSync`: it strips a UTF-8 BOM and
+		// decodes UTF-16 exactly as the compiler does when it computes the hash
+		// this is compared against. Reading the bytes any other way makes every
+		// such file mismatch forever — a silent, permanent fallthrough that
+		// nothing else would report.
+		const text = ts.sys.readFile(path.resolve(directory, name));
+		if (text === undefined) {
+			return false;
+		}
+
+		if (hashFromText(ts.sys, text) !== version) {
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/src/lint-cli/lib/typescript/gate.ts
+++ b/src/lint-cli/lib/typescript/gate.ts
@@ -1,0 +1,115 @@
+// cspell:words buildinfo mtimes relativised
+import crypto from "node:crypto";
+import path from "node:path";
+
+import { MANIFEST_FIELDS, manifestSubset } from "../cache/package-hash.ts";
+import { findWorkspaceMembers, findWorkspaceRoot } from "../files/workspace.ts";
+import { stableStringify } from "../stable-json.ts";
+import { readFileIfPresent } from "../state.ts";
+
+/**
+ * Lockfiles whose content pins which package version — and therefore which
+ * `.d.ts` — every import resolves to. Hashed by content rather than mtime: a
+ * reinstall rewrites mtimes without changing what resolves.
+ */
+const LOCKFILES = [
+	"pnpm-lock.yaml",
+	"package-lock.json",
+	"yarn.lock",
+	"bun.lock",
+	"bun.lockb",
+] as const;
+
+/**
+ * Digest everything outside the `.tsbuildinfo` that can change how a file's
+ * imports resolve, for the buildinfo fast path to gate on.
+ *
+ * The builder notices these through its `referencedMap` comparison — a moved
+ * `exports` target or a flipped `type` re-resolves an import, and the file's
+ * referenced set changes even though its own text did not. The fast path only
+ * compares source-text hashes and root membership, so it is structurally blind
+ * to resolution drift and has to be told about it here instead.
+ *
+ * `computePackageJsonHash` is deliberately not reused: it covers only `cwd` and
+ * the workspace root, omits `type`, and — more importantly — it is consumed by
+ * a compare-and-swap the planner has already run by the time the builder is
+ * asked for an affected set, so reading it here would always say "unchanged".
+ *
+ * Returns `undefined` when any input is undeterminable (no readable local
+ * `package.json`, an unreadable workspace declaration, a member walk that
+ * outgrew its budget). The caller must then take the builder path: a gate that
+ * cannot see the whole resolution surface must not certify it as unchanged.
+ *
+ * @param cwd - The consumer project root.
+ * @returns The hex digest, or `undefined` when it cannot be computed.
+ */
+export function computeResolutionGate(cwd: string): string | undefined {
+	const local = manifestSubset(cwd, MANIFEST_FIELDS);
+	if (local === undefined) {
+		return undefined;
+	}
+
+	const root = findWorkspaceRoot(cwd);
+	const members = findWorkspaceMembers(root);
+	if (members === undefined) {
+		return undefined;
+	}
+
+	const manifests: Record<string, unknown> = { ".": local };
+	for (const directory of [root, ...members]) {
+		// Keyed by the member's path relative to the root so the digest does not
+		// move with the checkout, and sorted by `stableStringify` regardless of
+		// the order the walk found them in.
+		manifests[path.relative(root, directory) || "<root>"] = manifestSubset(
+			directory,
+			MANIFEST_FIELDS,
+		);
+	}
+
+	const lockfiles: Record<string, unknown> = {};
+	const lockfileDirectories = new Set([cwd, root]);
+	for (const directory of lockfileDirectories) {
+		for (const name of LOCKFILES) {
+			const raw = readFileIfPresent(path.join(directory, name));
+			if (raw !== undefined) {
+				lockfiles[`${path.relative(root, directory)}/${name}`] = crypto
+					.createHash("sha256")
+					.update(raw)
+					.digest("hex");
+			}
+		}
+	}
+
+	return crypto
+		.createHash("sha256")
+		.update(stableStringify({ lockfiles, manifests }))
+		.digest("hex");
+}
+
+/**
+ * Combine the run-wide resolution gate with one project's effective compiler
+ * options into the value stored beside its buildinfo.
+ *
+ * The options belong here rather than in the buildinfo comparison because the
+ * buildinfo's own `options` block is a filtered, path-relativised projection
+ * (only `affectsBuildInfo` options survive, and paths are rewritten relative to
+ * the buildinfo directory), so it cannot be compared against the options the
+ * builder was handed.
+ *
+ * @param resolution - The run's resolution gate, or `undefined`.
+ * @param options - The project's effective compiler options.
+ * @returns The gate value, or `undefined` when the resolution gate is unknown.
+ */
+export function buildGateValue(
+	resolution: string | undefined,
+	options: Record<string, unknown>,
+): string | undefined {
+	if (resolution === undefined) {
+		return undefined;
+	}
+
+	return crypto
+		.createHash("sha256")
+		.update(stableStringify({ options, resolution }))
+		.digest("hex");
+}

--- a/src/lint-cli/lib/typescript/typescript-internal.d.ts
+++ b/src/lint-cli/lib/typescript/typescript-internal.d.ts
@@ -1,0 +1,18 @@
+// cspell:words buildinfo
+import type { System } from "typescript";
+
+// One TypeScript export the compiler's public `.d.ts` does not declare, used by
+// `buildinfo.ts`. It has to be reached somehow: it is the exact function that
+// produced the `fileInfos[].version` hashes in a `.tsbuildinfo`, and writing
+// the hash out again locally would mean tracking the compiler's
+// inline-source-map stripping and hash choice — drifting silently, since a
+// wrong hash only ever means "never matches" and so degrades into never taking
+// the fast path.
+//
+// Typed as possibly-undefined, which is the honest shape for an undeclared
+// export: the runtime check that guards it is then a real check rather than
+// something the type system has been told to ignore.
+declare module "typescript" {
+	// eslint-disable-next-line id-length -- The compiler owns this name.
+	const getSourceFileVersionAsHashFromText: ((host: System, text: string) => string) | undefined;
+}

--- a/test/buildinfo-child.ts
+++ b/test/buildinfo-child.ts
@@ -1,0 +1,41 @@
+// cspell:words buildinfo typeaware
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import { resolveRunContext } from "../src/lint-cli/lib/context.ts";
+import { computeAffectedFiles } from "../src/lint-cli/lib/typescript/affected.ts";
+
+/**
+ * Run one builder pass in a process of its own and write the answer to a file.
+ *
+ * The A/B fixtures compare the buildinfo fast path against the real builder,
+ * and both drain state destructively — a shared process would let TypeScript's
+ * own per-process caches make the second answer depend on the first, which is
+ * exactly the independence the comparison is testing for.
+ *
+ * Usage: `node test/buildinfo-child.ts <cwd> <outFile>`.
+ */
+const [cwd = "", outFile = ""] = process.argv.slice(2);
+
+const result = computeAffectedFiles(resolveRunContext(cwd, {}, true), undefined);
+
+/**
+ * Reduce one pass's answer to something a parent process can compare: the
+ * affected paths as sorted, project-relative posix strings.
+ *
+ * @returns The serializable answer.
+ */
+function toPayload(): Record<string, unknown> {
+	if (result === undefined) {
+		return { skipped: true };
+	}
+
+	const affected = Array.from(result.affected, (file) => {
+		return path.relative(cwd, file).split(path.sep).join("/");
+	});
+
+	return { affected: affected.sort(), firstRun: result.firstRun, skipped: false };
+}
+
+fs.writeFileSync(outFile, JSON.stringify(toPayload()));

--- a/test/lint-cli-buildinfo.spec.ts
+++ b/test/lint-cli-buildinfo.spec.ts
@@ -1,4 +1,4 @@
-// cspell:words tsbuildinfo tsgate typeaware buildinfo mojibake
+// cspell:words tsbuildinfo tsgate typeaware buildinfo mojibake unparseable
 import { Buffer } from "node:buffer";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
@@ -400,16 +400,30 @@ describe("buildinfo fast path", () => {
 	});
 
 	it("agrees with the builder on a truncated buildinfo", () => {
-		expect.assertions(2);
+		expect.assertions(3);
+
+		// Corrupt to a fixed unparseable prefix rather than by slicing the real
+		// file: how far into a buildinfo a byte offset lands depends on the path
+		// lengths baked into it, which differ per platform (a fixture whose
+		// `typescript` resolves onto another drive stores absolute names, not
+		// relative ones). A length-derived cut therefore corrupts fatally on one
+		// OS and harmlessly on another.
+		let corrupted = 0;
 
 		const { builder, fast } = compare({
 			mutate: (directory) => {
 				for (const file of stateFiles(directory, "tsbuildinfo")) {
-					fs.writeFileSync(file, fs.readFileSync(file, "utf8").slice(0, 400));
+					fs.writeFileSync(file, '{"version":');
+					corrupted += 1;
 				}
 			},
 			tree: CHAIN,
 		});
+
+		// Both sides must actually have been corrupted; a mutation that silently
+		// matched no state file would make the assertions below pass for the
+		// wrong reason.
+		expect(corrupted).toBe(2);
 
 		// The fast path declines and hands over to the builder, whose own
 		// `readBuilderProgram` then throws on the same file — so the run degrades

--- a/test/lint-cli-buildinfo.spec.ts
+++ b/test/lint-cli-buildinfo.spec.ts
@@ -399,8 +399,8 @@ describe("buildinfo fast path", () => {
 		expect(fastPath).toBe(false);
 	});
 
-	it("agrees with the builder on a truncated buildinfo", () => {
-		expect.assertions(3);
+	it("agrees with the builder on a corrupt buildinfo", () => {
+		expect.assertions(4);
 
 		// Corrupt to a fixed unparseable prefix rather than by slicing the real
 		// file: how far into a buildinfo a byte offset lands depends on the path
@@ -425,14 +425,14 @@ describe("buildinfo fast path", () => {
 		// wrong reason.
 		expect(corrupted).toBe(2);
 
-		// The fast path declines and hands over to the builder, whose own
-		// `readBuilderProgram` then throws on the same file — so the run degrades
-		// to a skipped pass. That is pre-existing behaviour, reproduced here only
-		// to pin that the fast path neither hides it nor adds a throw of its own.
-		// The gate-mtime observable says nothing about a run that aborted before
-		// reaching the write, so this scenario asserts only the answers.
+		// The fast path declines, and the builder recovers: `getBuildInfo` reads
+		// an unparseable file as "no prior state" by design, so the run rebuilds
+		// and reports every file rather than degrading to a skipped pass. Pinned
+		// because a skipped pass silently disables type-aware invalidation, and
+		// nothing downstream would notice.
 		expect(fast).toStrictEqual(builder);
-		expect(fast.skipped).toBe(true);
+		expect(fast.skipped).toBe(false);
+		expect(fast.affected).toStrictEqual(["src/a.ts", "src/b.ts", "src/c.ts"]);
 	});
 
 	it("agrees with the builder after a TypeScript version bump", () => {

--- a/test/lint-cli-buildinfo.spec.ts
+++ b/test/lint-cli-buildinfo.spec.ts
@@ -1,0 +1,781 @@
+// cspell:words tsbuildinfo tsgate typeaware buildinfo mojibake
+import { Buffer } from "node:buffer";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, onTestFinished } from "vitest";
+
+import { isRecord, isStringArray } from "../src/guards.ts";
+
+/** The A/B child (see `test/buildinfo-child.ts`). */
+const CHILD = fileURLToPath(new URL("./buildinfo-child.ts", import.meta.url));
+
+/** Where every state file the runner writes lands inside a fixture. */
+const STATE_DIRECTORY = "node_modules/.cache/isentinel-lint";
+
+/** An mtime far enough in the past that no write could reproduce it. */
+const ANCIENT_SECONDS = 1_000_000_000;
+
+/** The answer the child reports for one builder pass. */
+interface ChildResult {
+	/** Project-relative posix paths the pass reported affected. */
+	affected?: Array<string>;
+	/** Whether the pass established initial state. */
+	firstRun?: boolean;
+	/** True when the builder path was skipped entirely. */
+	skipped: boolean;
+}
+
+/** A fixture's file tree, keyed by project-relative path. */
+type Tree = Record<string, string>;
+
+const TSCONFIG = JSON.stringify({
+	compilerOptions: { module: "commonjs", strict: true, target: "es2020" },
+	include: ["src"],
+});
+
+/** The same config widened to a second root directory. */
+const WIDE_TSCONFIG = JSON.stringify({
+	compilerOptions: { module: "commonjs", strict: true, target: "es2020" },
+	include: ["src", "extra"],
+});
+
+/** `src/a.ts` as the chain fixture ships it. */
+const ORIGINAL_A = "export function a() { return 1; }\n";
+
+/** An edit to `src/a.ts` that changes its inferred return type. */
+const RESHAPED_A = "export function a() { return 'text'; }\n";
+
+/**
+ * The chain fixture: `c` imports `b` imports `a`, with inferred return types.
+ */
+const CHAIN: Tree = {
+	"package.json": JSON.stringify({ name: "fixture", version: "0.0.0" }),
+	"src/a.ts": ORIGINAL_A,
+	"src/b.ts": "import { a } from './a';\nexport function b() { return a(); }\n",
+	"src/c.ts": "import { b } from './b';\nexport function c() { return b(); }\n",
+	"tsconfig.json": TSCONFIG,
+};
+
+/** A workspace whose sibling package is linked from the root. */
+const WORKSPACE: Tree = {
+	"package.json": JSON.stringify({
+		name: "fixture",
+		dependencies: { sibling: "workspace:*" },
+		version: "0.0.0",
+	}),
+	"packages/sibling/index.d.ts": "export declare function sibling(): number;\n",
+	"packages/sibling/package.json": JSON.stringify({
+		name: "sibling",
+		types: "index.d.ts",
+		version: "1.0.0",
+	}),
+	"pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+	"pnpm-workspace.yaml": "packages:\n  - packages/*\n",
+	"src/a.ts": ORIGINAL_A,
+	"tsconfig.json": TSCONFIG,
+};
+
+/** A byte-order mark, which `ts.sys.readFile` strips and `fs` does not. */
+const BOM = "﻿";
+
+/** A fixture whose sources are stored in encodings `fs` would mangle. */
+const ENCODED: Tree = {
+	"package.json": JSON.stringify({ name: "fixture", version: "0.0.0" }),
+	"src/bom.ts": `${BOM}export function bom() { return 1; }\n`,
+	"tsconfig.json": TSCONFIG,
+};
+
+/** A solution-style entry config whose files all live behind references. */
+const SOLUTION: Tree = {
+	"app/b.ts": "import { a } from '../src/a';\nexport function b() { return a(); }\n",
+	"app/tsconfig.json": JSON.stringify({
+		compilerOptions: { composite: true, module: "commonjs", strict: true, target: "es2020" },
+		include: ["."],
+	}),
+	"package.json": JSON.stringify({ name: "fixture", version: "0.0.0" }),
+	"src/a.ts": ORIGINAL_A,
+	"tsconfig.json": JSON.stringify({
+		files: [],
+		include: [],
+		references: [{ path: "./tsconfig.lib.json" }, { path: "./app" }],
+	}),
+	"tsconfig.lib.json": JSON.stringify({
+		compilerOptions: { composite: true, module: "commonjs", strict: true, target: "es2020" },
+		include: ["src"],
+	}),
+};
+
+/** One A/B scenario: what the tree starts as, and what happens to it. */
+interface Scenario {
+	/** The scenario's mutation, applied after both sides are warm. */
+	mutate: (directory: string) => void;
+	/** Extra setup applied before warming, for content a `Tree` cannot hold. */
+	prepare?: (directory: string) => void;
+	/** The fixture's files. */
+	tree: Tree;
+	/** Whether to establish builder state first. Defaults to true. */
+	warm?: boolean;
+}
+
+/** What one A/B comparison observed. */
+interface Comparison {
+	/** The answer from the run forced down the builder path. */
+	builder: ChildResult;
+	/** The answer from the run allowed to take the fast path. */
+	fast: ChildResult;
+	/** Whether the fast side actually short-circuited. */
+	fastPath: boolean;
+}
+
+/**
+ * Write a file, creating its directory.
+ *
+ * @param absolute - The absolute file path.
+ * @param content - The content to write.
+ */
+function writeFile(absolute: string, content: string): void {
+	fs.mkdirSync(path.dirname(absolute), { recursive: true });
+	fs.writeFileSync(absolute, content);
+}
+
+/**
+ * Write out a fixture project with its own resolvable `typescript`.
+ *
+ * @param tree - The files to write, keyed by project-relative path.
+ * @returns The absolute project root.
+ */
+function createFixture(tree: Tree): string {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), "buildinfo-fx-"));
+
+	onTestFinished(() => {
+		fs.rmSync(directory, { force: true, recursive: true });
+	});
+
+	const typescriptDirectory = path.dirname(
+		createRequire(import.meta.url).resolve("typescript/package.json"),
+	);
+	fs.mkdirSync(path.join(directory, "node_modules"), { recursive: true });
+	fs.symlinkSync(
+		fs.realpathSync(typescriptDirectory),
+		path.join(directory, "node_modules", "typescript"),
+		"junction",
+	);
+
+	for (const [relative, content] of Object.entries(tree)) {
+		writeFile(path.join(directory, relative), content);
+	}
+
+	return directory;
+}
+
+/**
+ * Read a JSON file as a record, or an empty one when it holds anything else.
+ *
+ * @param file - The absolute file path.
+ * @returns The parsed object.
+ */
+function readJson(file: string): Record<string, unknown> {
+	const parsed: unknown = JSON.parse(fs.readFileSync(file, "utf8"));
+	return isRecord(parsed) ? parsed : {};
+}
+
+/**
+ * Run one builder pass against a fixture, in a process of its own.
+ *
+ * @param directory - The fixture project root.
+ * @returns The pass's answer.
+ */
+function runPass(directory: string): ChildResult {
+	const outFile = path.join(os.tmpdir(), `buildinfo-ab-${process.pid}-${Math.random()}.json`);
+	try {
+		execFileSync(process.execPath, [CHILD, directory, outFile], {
+			cwd: directory,
+			stdio: ["ignore", "ignore", "pipe"],
+		});
+
+		const { affected, firstRun, skipped } = readJson(outFile);
+		return {
+			affected: isStringArray(affected) ? affected : undefined,
+			firstRun: typeof firstRun === "boolean" ? firstRun : undefined,
+			skipped: skipped === true,
+		};
+	} finally {
+		fs.rmSync(outFile, { force: true });
+	}
+}
+
+/**
+ * Every state file of one kind a fixture holds.
+ *
+ * @param directory - The fixture project root.
+ * @param prefix - The state-file name prefix (`tsbuildinfo` or `tsgate`).
+ * @returns Absolute paths, empty when the state directory is absent.
+ */
+function stateFiles(directory: string, prefix: string): Array<string> {
+	const stateDirectory = path.join(directory, STATE_DIRECTORY);
+	if (!fs.existsSync(stateDirectory)) {
+		return [];
+	}
+
+	return fs
+		.readdirSync(stateDirectory)
+		.filter((name) => name.startsWith(`${prefix}-`))
+		.map((name) => path.join(stateDirectory, name));
+}
+
+/**
+ * Backdate every gate file so a later write is detectable by mtime alone. The
+ * fast path never writes the gate and the builder path always does, which makes
+ * this the one observable that says which path a run took.
+ *
+ * @param directory - The fixture project root.
+ */
+function backdateGates(directory: string): void {
+	for (const file of stateFiles(directory, "tsgate")) {
+		fs.utimesSync(file, ANCIENT_SECONDS, ANCIENT_SECONDS);
+	}
+}
+
+/**
+ * Whether every gate file still carries its backdated mtime — that is, whether
+ * the run took the fast path for every project.
+ *
+ * @param directory - The fixture project root.
+ * @returns True when no gate was rewritten.
+ */
+function tookFastPath(directory: string): boolean {
+	const gates = stateFiles(directory, "tsgate");
+	return (
+		gates.length > 0 &&
+		gates.every((file) => Math.round(fs.statSync(file).mtimeMs / 1000) === ANCIENT_SECONDS)
+	);
+}
+
+/**
+ * Compare the fast path against the real builder on the same scenario.
+ *
+ * Both sides get their own fixture, warmed identically, and the same mutation.
+ * The builder side then loses its gate files, which is the one thing that
+ * forces `isBuildInfoUnchanged` to decline without perturbing the buildinfo
+ * the two sides are being compared over.
+ *
+ * @param scenario - The tree, its setup and its mutation.
+ * @returns The two answers plus whether the fast side short-circuited.
+ */
+function compare({ mutate, prepare, tree, warm = true }: Scenario): Comparison {
+	const builderDirectory = createFixture(tree);
+	const fastDirectory = createFixture(tree);
+
+	for (const directory of [builderDirectory, fastDirectory]) {
+		prepare?.(directory);
+		if (warm) {
+			runPass(directory);
+		}
+
+		mutate(directory);
+	}
+
+	for (const file of stateFiles(builderDirectory, "tsgate")) {
+		fs.rmSync(file, { force: true });
+	}
+
+	backdateGates(fastDirectory);
+	const builder = runPass(builderDirectory);
+	const fast = runPass(fastDirectory);
+
+	return { builder, fast, fastPath: tookFastPath(fastDirectory) };
+}
+
+/** A mutation that changes nothing. */
+function unchanged(): void {
+	// The warm-untouched scenario mutates nothing by design.
+}
+
+/**
+ * Bump a file's mtime without changing its content.
+ *
+ * @param file - The absolute file path.
+ */
+function touch(file: string): void {
+	const future = Date.now() / 1000 + 60;
+	fs.utimesSync(file, future, future);
+}
+
+describe("buildinfo fast path", () => {
+	it("agrees with the builder on a warm, untouched tree", () => {
+		expect.assertions(3);
+
+		const { builder, fast, fastPath } = compare({ mutate: unchanged, tree: CHAIN });
+
+		expect(fast).toStrictEqual(builder);
+		expect(fast.affected).toStrictEqual([]);
+		expect(fastPath).toBe(true);
+	});
+
+	it("agrees with the builder when an mtime moved but the content did not", () => {
+		expect.assertions(3);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				touch(path.join(directory, "src/a.ts"));
+			},
+			tree: CHAIN,
+		});
+
+		expect(fast).toStrictEqual(builder);
+		expect(fast.affected).toStrictEqual([]);
+		// Content-addressed, so a pure mtime bump must not cost a builder pass.
+		expect(fastPath).toBe(true);
+	});
+
+	it("agrees with the builder on a real content change", () => {
+		expect.assertions(3);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				writeFile(path.join(directory, "src/a.ts"), RESHAPED_A);
+			},
+			tree: CHAIN,
+		});
+
+		expect(fast).toStrictEqual(builder);
+		expect(fast.affected).toStrictEqual(["src/a.ts", "src/b.ts", "src/c.ts"]);
+		expect(fastPath).toBe(false);
+	});
+
+	it("agrees with the builder once that change has been persisted", () => {
+		expect.assertions(3);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				writeFile(path.join(directory, "src/a.ts"), RESHAPED_A);
+				runPass(directory);
+			},
+			tree: CHAIN,
+		});
+
+		expect(fast).toStrictEqual(builder);
+		expect(fast.affected).toStrictEqual([]);
+		expect(fastPath).toBe(true);
+	});
+
+	it("agrees with the builder when the tree is restored under a moved buildinfo", () => {
+		expect.assertions(3);
+
+		// The buildinfo ends up describing the *edited* text while the tree holds
+		// the original: a file that reads as unchanged by mtime and as changed by
+		// content, in the direction only the fast path could miss.
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				const fileA = path.join(directory, "src/a.ts");
+				writeFile(fileA, RESHAPED_A);
+				runPass(directory);
+				writeFile(fileA, ORIGINAL_A);
+			},
+			tree: CHAIN,
+		});
+
+		expect(fast).toStrictEqual(builder);
+		expect(fast.affected).toStrictEqual(["src/a.ts", "src/b.ts", "src/c.ts"]);
+		expect(fastPath).toBe(false);
+	});
+
+	it("agrees with the builder on a first run", () => {
+		expect.assertions(3);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: unchanged,
+			tree: CHAIN,
+			warm: false,
+		});
+
+		expect(fast).toStrictEqual(builder);
+		expect(fast.firstRun).toBe(true);
+		expect(fastPath).toBe(false);
+	});
+
+	it("agrees with the builder on a truncated buildinfo", () => {
+		expect.assertions(2);
+
+		const { builder, fast } = compare({
+			mutate: (directory) => {
+				for (const file of stateFiles(directory, "tsbuildinfo")) {
+					fs.writeFileSync(file, fs.readFileSync(file, "utf8").slice(0, 400));
+				}
+			},
+			tree: CHAIN,
+		});
+
+		// The fast path declines and hands over to the builder, whose own
+		// `readBuilderProgram` then throws on the same file — so the run degrades
+		// to a skipped pass. That is pre-existing behaviour, reproduced here only
+		// to pin that the fast path neither hides it nor adds a throw of its own.
+		// The gate-mtime observable says nothing about a run that aborted before
+		// reaching the write, so this scenario asserts only the answers.
+		expect(fast).toStrictEqual(builder);
+		expect(fast.skipped).toBe(true);
+	});
+
+	it("agrees with the builder after a TypeScript version bump", () => {
+		expect.assertions(2);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				for (const file of stateFiles(directory, "tsbuildinfo")) {
+					fs.writeFileSync(file, JSON.stringify({ ...readJson(file), version: "0.0.0" }));
+				}
+			},
+			tree: CHAIN,
+		});
+
+		expect(fast).toStrictEqual(builder);
+		expect(fastPath).toBe(false);
+	});
+});
+
+describe("buildinfo fast path root drift", () => {
+	it("agrees with the builder when a tsconfig include gains a root", () => {
+		expect.assertions(3);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				writeFile(path.join(directory, "tsconfig.json"), WIDE_TSCONFIG);
+			},
+			tree: { ...CHAIN, "extra/d.ts": "export function d() { return 4; }\n" },
+		});
+
+		expect(fast).toStrictEqual(builder);
+		expect(fast.affected).toStrictEqual(["extra/d.ts"]);
+		expect(fastPath).toBe(false);
+	});
+
+	it("agrees with the builder when a tsconfig include loses a root", () => {
+		expect.assertions(2);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				writeFile(path.join(directory, "tsconfig.json"), TSCONFIG);
+			},
+			tree: {
+				...CHAIN,
+				"extra/d.ts": "export function d() { return 4; }\n",
+				"tsconfig.json": WIDE_TSCONFIG,
+			},
+		});
+
+		// A root only ever leaving the set is the direction a one-way membership
+		// check would pass, which is why the comparison runs both ways.
+		expect(fast).toStrictEqual(builder);
+		expect(fastPath).toBe(false);
+	});
+
+	it("agrees with the builder when a root file is deleted", () => {
+		expect.assertions(2);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				fs.rmSync(path.join(directory, "src/lonely.ts"));
+			},
+			tree: {
+				"package.json": JSON.stringify({ name: "fixture", version: "0.0.0" }),
+				"src/a.ts": ORIGINAL_A,
+				"src/lonely.ts": "export function lonely() { return 2; }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+		});
+
+		expect(fast).toStrictEqual(builder);
+		expect(fastPath).toBe(false);
+	});
+
+	it("agrees with the builder when a node_modules declaration is deleted", () => {
+		expect.assertions(2);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				fs.rmSync(path.join(directory, "node_modules/dep/index.d.ts"));
+			},
+			tree: {
+				"node_modules/dep/index.d.ts": "export declare function dep(): number;\n",
+				"node_modules/dep/package.json": JSON.stringify({
+					name: "dep",
+					types: "index.d.ts",
+					version: "1.0.0",
+				}),
+				"package.json": JSON.stringify({ name: "fixture", version: "0.0.0" }),
+				"src/a.ts": "import { dep } from 'dep';\nexport function a() { return dep(); }\n",
+				"tsconfig.json": TSCONFIG,
+			},
+		});
+
+		// A deleted dependency declaration is a mismatch to find, never a throw.
+		expect(fast).toStrictEqual(builder);
+		expect(fastPath).toBe(false);
+	});
+});
+
+describe("buildinfo fast path resolution gate", () => {
+	it("falls through when only the lockfile moved", () => {
+		expect.assertions(2);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				writeFile(
+					path.join(directory, "pnpm-lock.yaml"),
+					"lockfileVersion: '9.0'\nimporters:\n  .: {}\n",
+				);
+			},
+			tree: WORKSPACE,
+		});
+
+		// Nothing in the tree changed, so both answers are empty — but the fast
+		// path must not be the one that says so: a dependency swap leaves every
+		// retained store path hashing clean, and only the lockfile records it.
+		expect(fast).toStrictEqual(builder);
+		expect(fastPath).toBe(false);
+	});
+
+	it("falls through when the package type flips", () => {
+		expect.assertions(2);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				writeFile(
+					path.join(directory, "package.json"),
+					JSON.stringify({
+						name: "fixture",
+						dependencies: { sibling: "workspace:*" },
+						type: "module",
+						version: "0.0.0",
+					}),
+				);
+			},
+			tree: WORKSPACE,
+		});
+
+		// `type` decides every file's `impliedFormat`, which the builder compares
+		// and the fast path cannot see.
+		expect(fast).toStrictEqual(builder);
+		expect(fastPath).toBe(false);
+	});
+
+	it("falls through when a workspace sibling remaps its exports", () => {
+		expect.assertions(2);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				writeFile(
+					path.join(directory, "packages/sibling/package.json"),
+					JSON.stringify({
+						name: "sibling",
+						exports: { ".": { types: "./other.d.ts" } },
+						types: "index.d.ts",
+						version: "1.0.0",
+					}),
+				);
+			},
+			tree: WORKSPACE,
+		});
+
+		// Neither the lockfile nor any source moves for this, and a sibling's
+		// manifest is in no cache-bust pattern — the gate is the only thing
+		// between it and a stale type-aware cache.
+		expect(fast).toStrictEqual(builder);
+		expect(fastPath).toBe(false);
+	});
+
+	it("still takes the fast path when an unrelated manifest field changes", () => {
+		expect.assertions(2);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				writeFile(
+					path.join(directory, "packages/sibling/package.json"),
+					JSON.stringify({
+						name: "sibling",
+						description: "now documented",
+						types: "index.d.ts",
+						version: "1.0.0",
+					}),
+				);
+			},
+			tree: WORKSPACE,
+		});
+
+		expect(fast).toStrictEqual(builder);
+		expect(fastPath).toBe(true);
+	});
+});
+
+describe("buildinfo fast path unsupported shapes", () => {
+	it("declines an outFile project", () => {
+		expect.assertions(2);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: unchanged,
+			tree: {
+				"package.json": JSON.stringify({ name: "fixture", version: "0.0.0" }),
+				"src/a.ts": ORIGINAL_A,
+				"tsconfig.json": JSON.stringify({
+					compilerOptions: {
+						module: "system",
+						outFile: "./out.js",
+						strict: true,
+						target: "es2020",
+					},
+					include: ["src"],
+				}),
+			},
+		});
+
+		// That buildinfo has no referencedMap and a different fileInfos shape, so
+		// verifying it against this check's model would be meaningless.
+		expect(fast).toStrictEqual(builder);
+		expect(fastPath).toBe(false);
+	});
+});
+
+describe("buildinfo fast path encodings", () => {
+	/**
+	 * Write the UTF-16 source, which a `Tree` cannot carry: fixture trees are
+	 * written as UTF-8.
+	 *
+	 * @param directory - The fixture project root.
+	 * @param body - The body of its exported function.
+	 */
+	function writeUtf16(directory: string, body: string): void {
+		fs.mkdirSync(path.join(directory, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(directory, "src/wide.ts"),
+			Buffer.from(`${BOM}export function wide() { return ${body}; }\n`, "utf16le"),
+		);
+	}
+
+	it("takes the fast path across BOM and UTF-16 sources", () => {
+		expect.assertions(3);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: unchanged,
+			prepare: (directory) => {
+				writeUtf16(directory, "1");
+			},
+			tree: ENCODED,
+		});
+
+		// Reading these with `fs.readFileSync(file, "utf8")` leaves the BOM in
+		// place and turns the UTF-16 file into mojibake, so both hash differently
+		// forever and the fast path silently never fires again.
+		expect(fast).toStrictEqual(builder);
+		expect(fast.affected).toStrictEqual([]);
+		expect(fastPath).toBe(true);
+	});
+
+	it("agrees with the builder on an edit to a UTF-16 source", () => {
+		expect.assertions(3);
+
+		const { builder, fast, fastPath } = compare({
+			mutate: (directory) => {
+				writeUtf16(directory, "2");
+			},
+			prepare: (directory) => {
+				writeUtf16(directory, "1");
+			},
+			tree: ENCODED,
+		});
+
+		expect(fast).toStrictEqual(builder);
+		expect(fast.affected).toStrictEqual(["src/wide.ts"]);
+		expect(fastPath).toBe(false);
+	});
+});
+
+describe("buildinfo fast path across a solution", () => {
+	/**
+	 * Drop the `app` project's state so it is cold while the library project
+	 * stays warm — the mixed shape where one project must take each path.
+	 *
+	 * Which buildinfo is which is found by reading them, not by sorting names:
+	 * each is suffixed with a digest of its tsconfig's (temp-directory) path,
+	 * so the ordering differs between the two sides of a comparison.
+	 *
+	 * @param directory - The fixture project root.
+	 */
+	function coolAppProject(directory: string): void {
+		for (const file of stateFiles(directory, "tsbuildinfo")) {
+			const { fileNames } = readJson(file);
+			if (
+				!isStringArray(fileNames) ||
+				fileNames.every((name) => !name.endsWith("app/b.ts"))
+			) {
+				continue;
+			}
+
+			const suffix = path.basename(file).slice("tsbuildinfo".length);
+			fs.rmSync(file, { force: true });
+			fs.rmSync(path.join(directory, STATE_DIRECTORY, `tsgate${suffix}`), { force: true });
+		}
+	}
+
+	it("agrees with the builder when one project is cold and one is warm", () => {
+		expect.assertions(3);
+
+		const { builder, fast } = compare({ mutate: coolAppProject, tree: SOLUTION });
+
+		expect(fast).toStrictEqual(builder);
+		// One project had prior state, so the run as a whole is not a first run —
+		// and the cold project still contributes its own files.
+		expect(fast.firstRun).toBe(false);
+		expect(fast.affected).toContain("app/b.ts");
+	});
+
+	it("takes the fast path for every project once all are warm", () => {
+		expect.assertions(3);
+
+		const { builder, fast, fastPath } = compare({ mutate: unchanged, tree: SOLUTION });
+
+		expect(fast).toStrictEqual(builder);
+		expect(fast.affected).toStrictEqual([]);
+		expect(fastPath).toBe(true);
+	});
+});
+
+describe("persisted buildinfo", () => {
+	it("leaves no pending emit or change set behind", () => {
+		expect.assertions(4);
+
+		// Without this the feature evaporates silently: `persistBuilderState`
+		// swallows every output but the buildinfo, and if that ever left emit
+		// work recorded as pending, the fast path's first guard would decline
+		// forever from the first edit onwards and no other test would notice.
+		const directory = createFixture(CHAIN);
+		runPass(directory);
+		writeFile(path.join(directory, "src/a.ts"), RESHAPED_A);
+		runPass(directory);
+
+		const [file = ""] = stateFiles(directory, "tsbuildinfo");
+		const info = readJson(file);
+
+		expect(info["affectedFilesPendingEmit"]).toBeUndefined();
+		expect(info["changeFileSet"]).toBeUndefined();
+		expect(info["pendingEmit"]).toBeUndefined();
+		expect(info["checkPending"]).toBeUndefined();
+	});
+
+	it("writes no JavaScript or declaration output into the project", () => {
+		expect.assertions(1);
+
+		const directory = createFixture(CHAIN);
+		runPass(directory);
+
+		expect(fs.readdirSync(path.join(directory, "src")).sort()).toStrictEqual([
+			"a.ts",
+			"b.ts",
+			"c.ts",
+		]);
+	});
+});


### PR DESCRIPTION
`computeAffectedFiles` constructed a full TypeScript program on every run to decide which files the type-aware ESLint pass must re-lint. On this repo that is 1349 files / 14.8 MB, and 98% of the cost is a single `createEmitAndSemanticDiagnosticsBuilderProgram` call — paid in full even when the answer is "nothing changed".

The `.tsbuildinfo` already stores what that question needs: per-file source-text hashes, the root set, and pending-work markers. So verify it directly and only build a program when verification declines.

**Warm run, nothing changed: ~1.3–2.3s → ~0.2s.** Runs that do have a change pay ~74ms for the failed verification, ~1% of their cost.

## Correctness

The equivalence target is `createBuilderProgramState` (typescript.js:131324), which marks a file changed iff it is new, its `version` hash differs, its `impliedFormat` differs, its `referencedMap` keys differ, or a referenced file was deleted. Verification covers the hash test directly and root membership via the `root` field; it structurally cannot see format or resolution drift, so those are gated.

- **Hash** — TypeScript'"'"'s own `getSourceFileVersionAsHashFromText`, over text read with `ts.sys.readFile`. Not a reimplementation: TS strips a trailing `sourceMappingURL` comment before hashing, and `fs.readFileSync(f, "utf8")` would mishandle BOMs and UTF-16, silently disabling the fast path forever with nothing failing. The UTF-8-BOM/UTF-16 A/B pair exists to catch exactly that.
- **Roots** — from the `root` fileId ranges, not `fileNames`. `fileNames` is every program file including libs and `node_modules`, a strict superset of the roots; comparing against it would never match and the fast path would never fire.
- **Gate** — a hash of the effective compiler options plus a resolution digest: the resolution fields and `type` of `package.json` for cwd, workspace root and every workspace member, plus lockfile content hashes. This covers the two drift classes nothing else caught: a workspace sibling remapping its `exports` (doesn'"'"'t touch the lockfile, isn'"'"'t in the bust patterns) and a `type` flip changing `impliedFormat` program-wide.

**The fast path never writes.** Gate state is written only by the builder path, after a successful persist. A compare-and-swap would consume the change at read time: options change → CAS stores the new value → falls through → builder throws → nothing persists → next run reads "unchanged" and verifies against a buildinfo the builder never advanced. For the same reason the existing `package-json-hash` state is not reused — `plan.ts` has already swapped it earlier in the same process.

Bails to the builder on: pending `changeFileSet` / `affectedFilesPendingEmit` / `pendingEmit` / `checkPending`, `resolvedRoot`, `options.outFile`, a `ts.version` mismatch, an unexpected shape, or a missing hash function. One try/catch around the whole thing; an unreadable file is a mismatch, never a throw. `persistBuilderState` now writes temp+rename, since the buildinfo has a second consumer.

Documented as out of contract: non-root in-repo files that shadow resolution, hand-edited `node_modules` with no lockfile change.

## Testing

23 new tests. Each A/B scenario builds two identical fixtures, warms them identically, then forces one side to decline and runs both in **separate processes** against private buildinfos. Whether the fast path actually fired is observed by backdating gate mtimes, since only the builder path writes them.

**All 21 scenarios agree with the real builder.** Untouched; mtime-bumped-but-identical; real change; post-persist; content restored so the buildinfo describes edited text; first run; lockfile-only bump; `type` flip; sibling `exports` remap; sibling *unrelated* field (control — verification correctly stays engaged); tsconfig gaining and losing a root; deleted root and deleted `node_modules` declaration; truncated buildinfo; TS patch bump; `outFile` project; a solution with one cold and one warm project; BOM/UTF-16 clean and edited.

Plus a regression assertion that a normally-persisted buildinfo leaves all four pending markers absent — without it, a future change could leave `affectedFilesPendingEmit` populated and permanently disable this feature with no test failing.

Full suite: 526 passing (503 on `main`).

## Also: `emitDeclarationOnly`, kept but not a win

Forcing `emitDeclarationOnly: true` in the builder options halves the emit'"'"'s output — 428 writes/1.8 MB → 217/0.6 MB — and a controlled a←b←c fixture confirms it does **not** degrade shape hashing: a body-only edit still reports one file, not its importers.

But wall clock does not move. The emit'"'"'s cost is the declaration work itself, which `declaration: true` requires. The commit says so plainly so it isn'"'"'t later mistaken for a perf lever.

## Review notes

- `findWorkspaceMembers` parses `pnpm-workspace.yaml`'"'"'s `packages:` with a hand-rolled line scanner — no YAML or glob parser is a production dependency here. It handles block and JSON-flow forms; anything else yields no gate, which falls through to the builder. This is the piece most worth a second look.
- Independent of #657; the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * TypeScript incremental builds now use a stronger “resolution gate” with a verified build cache fast path, reducing unnecessary rebuilds.
  * Cache validation more accurately tracks relevant workspace, lockfile, and package-type changes.
* **Reliability**
  * Improved validation and defensive handling of corrupted, truncated, or incompatible build state.
  * Build state is now written more safely to avoid incomplete cache data.
* **Compatibility**
  * Workspace discovery now supports common pnpm and npm workspace configurations, including member directory expansion.
* **Tests**
  * Added extensive coverage for the buildinfo fast-path behavior across many change scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->