### PR TITLE
feat(naming): match @rbxts/react component types in .ts files

### DIFF
--- a/src/eslint/configs/naming.ts
+++ b/src/eslint/configs/naming.ts
@@ -9,6 +9,30 @@ import type {
 
 const RBXTS_REACT = "@rbxts/react";
 
+/**
+ * Component-valued types from `@rbxts/react`.
+ *
+ * `ComponentType` is an alias for `ComponentClass | FunctionComponent`, and the
+ * type matcher splits unions before matching, so both members have to be listed
+ * for a `ComponentType`-annotated name to match.
+ */
+const REACT_COMPONENT_TYPES = [
+	{ name: "ComponentClass", from: RBXTS_REACT },
+	{ name: "Context", from: RBXTS_REACT },
+	{ name: "ExoticComponent", from: RBXTS_REACT },
+	{ name: "FC", from: RBXTS_REACT },
+	{ name: "ForwardRefExoticComponent", from: RBXTS_REACT },
+	{ name: "FunctionComponent", from: RBXTS_REACT },
+	{ name: "LazyExoticComponent", from: RBXTS_REACT },
+	{ name: "MemoExoticComponent", from: RBXTS_REACT },
+	{ name: "NamedExoticComponent", from: RBXTS_REACT },
+];
+
+const REACT_ELEMENT_RETURN_TYPES = [
+	{ returns: { name: "Element", from: RBXTS_REACT } },
+	{ returns: { name: "ReactNode", from: RBXTS_REACT } },
+];
+
 export async function naming(
 	options: NamingConfig & OptionsTypeScriptParserOptions & OptionsTypeScriptWithTypes = {},
 ): Promise<Array<TypedFlatConfigItem>> {
@@ -53,6 +77,7 @@ export async function naming(
 									format: null,
 									selector: "import",
 								},
+								...(isRoblox ? reactSelectors() : []),
 								{
 									format: null,
 									modifiers: ["destructured"],
@@ -240,52 +265,7 @@ export async function naming(
 									leadingUnderscore: "allow",
 									selector: "variable",
 								},
-								...(isRoblox
-									? [
-											{
-												// React components and contexts
-												// conventionally use PascalCase
-												format: ["StrictPascalCase"],
-												selector: ["parameter", "variable"],
-												types: [
-													{ name: "Context", from: RBXTS_REACT },
-													{ name: "FC", from: RBXTS_REACT },
-													{
-														name: "FunctionComponent",
-														from: RBXTS_REACT,
-													},
-												],
-											},
-											{
-												// components typed as anonymous
-												// functions (e.g. `() =>
-												// React.ReactNode`) have no
-												// symbol name to match, so match
-												// by return type instead;
-												// permissive since camelCase
-												// helpers can also return
-												// elements. typeMethod covers
-												// function-typed interface
-												// members
-												format: ["strictCamelCase", "StrictPascalCase"],
-												selector: ["parameter", "typeMethod", "variable"],
-												types: [
-													{
-														returns: {
-															name: "Element",
-															from: RBXTS_REACT,
-														},
-													},
-													{
-														returns: {
-															name: "ReactNode",
-															from: RBXTS_REACT,
-														},
-													},
-												],
-											},
-										]
-									: []),
+								...(isRoblox ? reactSelectors() : []),
 
 								{
 									format: null,
@@ -422,5 +402,37 @@ export async function naming(
 					},
 				]
 			: []),
+	];
+}
+
+/**
+ * Selectors that let React component values carry component casing.
+ *
+ * @returns The naming-convention selectors for `@rbxts/react` types.
+ */
+function reactSelectors(): Array<Record<string, unknown>> {
+	return [
+		{
+			// React components and contexts conventionally use PascalCase
+			format: ["StrictPascalCase"],
+			selector: ["parameter", "variable"],
+			types: REACT_COMPONENT_TYPES,
+		},
+		{
+			// Properties holding a component are named for the component, but
+			// camelCase stays legal so existing props do not have to move
+			format: ["strictCamelCase", "StrictPascalCase"],
+			selector: ["classProperty", "typeProperty"],
+			types: REACT_COMPONENT_TYPES,
+		},
+		{
+			// components typed as anonymous functions (e.g. `() =>
+			// React.ReactNode`) have no symbol name to match, so match by return
+			// type instead; permissive since camelCase helpers can also return
+			// elements. typeMethod covers function-typed interface members
+			format: ["strictCamelCase", "StrictPascalCase"],
+			selector: ["parameter", "typeMethod", "variable"],
+			types: REACT_ELEMENT_RETURN_TYPES,
+		},
 	];
 }

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -633,7 +633,7 @@ describe("oxlintTargets", () => {
 		expect.assertions(1);
 
 		const directory = temporaryDirectory();
-		execFileSync("git", ["init", "-q"], { cwd: directory });
+		withoutGitEnvironment(() => execFileSync("git", ["init", "-q"], { cwd: directory }));
 		fs.writeFileSync(path.join(directory, ".gitignore"), "src/typegen.d.ts\n");
 
 		// The only oxlint-eligible target is the one git ignores, so the set
@@ -650,7 +650,7 @@ describe("oxlintTargets", () => {
 		expect.assertions(1);
 
 		const directory = temporaryDirectory();
-		execFileSync("git", ["init", "-q"], { cwd: directory });
+		withoutGitEnvironment(() => execFileSync("git", ["init", "-q"], { cwd: directory }));
 		fs.writeFileSync(path.join(directory, ".gitignore"), "src/typegen.d.ts\n");
 
 		expect(


### PR DESCRIPTION
## What

`readonly FallbackComponent: React.ComponentType<FallbackProperties>;` was an error in a `.ts` file. Only the `.tsx` block had React type matchers, so in `.ts` the property fell through to the camelCase default.

Both blocks now share one `reactSelectors()` helper:

- **Component-typed names** — `ComponentClass`, `Context`, `ExoticComponent`, `FC`, `ForwardRefExoticComponent`, `FunctionComponent`, `LazyExoticComponent`, `MemoExoticComponent`, `NamedExoticComponent`. PascalCase for `parameter`/`variable`; camelCase **or** PascalCase for `classProperty`/`typeProperty`.
- **Element-returning function types** — unchanged, moved into the helper.

Still gated on `naming: { roblox: … }`.

## Why `ComponentType` needs both union members

`ComponentType<P> = ComponentClass<P> | FunctionComponent<P>`. The flawless type matcher splits unions before it compares names, so the alias symbol never matches. A matcher for `{ name: "ComponentType" }` alone hits nothing — verified: 0 of 10 sites matched. Listing both members matches all of them.

`React.ElementType` stays unmatched for the same reason: it unions in `string`, which is not a React type. A namespace-wide fallback (`types: [{ from: "@rbxts/react" }]`) is not expressible today — see https://github.com/christopher-buss/eslint-plugin-flawless/issues/20.

## Second commit: a destructive test bug

`test/lint-cli.spec.ts` ran `git init` in a temporary directory with the ambient environment. Under a git hook, `GIT_DIR` points at the repository being committed, so `git init` re-initialised **that** repository and set `core.bare = true`, which breaks every later git command in the checkout and its worktrees. It hit this repository during work on this branch. The init calls now use `withoutGitEnvironment`, the helper the assertions already used.

## Test

- `pnpm test` — 37 files, 548 tests, pass.
- Same suite with `GIT_DIR`/`GIT_INDEX_FILE` set, as a hook does: passes, and `core.bare` stays `false`.
- End-to-end through the real preset, against a fixture with `@rbxts/react` installed: the `ComponentType`, `FunctionComponent`, `ComponentClass`, `FC`, `Context`, memo and lazy properties are clean in `.ts` and `.tsx`; a PascalCase `string` property and a camelCase component parameter still error.
- `pnpm gen` — no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Linting Improvements**
  - Improved React naming checks when Roblox mode is enabled.
  - React components and component-valued variables now consistently follow PascalCase conventions.
  - Component-related properties support appropriate camelCase or PascalCase naming.
  - Expanded recognition of React component types while preserving existing flexibility for React element values.

- **Reliability**
  - Improved test isolation for projects using Git-related environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->