### PR TITLE
perf(lint-cli): spawn the typed pass immediately after a config edit

### DIFF
--- a/src/lint-cli/lib/cache/bust.ts
+++ b/src/lint-cli/lib/cache/bust.ts
@@ -40,7 +40,7 @@ export interface BustOutcome {
 	 * Listed whether or not the file was there to delete — an absent cache
 	 * means "everything is dirty" just as a deleted one does.
 	 */
-	cleared: Array<string>;
+	cleared: ReadonlyArray<string>;
 	/** True when no prior hash existed (state stored, no bust). */
 	firstRun: boolean;
 }

--- a/src/lint-cli/lib/cache/bust.ts
+++ b/src/lint-cli/lib/cache/bust.ts
@@ -32,8 +32,17 @@ export interface HashBust {
 
 /** Outcome of a hash-drift check. */
 export interface BustOutcome {
-	/** True when the hash changed and this variant's caches were deleted. */
-	busted: boolean;
+	/**
+	 * Absolute paths of the cache files this bust deleted, empty when the hash
+	 * did not change. Reported rather than merely counted because the planner
+	 * folds them into the set a pass sizes against: a pass whose cache is gone
+	 * has every file dirty already, so the TypeScript builder behind its
+	 * invalidation could only produce removals nothing will read.
+	 *
+	 * Listed whether or not the file was there to delete — an absent cache
+	 * means "everything is dirty" just as a deleted one does.
+	 */
+	cleared: Array<string>;
 	/** True when no prior hash existed (state stored, no bust). */
 	firstRun: boolean;
 }
@@ -90,17 +99,20 @@ export function applyHashBust(
 	hash: string | undefined,
 ): BustOutcome {
 	if (hash === undefined) {
-		return { busted: false, firstRun: false };
+		return { cleared: [], firstRun: false };
 	}
 
 	const swap = swapState(statePath(run.cwd, bust.name, run.key), hash);
 	if (swap !== "changed") {
-		return { busted: false, firstRun: swap === "first" };
+		return { cleared: [], firstRun: swap === "first" };
 	}
 
+	const cleared: Array<string> = [];
 	for (const base of bust.caches) {
-		fs.rmSync(path.resolve(run.cwd, cacheFileFor(base, run.key)), { force: true });
+		const cacheFilePath = path.resolve(run.cwd, cacheFileFor(base, run.key));
+		fs.rmSync(cacheFilePath, { force: true });
+		cleared.push(cacheFilePath);
 	}
 
-	return { busted: true, firstRun: false };
+	return { cleared, firstRun: false };
 }

--- a/src/lint-cli/lib/cache/bust.ts
+++ b/src/lint-cli/lib/cache/bust.ts
@@ -34,10 +34,8 @@ export interface HashBust {
 export interface BustOutcome {
 	/**
 	 * Absolute paths of the cache files this bust deleted, empty when the hash
-	 * did not change. Reported rather than merely counted because the planner
-	 * folds them into the set a pass sizes against: a pass whose cache is gone
-	 * has every file dirty already, so the TypeScript builder behind its
-	 * invalidation could only produce removals nothing will read.
+	 * did not change. Named rather than counted because the planner folds them
+	 * into the set each pass is sized against (see `mutatingDirtyCount`).
 	 *
 	 * Listed whether or not the file was there to delete — an absent cache
 	 * means "everything is dirty" just as a deleted one does.

--- a/src/lint-cli/lib/plan/plan.ts
+++ b/src/lint-cli/lib/plan/plan.ts
@@ -159,11 +159,12 @@ export function plan(options: LintCliOptions, run: RunContext): StagedPlan {
 	// `--no-cache` never touches cache state, and `--print` (mutate=false) never
 	// mutates.
 	//
-	// The package.json bust runs first and deletes only this variant's type-aware
-	// caches (a syntactic lint is immune to resolution changes), so it does NOT
-	// feed `clearedCaches` — the fast cache survives it. The mtime sweep below is
-	// the wholesale one, and it covers every variant on disk, not just the ones
-	// this run selected.
+	// Every deletion feeds `clearedCaches`, whichever bust made it: a pass whose
+	// cache is gone re-lints every file, so sizing must not then pay for the
+	// TypeScript builder behind its invalidation. The package.json bust spares
+	// the fast cache, so it contributes only the two type-aware ones. The mtime
+	// sweep below is the wholesale one, and it covers every variant on disk, not
+	// just the ones this run selected.
 	const canMutateCaches = mutate && options.cache;
 	const hasTypeAwarePass = descriptors.some((descriptor) => descriptor.invalidation !== "none");
 
@@ -173,6 +174,8 @@ export function plan(options: LintCliOptions, run: RunContext): StagedPlan {
 	// `--no-cache` counts every file dirty regardless.
 	const configHash = options.cache ? computeConfigHash(cwd, files.configFiles) : undefined;
 
+	const clearedCaches = new Set<string>();
+
 	if (canMutateCaches) {
 		// Config drift through a module `eslint.config.*` imports shifts ESLint's
 		// per-entry `hashOfConfig` (a full re-lint) but touches no bust file, so
@@ -181,14 +184,19 @@ export function plan(options: LintCliOptions, run: RunContext): StagedPlan {
 		// three of this variant's caches when it changed. Applies to every pass
 		// (a config change can alter a syntactic lint), so it runs before the
 		// type-aware-only package.json bust.
-		applyHashBust(run, CONFIG_DRIFT, configHash);
+		addCleared(clearedCaches, applyHashBust(run, CONFIG_DRIFT, configHash).cleared);
 	}
 
 	if (canMutateCaches && hasTypeAwarePass) {
-		applyHashBust(run, PACKAGE_RESOLUTION, computePackageJsonHash(cwd));
+		const outcome = applyHashBust(run, PACKAGE_RESOLUTION, computePackageJsonHash(cwd));
+		addCleared(clearedCaches, outcome.cleared);
 	}
 
-	const clearedCaches = new Set(canMutateCaches ? sweepStaleCaches(cwd, newestBustMtime) : []);
+	// The sweep runs last and lists what is still on disk, so it can only report
+	// caches the busts above left alone — hence the union rather than a replace.
+	if (canMutateCaches) {
+		addCleared(clearedCaches, sweepStaleCaches(cwd, newestBustMtime));
+	}
 
 	// Drop the files ESLint declines to lint before anything sizes from them:
 	// they never enter a cache, so they would otherwise read as dirty forever
@@ -230,6 +238,20 @@ export function plan(options: LintCliOptions, run: RunContext): StagedPlan {
 
 function resolveOxlintTypeAware(options: LintCliOptions): boolean {
 	return !options.eslint && options.oxlintTypeAware && options.typeAware !== "off";
+}
+
+/**
+ * Fold one deletion step's cache paths into the run's cleared set. Every source
+ * resolves its paths against `cwd` the same way sizing does, so the raw strings
+ * compare directly.
+ *
+ * @param into - The accumulating cleared set (mutated).
+ * @param cleared - The absolute cache paths this step deleted.
+ */
+function addCleared(into: Set<string>, cleared: ReadonlyArray<string>): void {
+	for (const cacheFilePath of cleared) {
+		into.add(cacheFilePath);
+	}
 }
 
 /**

--- a/src/lint-cli/lib/plan/plan.ts
+++ b/src/lint-cli/lib/plan/plan.ts
@@ -159,12 +159,12 @@ export function plan(options: LintCliOptions, run: RunContext): StagedPlan {
 	// `--no-cache` never touches cache state, and `--print` (mutate=false) never
 	// mutates.
 	//
-	// Every deletion feeds `clearedCaches`, whichever bust made it: a pass whose
-	// cache is gone re-lints every file, so sizing must not then pay for the
-	// TypeScript builder behind its invalidation. The package.json bust spares
-	// the fast cache, so it contributes only the two type-aware ones. The mtime
-	// sweep below is the wholesale one, and it covers every variant on disk, not
-	// just the ones this run selected.
+	// Every deletion feeds `clearedCaches`, whichever step made it, so that
+	// sizing can tell a pass that re-lints everything from one that does not (see
+	// `mutatingDirtyCount`). The package.json bust spares the fast cache, so it
+	// contributes only the two type-aware ones. The mtime sweep below is the
+	// wholesale one, and it covers every variant on disk, not just the ones this
+	// run selected.
 	const canMutateCaches = mutate && options.cache;
 	const hasTypeAwarePass = descriptors.some((descriptor) => descriptor.invalidation !== "none");
 
@@ -174,8 +174,7 @@ export function plan(options: LintCliOptions, run: RunContext): StagedPlan {
 	// `--no-cache` counts every file dirty regardless.
 	const configHash = options.cache ? computeConfigHash(cwd, files.configFiles) : undefined;
 
-	const clearedCaches = new Set<string>();
-
+	const cleared: Array<string> = [];
 	if (canMutateCaches) {
 		// Config drift through a module `eslint.config.*` imports shifts ESLint's
 		// per-entry `hashOfConfig` (a full re-lint) but touches no bust file, so
@@ -184,19 +183,19 @@ export function plan(options: LintCliOptions, run: RunContext): StagedPlan {
 		// three of this variant's caches when it changed. Applies to every pass
 		// (a config change can alter a syntactic lint), so it runs before the
 		// type-aware-only package.json bust.
-		addCleared(clearedCaches, applyHashBust(run, CONFIG_DRIFT, configHash).cleared);
+		cleared.push(...applyHashBust(run, CONFIG_DRIFT, configHash).cleared);
+		if (hasTypeAwarePass) {
+			cleared.push(
+				...applyHashBust(run, PACKAGE_RESOLUTION, computePackageJsonHash(cwd)).cleared,
+			);
+		}
+
+		// The sweep runs last, so it lists only the caches the busts left on
+		// disk.
+		cleared.push(...sweepStaleCaches(cwd, newestBustMtime));
 	}
 
-	if (canMutateCaches && hasTypeAwarePass) {
-		const outcome = applyHashBust(run, PACKAGE_RESOLUTION, computePackageJsonHash(cwd));
-		addCleared(clearedCaches, outcome.cleared);
-	}
-
-	// The sweep runs last and lists what is still on disk, so it can only report
-	// caches the busts above left alone — hence the union rather than a replace.
-	if (canMutateCaches) {
-		addCleared(clearedCaches, sweepStaleCaches(cwd, newestBustMtime));
-	}
+	const clearedCaches = new Set(cleared);
 
 	// Drop the files ESLint declines to lint before anything sizes from them:
 	// they never enter a cache, so they would otherwise read as dirty forever
@@ -238,20 +237,6 @@ export function plan(options: LintCliOptions, run: RunContext): StagedPlan {
 
 function resolveOxlintTypeAware(options: LintCliOptions): boolean {
 	return !options.eslint && options.oxlintTypeAware && options.typeAware !== "off";
-}
-
-/**
- * Fold one deletion step's cache paths into the run's cleared set. Every source
- * resolves its paths against `cwd` the same way sizing does, so the raw strings
- * compare directly.
- *
- * @param into - The accumulating cleared set (mutated).
- * @param cleared - The absolute cache paths this step deleted.
- */
-function addCleared(into: Set<string>, cleared: ReadonlyArray<string>): void {
-	for (const cacheFilePath of cleared) {
-		into.add(cacheFilePath);
-	}
 }
 
 /**

--- a/src/lint-cli/lib/plan/sizing.ts
+++ b/src/lint-cli/lib/plan/sizing.ts
@@ -5,7 +5,7 @@ import { cacheFileFor } from "../cache/constants.ts";
 import type { DirtyCache } from "../cache/entries.ts";
 import { isCacheStale, normalizePath, openCache } from "../cache/entries.ts";
 import { applyTypeAwareInvalidation } from "../cache/invalidation.ts";
-import type { LintCliOptions, TypeAwareMode } from "../cli/types.ts";
+import type { LintCliOptions } from "../cli/types.ts";
 import type { RunContext } from "../context.ts";
 import type { RepoFiles } from "../files/collect.ts";
 import { hasBuilderState } from "../typescript/affected.ts";
@@ -42,9 +42,9 @@ export interface PassPlan {
  */
 export interface SizingInputs {
 	/**
-	 * The cache files the up-front stale sweep deleted (absolute paths). A pass
-	 * whose cache is in here counts every file as dirty and skips the builder —
-	 * everything re-lints regardless.
+	 * The cache files this run deleted up front (absolute paths), from the hash
+	 * busts and the stale sweep alike. A pass whose cache is in here counts
+	 * every file as dirty and skips the builder — everything re-lints anyway.
 	 */
 	clearedCaches: ReadonlySet<string>;
 	/** The lint-target lists, already filtered of ESLint-ignored files. */
@@ -100,28 +100,6 @@ export function sizePasses(
 }
 
 /**
- * Whether a pass whose cache this run deleted may skip its builder outright.
- *
- * With no cache, the affected set the builder computes has nothing to remove
- * from — but the builder is also the only thing that establishes the state a
- * later run invalidates against, so skipping it while none exists trades one
- * run's latency for stale diagnostics on the next (see `hasBuilderState`). The
- * syntactic pass builds no program at all, so it always skips.
- *
- * @param descriptor - The pass being sized.
- * @param run - The run context.
- * @param mode - The pass's type-aware mode.
- * @returns True when the builder can be skipped safely.
- */
-function canSkipBuilder(
-	descriptor: PassDescriptor,
-	run: RunContext,
-	mode: TypeAwareMode | undefined,
-): boolean {
-	return descriptor.invalidation === "none" || hasBuilderState(run, mode);
-}
-
-/**
  * Dirty count for a real run: clear the cache wholesale when stale, then fold
  * TS builder invalidation in, reusing a single loaded cache for the dirty query
  * and the surgical entry removal.
@@ -138,11 +116,19 @@ function mutatingDirtyCount(
 	targetFiles: Array<string>,
 	{ clearedCaches, run }: SizePassContext,
 ): number {
+	// Both facts this pass needs about its builder, read off the one field that
+	// records them: whether it builds a TypeScript program at all, and the mode
+	// that program runs under.
+	const buildsProgram = descriptor.invalidation !== "none";
 	const mode = descriptor.invalidation === "only" ? "only" : undefined;
-	if (clearedCaches.has(cacheLocation) && canSkipBuilder(descriptor, run, mode)) {
-		// A bust or the up-front sweep already deleted this pass's cache (see
-		// `plan`), so every file is dirty and the builder's invalidation would be
-		// pure waste — everything re-lints.
+
+	// A bust or the up-front sweep already deleted this pass's cache (see
+	// `plan`), so every file is dirty and the affected set the builder computes
+	// would have nothing to remove from. Skipping it is only safe once prior
+	// builder state exists: with none, the next run reports `firstRun` and throws
+	// its affected set away, so an importer of a file edited in between would
+	// keep a stale entry (see `hasBuilderState`).
+	if (clearedCaches.has(cacheLocation) && (!buildsProgram || hasBuilderState(run, mode))) {
 		return targetFiles.length;
 	}
 
@@ -151,7 +137,7 @@ function mutatingDirtyCount(
 		(cache?.getUpdatedFiles(targetFiles) ?? targetFiles).map((file) => normalizePath(file)),
 	);
 
-	if (descriptor.invalidation !== "none") {
+	if (buildsProgram) {
 		const outcome = applyTypeAwareInvalidation(run, {
 			alreadyDirty: dirty,
 			cache,

--- a/src/lint-cli/lib/plan/sizing.ts
+++ b/src/lint-cli/lib/plan/sizing.ts
@@ -5,9 +5,10 @@ import { cacheFileFor } from "../cache/constants.ts";
 import type { DirtyCache } from "../cache/entries.ts";
 import { isCacheStale, normalizePath, openCache } from "../cache/entries.ts";
 import { applyTypeAwareInvalidation } from "../cache/invalidation.ts";
-import type { LintCliOptions } from "../cli/types.ts";
+import type { LintCliOptions, TypeAwareMode } from "../cli/types.ts";
 import type { RunContext } from "../context.ts";
 import type { RepoFiles } from "../files/collect.ts";
+import { hasBuilderState } from "../typescript/affected.ts";
 import type { WorkerLimits } from "./concurrency.ts";
 import { computeWorkerCount } from "./concurrency.ts";
 import type { PassDescriptor } from "./passes.ts";
@@ -99,6 +100,28 @@ export function sizePasses(
 }
 
 /**
+ * Whether a pass whose cache this run deleted may skip its builder outright.
+ *
+ * With no cache, the affected set the builder computes has nothing to remove
+ * from — but the builder is also the only thing that establishes the state a
+ * later run invalidates against, so skipping it while none exists trades one
+ * run's latency for stale diagnostics on the next (see `hasBuilderState`). The
+ * syntactic pass builds no program at all, so it always skips.
+ *
+ * @param descriptor - The pass being sized.
+ * @param run - The run context.
+ * @param mode - The pass's type-aware mode.
+ * @returns True when the builder can be skipped safely.
+ */
+function canSkipBuilder(
+	descriptor: PassDescriptor,
+	run: RunContext,
+	mode: TypeAwareMode | undefined,
+): boolean {
+	return descriptor.invalidation === "none" || hasBuilderState(run, mode);
+}
+
+/**
  * Dirty count for a real run: clear the cache wholesale when stale, then fold
  * TS builder invalidation in, reusing a single loaded cache for the dirty query
  * and the surgical entry removal.
@@ -115,10 +138,11 @@ function mutatingDirtyCount(
 	targetFiles: Array<string>,
 	{ clearedCaches, run }: SizePassContext,
 ): number {
-	if (clearedCaches.has(cacheLocation)) {
-		// The up-front sweep already deleted this pass's cache (see `plan`), so
-		// every file is dirty and the builder would be pure waste — everything
-		// re-lints.
+	const mode = descriptor.invalidation === "only" ? "only" : undefined;
+	if (clearedCaches.has(cacheLocation) && canSkipBuilder(descriptor, run, mode)) {
+		// A bust or the up-front sweep already deleted this pass's cache (see
+		// `plan`), so every file is dirty and the builder's invalidation would be
+		// pure waste — everything re-lints.
 		return targetFiles.length;
 	}
 
@@ -132,7 +156,7 @@ function mutatingDirtyCount(
 			alreadyDirty: dirty,
 			cache,
 			cacheLocation,
-			mode: descriptor.invalidation === "only" ? "only" : undefined,
+			mode,
 			targetFiles,
 		});
 		if (outcome.busted) {

--- a/src/lint-cli/lib/typescript/affected.ts
+++ b/src/lint-cli/lib/typescript/affected.ts
@@ -159,6 +159,49 @@ export function computeAffectedFiles(
 }
 
 /**
+ * Whether a previous run left builder state for this mode and config variant.
+ *
+ * The one thing a builder pass does that nothing else can is establish this
+ * state. Its affected set is disposable — a caller with an empty cache re-lints
+ * regardless — but a run that skips the builder while no state exists only
+ * defers the cost onto the next run, which then reports `firstRun` and throws
+ * its affected set away. A file edited in between would be re-linted on its own
+ * mtime while its importers kept stale type-aware cache entries, which no later
+ * run revisits. Callers that skip the builder as an optimisation ask this
+ * first.
+ *
+ * Any one project's state is enough: {@link computeAffectedFiles} reports
+ * `firstRun` only when no project at all had state, and a newly added project
+ * contributes its whole file set rather than an empty one.
+ *
+ * @param run - The run context.
+ * @param mode - The active ESLint type-aware mode (never `"off"` here).
+ * @returns True when at least one buildinfo for this mode and variant exists.
+ */
+export function hasBuilderState(
+	{ key, cwd }: RunContext,
+	mode: TypeAwareMode | undefined,
+): boolean {
+	const prefix = `tsbuildinfo-${modeSuffix(mode)}-${key}-`;
+	try {
+		return fs.readdirSync(stateDirectory(cwd)).some((name) => name.startsWith(prefix));
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * The state-file segment discriminating the type-aware mode a builder ran
+ * under. Two modes resolve different programs, so their state cannot be shared.
+ *
+ * @param mode - The active ESLint type-aware mode (never `"off"` here).
+ * @returns The file-name segment for that mode.
+ */
+function modeSuffix(mode: TypeAwareMode | undefined): string {
+	return mode === "only" ? "typeaware" : "full";
+}
+
+/**
  * Resolve the builder incremental-state (`.tsbuildinfo`) file for a mode and
  * config variant.
  *
@@ -187,8 +230,7 @@ function builderStatePath(
 	key: string,
 	projectId: string,
 ): string {
-	const suffix = mode === "only" ? "typeaware" : "full";
-	return statePath(cwd, "tsbuildinfo", suffix, key, projectId);
+	return statePath(cwd, "tsbuildinfo", modeSuffix(mode), key, projectId);
 }
 
 /**
@@ -219,8 +261,7 @@ function gateStatePath(
 	key: string,
 	projectId: string,
 ): string {
-	const suffix = mode === "only" ? "typeaware" : "full";
-	return statePath(cwd, "tsgate", suffix, key, projectId);
+	return statePath(cwd, "tsgate", modeSuffix(mode), key, projectId);
 }
 
 /**

--- a/src/lint-cli/lib/typescript/affected.ts
+++ b/src/lint-cli/lib/typescript/affected.ts
@@ -74,6 +74,13 @@ const warned = new Set<string>();
 const BUILD_INFO_STATE = "tsbuildinfo";
 
 /**
+ * State-file base name for the gate paired with each buildinfo. Deliberately
+ * not a `tsbuildinfo-` suffix, so anything enumerating a variant's buildinfo
+ * files does not pick a gate up as one (see {@link gateStatePath}).
+ */
+const GATE_STATE = "tsgate";
+
+/**
  * Compute the set of files whose type-aware lint results may have changed since
  * the previous run, using TypeScript's builder API. The builder does a native
  * shape-hash BFS: it recomputes each dependent's emitted-`.d.ts` shape hash and
@@ -195,7 +202,14 @@ export function hasBuilderState(
 	// "always build", with no error and nothing to fail on.
 	const prefix = `${path.basename(statePath(cwd, BUILD_INFO_STATE, modeSuffix(mode), key))}-`;
 	try {
-		return fs.readdirSync(stateDirectory(cwd)).some((name) => name.startsWith(prefix));
+		// Both writers in this directory stage through a sibling
+		// `<name>.<pid>.tmp` (see `persistBuilderState` and `writeState`), which
+		// shares the prefix. A run killed mid-write leaves one behind for good,
+		// and counting it as state would re-enable the skip with nothing on disk
+		// to invalidate against.
+		return fs
+			.readdirSync(stateDirectory(cwd))
+			.some((name) => name.startsWith(prefix) && !name.endsWith(".tmp"));
 	} catch {
 		return false;
 	}
@@ -272,7 +286,7 @@ function gateStatePath(
 	key: string,
 	projectId: string,
 ): string {
-	return statePath(cwd, "tsgate", modeSuffix(mode), key, projectId);
+	return statePath(cwd, GATE_STATE, modeSuffix(mode), key, projectId);
 }
 
 /**

--- a/src/lint-cli/lib/typescript/affected.ts
+++ b/src/lint-cli/lib/typescript/affected.ts
@@ -68,6 +68,12 @@ interface ProjectWalkResult {
 const warned = new Set<string>();
 
 /**
+ * State-file base name for the builder's incremental state, shared by the
+ * per-project path and the prefix {@link hasBuilderState} scans for.
+ */
+const BUILD_INFO_STATE = "tsbuildinfo";
+
+/**
  * Compute the set of files whose type-aware lint results may have changed since
  * the previous run, using TypeScript's builder API. The builder does a native
  * shape-hash BFS: it recomputes each dependent's emitted-`.d.ts` shape hash and
@@ -182,7 +188,12 @@ export function hasBuilderState(
 	{ key, cwd }: RunContext,
 	mode: TypeAwareMode | undefined,
 ): boolean {
-	const prefix = `tsbuildinfo-${modeSuffix(mode)}-${key}-`;
+	// Named through the same `statePath` the buildinfo files themselves are,
+	// minus the per-project digest, so the base name and the hyphen-join rule are
+	// stated once. Spelling the prefix out here would let a rename slip past
+	// silently: the scan would stop matching and the guard would degrade to
+	// "always build", with no error and nothing to fail on.
+	const prefix = `${path.basename(statePath(cwd, BUILD_INFO_STATE, modeSuffix(mode), key))}-`;
 	try {
 		return fs.readdirSync(stateDirectory(cwd)).some((name) => name.startsWith(prefix));
 	} catch {
@@ -230,7 +241,7 @@ function builderStatePath(
 	key: string,
 	projectId: string,
 ): string {
-	return statePath(cwd, "tsbuildinfo", modeSuffix(mode), key, projectId);
+	return statePath(cwd, BUILD_INFO_STATE, modeSuffix(mode), key, projectId);
 }
 
 /**

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -24,6 +24,7 @@ import type { RunContext } from "../src/lint-cli/lib/context.ts";
 import type { CommandPlan } from "../src/lint-cli/lib/plan/compose.ts";
 import { plan } from "../src/lint-cli/lib/plan/plan.ts";
 import type { PassPlan } from "../src/lint-cli/lib/plan/sizing.ts";
+import { stateDirectory } from "../src/lint-cli/lib/state.ts";
 import { computeAffectedFiles } from "../src/lint-cli/lib/typescript/affected.ts";
 import { allPasses, composeInDirectory, runContext } from "./lint-cli-helpers.ts";
 import { withoutGitEnvironment } from "./without-git.ts";
@@ -42,6 +43,12 @@ const AGENT_ENVIRONMENT = { CLAUDECODE: "1" };
 
 /** The agent variant's config-variant key. */
 const AGENT_KEY = resolveCacheKey(AGENT_ENVIRONMENT);
+
+/** The type-aware builder state-file prefix for the default variant. */
+const TYPE_AWARE_BUILD_INFO = `tsbuildinfo-typeaware-${TEST_KEY}`;
+
+/** The full-config builder state-file prefix for the default variant. */
+const FULL_BUILD_INFO = `tsbuildinfo-full-${TEST_KEY}`;
 
 const TSCONFIG = JSON.stringify({
 	compilerOptions: { module: "commonjs", strict: true, target: "es2020" },
@@ -132,15 +139,18 @@ const SOLUTION_FIXTURE = {
  *
  * @param directory - The fixture project root.
  * @param prefix - The `tsbuildinfo-<mode>-<key>` prefix to match.
- * @returns The matching file names, empty when the cache directory is absent.
+ * @returns The matching absolute paths, empty when the cache directory is absent.
  */
 function builderStateFiles(directory: string, prefix: string): Array<string> {
-	const stateDirectory = path.join(directory, "node_modules/.cache/isentinel-lint");
-	if (!fs.existsSync(stateDirectory)) {
+	const cacheDirectory = stateDirectory(directory);
+	if (!fs.existsSync(cacheDirectory)) {
 		return [];
 	}
 
-	return fs.readdirSync(stateDirectory).filter((name) => name.startsWith(prefix));
+	return fs
+		.readdirSync(cacheDirectory)
+		.filter((name) => name.startsWith(prefix))
+		.map((name) => path.join(cacheDirectory, name));
 }
 
 /**
@@ -153,10 +163,7 @@ function builderStateFiles(directory: string, prefix: string): Array<string> {
  * @returns The matching files' contents.
  */
 function builderStateContents(directory: string, prefix: string): Array<string> {
-	const stateDirectory = path.join(directory, "node_modules/.cache/isentinel-lint");
-	return builderStateFiles(directory, prefix).map((name) => {
-		return fs.readFileSync(path.join(stateDirectory, name), "utf8");
-	});
+	return builderStateFiles(directory, prefix).map((file) => fs.readFileSync(file, "utf8"));
 }
 
 /**
@@ -278,7 +285,7 @@ describe("computeAffectedFiles", () => {
 
 		// One per file-owning project (lib + app); the file-less entry
 		// tsconfig contributes no state of its own.
-		expect(builderStateFiles(directory, `tsbuildinfo-typeaware-${TEST_KEY}`)).toHaveLength(2);
+		expect(builderStateFiles(directory, TYPE_AWARE_BUILD_INFO)).toHaveLength(2);
 	});
 
 	it("does not report first-run when only some projects are new", () => {
@@ -289,14 +296,12 @@ describe("computeAffectedFiles", () => {
 		// added while its siblings stay warm — the shape of a solution that
 		// gains a reference.
 		computeAffectedFiles(runFor(directory), "only");
-		const stateDirectory = path.join(directory, "node_modules/.cache/isentinel-lint");
-		const prefix = `tsbuildinfo-typeaware-${TEST_KEY}`;
-		const stateFiles = builderStateFiles(directory, prefix);
+		const stateFiles = builderStateFiles(directory, TYPE_AWARE_BUILD_INFO);
 
 		expect(stateFiles.length).toBeGreaterThan(1);
 
 		const [firstState = ""] = stateFiles;
-		fs.rmSync(path.join(stateDirectory, firstState));
+		fs.rmSync(firstState);
 
 		const result = computeAffectedFiles(runFor(directory), "only");
 
@@ -474,7 +479,7 @@ describe("applyTypeAwareInvalidation", () => {
 		expect(outcome.firstRun).toBe(true);
 		expect(outcome.busted).toBe(false);
 		expect(outcome.invalidated).toStrictEqual([]);
-		expect(builderStateFiles(directory, `tsbuildinfo-full-${TEST_KEY}`)).toHaveLength(1);
+		expect(builderStateFiles(directory, FULL_BUILD_INFO)).toHaveLength(1);
 		expect(cacheHasEntry(cacheFile, fileA)).toBe(true);
 		expect(cacheHasEntry(cacheFile, fileB)).toBe(true);
 	});
@@ -633,8 +638,6 @@ describe("typed-pass skip", () => {
 });
 
 describe("plan mutation", () => {
-	const buildInfo = `tsbuildinfo-typeaware-${TEST_KEY}`;
-
 	it("performs no I/O mutation in read-only (print) mode", () => {
 		expect.assertions(4);
 
@@ -656,7 +659,7 @@ describe("plan mutation", () => {
 			"typed",
 		]);
 		// Read-only planning never runs the builder or deletes caches.
-		expect(builderStateFiles(directory, buildInfo)).toHaveLength(0);
+		expect(builderStateFiles(directory, TYPE_AWARE_BUILD_INFO)).toHaveLength(0);
 		expect(fs.existsSync(cacheFile)).toBe(true);
 
 		// The mutating plan, by contrast, runs the builder — once its deferred
@@ -665,7 +668,7 @@ describe("plan mutation", () => {
 			return allPasses(plan(parseArguments([], {}), runContext(directory, { mutate: true })));
 		});
 
-		expect(builderStateFiles(directory, buildInfo)).toHaveLength(1);
+		expect(builderStateFiles(directory, TYPE_AWARE_BUILD_INFO)).toHaveLength(1);
 	});
 
 	it("marks the typed pass skipped in the plan when nothing type-relevant changed", () => {
@@ -773,7 +776,7 @@ describe("per-variant cache isolation", () => {
 		computeAffectedFiles(runFor(directory), "only");
 		computeAffectedFiles(runFor(directory, AGENT_ENVIRONMENT), "only");
 
-		expect(builderStateFiles(directory, `tsbuildinfo-typeaware-${TEST_KEY}`)).toHaveLength(1);
+		expect(builderStateFiles(directory, TYPE_AWARE_BUILD_INFO)).toHaveLength(1);
 		expect(builderStateFiles(directory, `tsbuildinfo-typeaware-${AGENT_KEY}`)).toHaveLength(1);
 	});
 });
@@ -865,8 +868,9 @@ function anyCacheExists(directory: string, key: string): boolean {
 
 /**
  * The cleared-path list a config-drift bust of one variant must report: every
- * cache, in the order the bust lists them. The planner sizes its passes against
- * these, so what the outcome names — not only what it deleted — is behaviour.
+ * cache, in the order the bust deletes them. The planner sizes its passes
+ * against these, so what the outcome names — not only what it deleted — is
+ * behaviour.
  *
  * @param directory - The fixture project root.
  * @param key - The config-variant key whose caches were busted.
@@ -1063,8 +1067,6 @@ describe("config drift sizing", () => {
 		return allPasses(runPlan).find((pass) => pass.descriptor.label === "typed");
 	}
 
-	const buildInfo = `tsbuildinfo-typeaware-${TEST_KEY}`;
-
 	it("runs no TypeScript builder when the drift bust cleared the caches", () => {
 		expect.assertions(3);
 
@@ -1075,7 +1077,7 @@ describe("config drift sizing", () => {
 		computeAffectedFiles(runFor(directory), "only");
 		seedCache(cacheFile, [fileA]);
 		withoutGitEnvironment(() => plan(args, runContext(directory, { mutate: true })));
-		const before = builderStateContents(directory, buildInfo);
+		const before = builderStateContents(directory, TYPE_AWARE_BUILD_INFO);
 
 		expect(before).toHaveLength(1);
 
@@ -1093,7 +1095,7 @@ describe("config drift sizing", () => {
 		expect(typedPass(drifted)!.shouldRun).toBe(true);
 		// The bust already deleted this pass's cache, so every file is dirty and
 		// the builder can only produce invalidation nothing will read.
-		expect(builderStateContents(directory, buildInfo)).toStrictEqual(before);
+		expect(builderStateContents(directory, TYPE_AWARE_BUILD_INFO)).toStrictEqual(before);
 	});
 
 	it("still seeds absent builder state when the bust cleared the caches", () => {
@@ -1116,7 +1118,7 @@ describe("config drift sizing", () => {
 		// Skipping the builder here would leave the *next* run with no prior
 		// state, so it would report a first run and discard its affected set —
 		// and an importer of a file edited in between would keep a stale entry.
-		expect(builderStateFiles(directory, buildInfo)).toHaveLength(1);
+		expect(builderStateFiles(directory, TYPE_AWARE_BUILD_INFO)).toHaveLength(1);
 	});
 
 	it("un-skips the typed pass when a module the config imports changed", () => {

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -1,4 +1,5 @@
 // cspell:words tsbuildinfo typeaware globals CLAUDECODE normalised buildinfo
+// cspell:words tsgate
 import fileEntryCache from "file-entry-cache";
 import fs from "node:fs";
 import { createRequire } from "node:module";
@@ -140,6 +141,28 @@ function builderStateFiles(directory: string, prefix: string): Array<string> {
 	}
 
 	return fs.readdirSync(stateDirectory).filter((name) => name.startsWith(prefix));
+}
+
+/**
+ * Delete every builder state file, leaving the rest of the state directory
+ * alone. A test that asserts a run did *not* build needs the buildinfo to be
+ * absent beforehand, so that a build is observable as one reappearing — and it
+ * must not take the `config-hash` state with it, or the drift bust under test
+ * would report a first run and never fire.
+ *
+ * @param directory - The fixture project root.
+ */
+function removeBuilderState(directory: string): void {
+	const stateDirectory = path.join(directory, "node_modules/.cache/isentinel-lint");
+	if (!fs.existsSync(stateDirectory)) {
+		return;
+	}
+
+	for (const name of fs.readdirSync(stateDirectory)) {
+		if (name.startsWith("tsbuildinfo-") || name.startsWith("tsgate-")) {
+			fs.rmSync(path.join(stateDirectory, name), { force: true });
+		}
+	}
 }
 
 /**
@@ -846,6 +869,19 @@ function anyCacheExists(directory: string, key: string): boolean {
 	return ALL_CACHE_FILES.some((name) => cacheExists(directory, key, name));
 }
 
+/**
+ * The cleared-path list a config-drift bust of one variant must report: every
+ * cache, in the order the bust lists them. The planner sizes its passes against
+ * these, so what the outcome names — not only what it deleted — is behaviour.
+ *
+ * @param directory - The fixture project root.
+ * @param key - The config-variant key whose caches were busted.
+ * @returns The expected `BustOutcome.cleared` value.
+ */
+function clearedPaths(directory: string, key: string): Array<string> {
+	return ALL_CACHE_FILES.map((name) => path.join(directory, cacheFileFor(name, key)));
+}
+
 function editRules(directory: string): void {
 	fs.writeFileSync(
 		path.join(directory, "eslint-rules.ts"),
@@ -862,7 +898,7 @@ describe("applyConfigDriftBust", () => {
 
 		const outcome = bustConfig(runFor(directory));
 
-		expect(outcome).toStrictEqual({ busted: false, firstRun: true });
+		expect(outcome).toStrictEqual({ cleared: [], firstRun: true });
 		expect(everyCacheExists(directory, TEST_KEY)).toBe(true);
 	});
 
@@ -876,7 +912,10 @@ describe("applyConfigDriftBust", () => {
 
 		const outcome = bustConfig(runFor(directory));
 
-		expect(outcome).toStrictEqual({ busted: true, firstRun: false });
+		expect(outcome).toStrictEqual({
+			cleared: clearedPaths(directory, TEST_KEY),
+			firstRun: false,
+		});
 		// Unlike the package.json bust, the fast (syntactic) cache is dropped
 		// too: a rule-severity change alters a syntactic lint.
 		expect(anyCacheExists(directory, TEST_KEY)).toBe(false);
@@ -894,7 +933,7 @@ describe("applyConfigDriftBust", () => {
 
 		// Content-addressed, so an mtime bump with identical content is a
 		// no-op.
-		expect(outcome).toStrictEqual({ busted: false, firstRun: false });
+		expect(outcome).toStrictEqual({ cleared: [], firstRun: false });
 		expect(everyCacheExists(directory, TEST_KEY)).toBe(true);
 	});
 
@@ -909,14 +948,14 @@ describe("applyConfigDriftBust", () => {
 		editRules(directory);
 
 		expect(bustConfig(runFor(directory))).toStrictEqual({
-			busted: true,
+			cleared: clearedPaths(directory, TEST_KEY),
 			firstRun: false,
 		});
 		// The no-agent run must not consume the drift on the agent's behalf.
 		expect(everyCacheExists(directory, AGENT_KEY)).toBe(true);
 
 		expect(bustConfig(runFor(directory, AGENT_ENVIRONMENT))).toStrictEqual({
-			busted: true,
+			cleared: clearedPaths(directory, AGENT_KEY),
 			firstRun: false,
 		});
 		expect(anyCacheExists(directory, AGENT_KEY)).toBe(false);
@@ -934,7 +973,7 @@ describe("applyConfigDriftBust", () => {
 			computeConfigHash(directory, []),
 		);
 
-		expect(outcome).toStrictEqual({ busted: false, firstRun: false });
+		expect(outcome).toStrictEqual({ cleared: [], firstRun: false });
 		expect(everyCacheExists(directory, TEST_KEY)).toBe(true);
 	});
 
@@ -952,7 +991,7 @@ describe("applyConfigDriftBust", () => {
 		expect(
 			applyHashBust(runFor(directory), CONFIG_DRIFT, computeConfigHash(directory, roots)),
 		).toStrictEqual({
-			busted: false,
+			cleared: [],
 			firstRun: false,
 		});
 	});
@@ -1029,6 +1068,33 @@ describe("config drift sizing", () => {
 	function typedPass(runPlan: ReturnType<typeof plan>): PassPlan | undefined {
 		return allPasses(runPlan).find((pass) => pass.descriptor.label === "typed");
 	}
+
+	it("runs no TypeScript builder when the drift bust cleared the caches", () => {
+		expect.assertions(2);
+
+		const directory = createFixture(CONFIG_IMPORT_FIXTURE);
+		const cacheFile = path.join(directory, TYPE_AWARE_CACHE);
+		const fileA = path.join(directory, "src/a.ts");
+		const args = parseArguments(["src"], {});
+		computeAffectedFiles(runFor(directory), "only");
+		seedCache(cacheFile, [fileA]);
+		withoutGitEnvironment(() => plan(args, runContext(directory, { mutate: true })));
+
+		// Clear the builder state so this run's builder, if it runs at all,
+		// leaves a buildinfo behind. Editing the imported module changes no bust
+		// file, so only the drift bust can delete the caches.
+		removeBuilderState(directory);
+		editRules(directory);
+
+		const drifted = withoutGitEnvironment(() => {
+			return plan(args, runContext(directory, { mutate: true }));
+		});
+
+		expect(typedPass(drifted)!.shouldRun).toBe(true);
+		// The bust already deleted this pass's cache, so every file is dirty and
+		// the builder can only produce invalidation nothing will read.
+		expect(builderStateFiles(directory, `tsbuildinfo-typeaware-${TEST_KEY}`)).toStrictEqual([]);
+	});
 
 	it("un-skips the typed pass when a module the config imports changed", () => {
 		expect.assertions(2);

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -25,7 +25,7 @@ import type { CommandPlan } from "../src/lint-cli/lib/plan/compose.ts";
 import { plan } from "../src/lint-cli/lib/plan/plan.ts";
 import type { PassPlan } from "../src/lint-cli/lib/plan/sizing.ts";
 import { stateDirectory } from "../src/lint-cli/lib/state.ts";
-import { computeAffectedFiles } from "../src/lint-cli/lib/typescript/affected.ts";
+import { computeAffectedFiles, hasBuilderState } from "../src/lint-cli/lib/typescript/affected.ts";
 import { allPasses, composeInDirectory, runContext } from "./lint-cli-helpers.ts";
 import { withoutGitEnvironment } from "./without-git.ts";
 
@@ -876,7 +876,7 @@ function anyCacheExists(directory: string, key: string): boolean {
  * @param key - The config-variant key whose caches were busted.
  * @returns The expected `BustOutcome.cleared` value.
  */
-function clearedPaths(directory: string, key: string): Array<string> {
+function allClearedPaths(directory: string, key: string): Array<string> {
 	return ALL_CACHE_FILES.map((name) => path.join(directory, cacheFileFor(name, key)));
 }
 
@@ -911,7 +911,7 @@ describe("applyConfigDriftBust", () => {
 		const outcome = bustConfig(runFor(directory));
 
 		expect(outcome).toStrictEqual({
-			cleared: clearedPaths(directory, TEST_KEY),
+			cleared: allClearedPaths(directory, TEST_KEY),
 			firstRun: false,
 		});
 		// Unlike the package.json bust, the fast (syntactic) cache is dropped
@@ -946,14 +946,14 @@ describe("applyConfigDriftBust", () => {
 		editRules(directory);
 
 		expect(bustConfig(runFor(directory))).toStrictEqual({
-			cleared: clearedPaths(directory, TEST_KEY),
+			cleared: allClearedPaths(directory, TEST_KEY),
 			firstRun: false,
 		});
 		// The no-agent run must not consume the drift on the agent's behalf.
 		expect(everyCacheExists(directory, AGENT_KEY)).toBe(true);
 
 		expect(bustConfig(runFor(directory, AGENT_ENVIRONMENT))).toStrictEqual({
-			cleared: clearedPaths(directory, AGENT_KEY),
+			cleared: allClearedPaths(directory, AGENT_KEY),
 			firstRun: false,
 		});
 		expect(anyCacheExists(directory, AGENT_KEY)).toBe(false);
@@ -1059,6 +1059,27 @@ describe("computeConfigHash discovery", () => {
 
 		expect(before).toBeDefined();
 		expect(after).toBe(before);
+	});
+});
+
+describe("hasBuilderState", () => {
+	it("ignores a temp file left behind by an interrupted write", () => {
+		expect.assertions(2);
+
+		// Both the buildinfo emit and `writeState` stage through a sibling
+		// `<name>.<pid>.tmp`, so a killed run leaves one under the same prefix
+		// the scan matches. Counting it as state would re-enable the builder skip
+		// with nothing on disk for the next run to invalidate against.
+		const directory = createFixture(CONFIG_IMPORT_FIXTURE);
+		const stray = path.join(stateDirectory(directory), `${TYPE_AWARE_BUILD_INFO}-abc.4242.tmp`);
+		fs.mkdirSync(path.dirname(stray), { recursive: true });
+		fs.writeFileSync(stray, "");
+
+		expect(hasBuilderState(runFor(directory), "only")).toBe(false);
+
+		computeAffectedFiles(runFor(directory), "only");
+
+		expect(hasBuilderState(runFor(directory), "only")).toBe(true);
 	});
 });
 

--- a/test/lint-cli-invalidation.spec.ts
+++ b/test/lint-cli-invalidation.spec.ts
@@ -144,25 +144,19 @@ function builderStateFiles(directory: string, prefix: string): Array<string> {
 }
 
 /**
- * Delete every builder state file, leaving the rest of the state directory
- * alone. A test that asserts a run did *not* build needs the buildinfo to be
- * absent beforehand, so that a build is observable as one reappearing — and it
- * must not take the `config-hash` state with it, or the drift bust under test
- * would report a first run and never fire.
+ * The content of every builder state file matching a prefix, in the order
+ * {@link builderStateFiles} lists them. A run that skipped the builder leaves
+ * these byte-identical; one that ran it over a changed program does not.
  *
  * @param directory - The fixture project root.
+ * @param prefix - The `tsbuildinfo-<mode>-<key>` prefix to match.
+ * @returns The matching files' contents.
  */
-function removeBuilderState(directory: string): void {
+function builderStateContents(directory: string, prefix: string): Array<string> {
 	const stateDirectory = path.join(directory, "node_modules/.cache/isentinel-lint");
-	if (!fs.existsSync(stateDirectory)) {
-		return;
-	}
-
-	for (const name of fs.readdirSync(stateDirectory)) {
-		if (name.startsWith("tsbuildinfo-") || name.startsWith("tsgate-")) {
-			fs.rmSync(path.join(stateDirectory, name), { force: true });
-		}
-	}
+	return builderStateFiles(directory, prefix).map((name) => {
+		return fs.readFileSync(path.join(stateDirectory, name), "utf8");
+	});
 }
 
 /**
@@ -1069,8 +1063,10 @@ describe("config drift sizing", () => {
 		return allPasses(runPlan).find((pass) => pass.descriptor.label === "typed");
 	}
 
+	const buildInfo = `tsbuildinfo-typeaware-${TEST_KEY}`;
+
 	it("runs no TypeScript builder when the drift bust cleared the caches", () => {
-		expect.assertions(2);
+		expect.assertions(3);
 
 		const directory = createFixture(CONFIG_IMPORT_FIXTURE);
 		const cacheFile = path.join(directory, TYPE_AWARE_CACHE);
@@ -1079,11 +1075,15 @@ describe("config drift sizing", () => {
 		computeAffectedFiles(runFor(directory), "only");
 		seedCache(cacheFile, [fileA]);
 		withoutGitEnvironment(() => plan(args, runContext(directory, { mutate: true })));
+		const before = builderStateContents(directory, buildInfo);
 
-		// Clear the builder state so this run's builder, if it runs at all,
-		// leaves a buildinfo behind. Editing the imported module changes no bust
-		// file, so only the drift bust can delete the caches.
-		removeBuilderState(directory);
+		expect(before).toHaveLength(1);
+
+		// A type-relevant edit the builder would otherwise record, alongside the
+		// config drift. Only the drift can reach the caches here: `eslint-rules`
+		// is neither a lint target nor a cache-bust file.
+		fs.writeFileSync(fileA, "export function a(): string { return 'now a string'; }\n");
+		touch(fileA);
 		editRules(directory);
 
 		const drifted = withoutGitEnvironment(() => {
@@ -1093,7 +1093,30 @@ describe("config drift sizing", () => {
 		expect(typedPass(drifted)!.shouldRun).toBe(true);
 		// The bust already deleted this pass's cache, so every file is dirty and
 		// the builder can only produce invalidation nothing will read.
-		expect(builderStateFiles(directory, `tsbuildinfo-typeaware-${TEST_KEY}`)).toStrictEqual([]);
+		expect(builderStateContents(directory, buildInfo)).toStrictEqual(before);
+	});
+
+	it("still seeds absent builder state when the bust cleared the caches", () => {
+		expect.assertions(2);
+
+		// Store the config hash without ever running the builder, then give the
+		// run caches to delete: the shape of a lint right after an install, which
+		// discards `node_modules` (the builder state with it) but not the caches.
+		const directory = createFixture(CONFIG_IMPORT_FIXTURE);
+		const args = parseArguments(["src"], {});
+		bustConfig(runFor(directory));
+		seedAllCaches(directory, TEST_KEY);
+		editRules(directory);
+
+		const drifted = withoutGitEnvironment(() => {
+			return plan(args, runContext(directory, { mutate: true }));
+		});
+
+		expect(typedPass(drifted)!.shouldRun).toBe(true);
+		// Skipping the builder here would leave the *next* run with no prior
+		// state, so it would report a first run and discard its affected set —
+		// and an importer of a file edited in between would keep a stale entry.
+		expect(builderStateFiles(directory, buildInfo)).toHaveLength(1);
 	});
 
 	it("un-skips the typed pass when a module the config imports changed", () => {

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -1176,7 +1176,7 @@ describe("applyPackageJsonBust", () => {
 	 * @param variantKey - The config-variant key whose caches were busted.
 	 * @returns The expected `BustOutcome.cleared` value.
 	 */
-	function clearedPaths(directory: string, variantKey: string): Array<string> {
+	function typeAwareClearedPaths(directory: string, variantKey: string): Array<string> {
 		return [CACHE_FILE_DEFAULT, CACHE_FILE_TYPE_AWARE].map((name) => {
 			return path.join(directory, cacheFileFor(name, variantKey));
 		});
@@ -1217,7 +1217,10 @@ describe("applyPackageJsonBust", () => {
 		writePackageJson(directory, { exports: "./other.js" });
 		const outcome = bustPackage(runContext(directory));
 
-		expect(outcome).toStrictEqual({ cleared: clearedPaths(directory, key), firstRun: false });
+		expect(outcome).toStrictEqual({
+			cleared: typeAwareClearedPaths(directory, key),
+			firstRun: false,
+		});
 		expect(fs.existsSync(path.join(directory, cacheFileFor(CACHE_FILE_TYPE_AWARE, key)))).toBe(
 			false,
 		);
@@ -1269,7 +1272,7 @@ describe("applyPackageJsonBust", () => {
 		// would make the second call a no-op and leave the agent's type-aware
 		// caches permanently stale.
 		expect(bustPackage(runContext(directory))).toStrictEqual({
-			cleared: clearedPaths(directory, key),
+			cleared: typeAwareClearedPaths(directory, key),
 			firstRun: false,
 		});
 		expect(
@@ -1277,7 +1280,7 @@ describe("applyPackageJsonBust", () => {
 		).toBe(true);
 
 		expect(bustPackage(agentRun)).toStrictEqual({
-			cleared: clearedPaths(directory, agentKey),
+			cleared: typeAwareClearedPaths(directory, agentKey),
 			firstRun: false,
 		});
 		expect(

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -1167,10 +1167,10 @@ describe("applyPackageJsonBust", () => {
 	}
 
 	/**
-	 * The cleared-path list a bust of one variant's caches must report: the two
-	 * type-aware caches, in the order the bust deletes them. The planner sizes
-	 * its passes against these, so what the outcome names — not only what it
-	 * deleted — is behaviour.
+	 * The cleared-path list this bust must report: the two type-aware caches,
+	 * in the order it deletes them. Spelled out rather than read back from
+	 * `PACKAGE_RESOLUTION.caches`, which would only assert the code against
+	 * itself.
 	 *
 	 * @param directory - The fixture root.
 	 * @param variantKey - The config-variant key whose caches were busted.

--- a/test/lint-cli.spec.ts
+++ b/test/lint-cli.spec.ts
@@ -1167,6 +1167,22 @@ describe("applyPackageJsonBust", () => {
 	}
 
 	/**
+	 * The cleared-path list a bust of one variant's caches must report: the two
+	 * type-aware caches, in the order the bust deletes them. The planner sizes
+	 * its passes against these, so what the outcome names — not only what it
+	 * deleted — is behaviour.
+	 *
+	 * @param directory - The fixture root.
+	 * @param variantKey - The config-variant key whose caches were busted.
+	 * @returns The expected `BustOutcome.cleared` value.
+	 */
+	function clearedPaths(directory: string, variantKey: string): Array<string> {
+		return [CACHE_FILE_DEFAULT, CACHE_FILE_TYPE_AWARE].map((name) => {
+			return path.join(directory, cacheFileFor(name, variantKey));
+		});
+	}
+
+	/**
 	 * Apply the package-resolution bust to a run, hashing its `package.json`
 	 * the way the planner does.
 	 *
@@ -1186,7 +1202,7 @@ describe("applyPackageJsonBust", () => {
 
 		const outcome = bustPackage(runContext(directory));
 
-		expect(outcome).toStrictEqual({ busted: false, firstRun: true });
+		expect(outcome).toStrictEqual({ cleared: [], firstRun: true });
 		expect(everyCacheExists(directory)).toBe(true);
 	});
 
@@ -1201,7 +1217,7 @@ describe("applyPackageJsonBust", () => {
 		writePackageJson(directory, { exports: "./other.js" });
 		const outcome = bustPackage(runContext(directory));
 
-		expect(outcome).toStrictEqual({ busted: true, firstRun: false });
+		expect(outcome).toStrictEqual({ cleared: clearedPaths(directory, key), firstRun: false });
 		expect(fs.existsSync(path.join(directory, cacheFileFor(CACHE_FILE_TYPE_AWARE, key)))).toBe(
 			false,
 		);
@@ -1226,7 +1242,7 @@ describe("applyPackageJsonBust", () => {
 		});
 		const outcome = bustPackage(runContext(directory));
 
-		expect(outcome).toStrictEqual({ busted: false, firstRun: false });
+		expect(outcome).toStrictEqual({ cleared: [], firstRun: false });
 		expect(everyCacheExists(directory)).toBe(true);
 	});
 
@@ -1253,7 +1269,7 @@ describe("applyPackageJsonBust", () => {
 		// would make the second call a no-op and leave the agent's type-aware
 		// caches permanently stale.
 		expect(bustPackage(runContext(directory))).toStrictEqual({
-			busted: true,
+			cleared: clearedPaths(directory, key),
 			firstRun: false,
 		});
 		expect(
@@ -1261,7 +1277,7 @@ describe("applyPackageJsonBust", () => {
 		).toBe(true);
 
 		expect(bustPackage(agentRun)).toStrictEqual({
-			busted: true,
+			cleared: clearedPaths(directory, agentKey),
 			firstRun: false,
 		});
 		expect(


### PR DESCRIPTION
## Problem

After an `eslint.config.*` edit, the typed ESLint pass took seconds to spawn.

`applyHashBust(CONFIG_DRIFT)` deletes the variant's three cache files, and it runs *before* `sweepStaleCaches` lists what is on disk. The sweep therefore could not see them, and only the sweep's deletions fed `clearedCaches` — the set `mutatingDirtyCount` uses to short-circuit. The typed pass fell through and ran the full TypeScript builder to invalidate a cache that was already gone: `openCache` returned `undefined`, `removeEntries` was a no-op, and the dirty count was already at maximum. Pure waste, on the critical path.

## Change

- `applyHashBust` reports the paths it deleted; `plan` folds every deletion — both busts and the sweep — into `clearedCaches`.
- The skip is gated on prior builder state existing. The builder's affected set is disposable when the cache is gone, but the builder is also the only thing that establishes the state a *later* run invalidates against. Skipping with none on disk (a lint right after an install, which discards `node_modules/.cache` but not the root `.eslintcache-*` files) would make the next run report `firstRun` and throw its affected set away, leaving importers of a file edited in between with stale type-aware entries.
- `hasBuilderState` ignores `<name>.<pid>.tmp` files. Both writers in the state directory stage through a sibling temp that shares the scanned prefix, so a run killed mid-write would otherwise leave one behind that reads as real state forever.

## Monorepo

No change needed, and none made. Cache and state files are keyed per `cwd` and per config variant, so parallel per-package lints never touch each other's. A hoisted root config is covered twice: `collectAncestorBustFiles` walks up to the workspace root for the mtime bust, and `configFiles` includes those ancestor entry points, so `computeConfigHash` walks the root config's import closure too. Each package observes the same drift on its own next run.

## Not addressed

`resolveIgnoredFiles` is now the dominant remaining delay on a config edit: a changed config hash misses its memo and spawns a child that loads the whole ESLint config. It cannot move off the critical path — its answer sizes the workers — and it is unchanged here.

## Testing

Four new tests in `test/lint-cli-invalidation.spec.ts`, each written red first. Full suite: 571 passing, no type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation after configuration changes, package resolution updates, and stale-cache cleanup.
  * Prevented stale entries from surviving initial TypeScript builder runs when no prior state exists.
  * Improved handling of interrupted or temporary build state files.
  * Cache-clearing results now accurately report the paths that were removed.

* **Tests**
  * Expanded coverage for configuration drift, cache variants, cleared caches, and missing builder state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->