### PR TITLE
feat(pnpm): enforce minimumReleaseAgeExcludePrune, sort pnpm 12 settings

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ ignoreWorkspaceRootCheck: true
 minimumReleaseAgeExclude:
   - eslint-plugin-flawless
 
+minimumReleaseAgeExcludePrune: true
 savePrefix: ""
 shellEmulator: true
 strictPeerDependencies: false

--- a/src/eslint/configs/pnpm.ts
+++ b/src/eslint/configs/pnpm.ts
@@ -63,6 +63,7 @@ export async function pnpm(
 						settings: {
 							catalogMode: "prefer",
 							cleanupUnusedCatalogs: true,
+							minimumReleaseAgeExcludePrune: true,
 							shellEmulator: true,
 							trustPolicy: "no-downgrade",
 							trustPolicyIgnoreAfter: 10080,

--- a/src/eslint/configs/sort.ts
+++ b/src/eslint/configs/sort.ts
@@ -459,6 +459,7 @@ export function sortPnpmWorkspace(): Array<TypedFlatConfigItem> {
 								"blockExoticSubdeps",
 								"cacheDir",
 								"catalogMode",
+								"catalogPrune",
 								"cleanupUnusedCatalogs",
 								"dedupeDirectDeps",
 								"dedupePeerDependents",
@@ -468,6 +469,7 @@ export function sortPnpmWorkspace(): Array<TypedFlatConfigItem> {
 								"enablePrePostScripts",
 								"engineStrict",
 								"extendNodePath",
+								"globalShims",
 								"hoist",
 								"hoistPattern",
 								"hoistWorkspacePackages",
@@ -483,6 +485,7 @@ export function sortPnpmWorkspace(): Array<TypedFlatConfigItem> {
 								"managePackageManagerVersions",
 								"minimumReleaseAge",
 								"minimumReleaseAgeExclude",
+								"minimumReleaseAgeExcludePrune",
 								"minimumReleaseAgeIgnoreMissingTime",
 								"minimumReleaseAgeStrict",
 								"modulesDir",
@@ -505,6 +508,7 @@ export function sortPnpmWorkspace(): Array<TypedFlatConfigItem> {
 								"shamefullyHoist",
 								"sharedWorkspaceLockfile",
 								"shellEmulator",
+								"sideEffectsCache",
 								"stateDir",
 								"strictDepBuilds",
 								"strictPeerDependencies",
@@ -518,6 +522,7 @@ export function sortPnpmWorkspace(): Array<TypedFlatConfigItem> {
 								"updateConfig",
 								"updateNotifier",
 								"verifyDepsBeforeRun",
+								"virtualStoreType",
 							],
 
 							// Lockfile
@@ -551,6 +556,7 @@ export function sortPnpmWorkspace(): Array<TypedFlatConfigItem> {
 								"onlyBuiltDependenciesFile",
 								"packageExtensions",
 								"peerDependencyRules",
+								"tasks",
 							],
 
 							// Unlisted keys: sort alphabetically, last.
@@ -575,7 +581,7 @@ export function sortPnpmWorkspace(): Array<TypedFlatConfigItem> {
 					{
 						order: { natural: true, type: "asc" },
 						pathPattern:
-							"^(supportedArchitectures\\.(cpu|libc|os)|updateConfig\\.ignoreDependencies|peerDependencyRules\\.(allowAny|ignoreMissing)|auditConfig\\.(ignoreCves|ignoreGhsas))$",
+							"^(supportedArchitectures\\.(cpu|libc|os)|update\\.ignoreDeps|updateConfig\\.ignoreDependencies|peerDependencyRules\\.(allowAny|ignoreMissing)|audit\\.ignore|auditConfig\\.(ignoreCves|ignoreGhsas)|sideEffectsCache\\.remote\\.packages|tasks\\.[^.]+\\.dependsOn)$",
 					},
 				],
 			},


### PR DESCRIPTION
## What

pnpm 12 added workspace settings the preset did not know about.

### 1. `yaml-enforce-settings`

Adds `minimumReleaseAgeExcludePrune: true`. `pnpm add`, `pnpm update` and `pnpm remove` then drop `minimumReleaseAgeExclude` entries the freshly written lockfile no longer resolves. Name patterns (`@scope/*`) are always kept, and the prune is skipped under `sharedWorkspaceLockfile: false`.

### 2. `pnpm-workspace.yaml` key order

New keys in the curated `yaml/sort-keys` order, alphabetical inside their existing groups:

| setting | shape | since |
| --- | --- | --- |
| `catalogPrune` | boolean | rename of `cleanupUnusedCatalogs` |
| `globalShims` | `false` or record of package to policy | 12.0 |
| `minimumReleaseAgeExcludePrune` | boolean | 12.x |
| `sideEffectsCache` | boolean or `{ read, write, remote }` | object form 12.1 |
| `tasks` | map of task to `{ concurrency, dependsOn }` | 12.1 |
| `virtualStoreType` | enum | 12.0 |

`tasks` sits in the "Other" group with the other section-shaped keys.

### 3. Nested sequences

`yaml/sort-sequence-values` gains `sideEffectsCache.remote.packages` and `tasks.<name>.dependsOn`, plus `audit.ignore` and `update.ignoreDeps` — the current spellings of `auditConfig.ignoreGhsas` and `updateConfig.ignoreDependencies`, which the pattern already covered.

## Notes

- `cleanupUnusedCatalogs` stays in `yaml-enforce-settings`. pnpm 12 keeps reading it, and `catalogPrune` is unknown to pnpm 11, which this repo still runs. Both names are in the sort order.
- `remoteSideEffectsCache` is left out: 12.0 added it and 12.1 superseded it with `sideEffectsCache.remote`.
- `scope` is left out: pnpm 12.1 ignores it in `pnpm-workspace.yaml`.
- `minimumReleaseAgeExcludePrune` is unknown to pnpm 11, which ignores unrecognized settings in silence, so the enforced key is inert there.
- The repo's own `pnpm-workspace.yaml` picked up the new key by autofix.

## Test plan

- `pnpm gen` — no drift
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 40 files, 591 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
