### PR TITLE
fix(oxlint): keep oxfmt in ESLint for non-JS/TS languages

### DIFF
--- a/src/eslint/oxlint-drop.ts
+++ b/src/eslint/oxlint-drop.ts
@@ -1,4 +1,4 @@
-import { GLOB_MARKDOWN_CODE } from "../globs.ts";
+import { GLOB_MARKDOWN_CODE, GLOB_SRC_EXTENSIONS } from "../globs.ts";
 import {
 	isPresetRuleJsPlugin,
 	isPresetRuleOxlintCovered,
@@ -9,6 +9,28 @@ import type { OxlintRoute } from "../oxlint/routing.ts";
 import type { TypedFlatConfigItem } from "./types.ts";
 
 const HYBRID_FORMATTING_RULES = new Set(["oxfmt/oxfmt"]);
+
+/** The real file extensions oxlint can parse. */
+const JS_TS_EXTENSIONS: ReadonlySet<string> = new Set(GLOB_SRC_EXTENSIONS);
+
+/** A glob wildcard, which makes an extension fragment match anything. */
+const GLOB_WILDCARD = /[*?]/;
+
+/** One brace or bracket group, with no nesting. */
+const GLOB_GROUP = /\{[^{}]*\}|\[[^[\]]*\]/gu;
+
+/**
+ * {@link GLOB_GROUP} as a capturing splitter, so the groups survive a split.
+ */
+const GLOB_GROUP_SPLIT = /(\{[^{}]*\}|\[[^[\]]*\])/u;
+
+/**
+ * Any glob group delimiter, left over when a group is nested or unterminated.
+ */
+const GLOB_GROUP_DELIMITER = /[{}[\]]/u;
+
+/** A single character, used to list the members of a bracket group. */
+const GLOB_ANY_CHARACTER = /./gu;
 
 /**
  * How much of the mapping oxlint owns in hybrid mode.
@@ -29,8 +51,10 @@ interface DeadRuleReference {
  * Warn when a user-supplied config references a rule that oxlint owns in hybrid
  * mode (`oxlint: true`). The preset drops every oxlint-covered rule from the
  * ESLint side and lets oxlint format real JS/TS files, so such entries silently
- * do nothing. Markdown-scoped configs are exempt: oxlint cannot lint Markdown
- * virtual files, so the preset re-enables those rules there.
+ * do nothing. Configs oxlint cannot reach are exempt: Markdown-scoped ones
+ * (oxlint cannot lint Markdown virtual files, so the preset re-enables those
+ * rules there) and ones scoped to a non-JS/TS language, which oxlint never
+ * parses.
  *
  * @param configs - The resolved flat config items.
  * @param mode - The hybrid mode; in `native` mode jsPlugin rules and formatting
@@ -78,6 +102,11 @@ export function warnMissingTsgolint(): void {
  * sibling is inserted directly after the original so later configs (for
  * example the markdown disables) still take precedence.
  *
+ * Configs scoped to a language oxlint does not parse are skipped outright: it
+ * reads only the JS/TS family, so handing it `oxfmt/oxfmt` for YAML, JSON, CSS
+ * or GraphQL would drop the formatter from ESLint without any engine picking it
+ * up. See {@link targetsJsOrTs}.
+ *
  * @param configs - The resolved flat config items (mutated in place).
  * @param typeAware - Whether oxlint runs type-aware (oxlint-tsgolint present).
  *   When `false`, tsgolint rules are kept in ESLint so they do not vanish from
@@ -96,7 +125,8 @@ export function dropOxlintCoveredRules(
 			!config.name.startsWith("isentinel/") ||
 			config.name.endsWith("/markdown-code") ||
 			config.rules === undefined ||
-			targetsMarkdown(config.files)
+			targetsMarkdown(config.files) ||
+			!targetsJsOrTs(config.files)
 		) {
 			continue;
 		}
@@ -178,6 +208,125 @@ function targetsMarkdown(files: TypedFlatConfigItem["files"]): boolean {
 	);
 }
 
+/**
+ * The strings one part of a {@link GLOB_GROUP_SPLIT} split can stand for: the
+ * comma-separated members of a brace group, the individual characters of a
+ * bracket group, or the literal text itself. A part that still holds a group
+ * delimiter is a nested or unterminated group, which is not expanded.
+ *
+ * @param part - One part of a glob fragment split on its groups.
+ * @returns The alternatives, or `undefined` when the part is not expandable.
+ */
+function groupAlternatives(part: string): Array<string> | undefined {
+	const body = part.slice(1, -1);
+	if (part.startsWith("{")) {
+		return body.split(",");
+	}
+
+	if (part.startsWith("[")) {
+		return body.match(GLOB_ANY_CHARACTER) ?? [];
+	}
+
+	return GLOB_GROUP_DELIMITER.test(part) ? undefined : [part];
+}
+
+/**
+ * Expand the brace and character-class alternatives of a glob fragment.
+ *
+ * Only the closed forms the preset's globs use are handled (`{,c,m}`, `[jt]`);
+ * anything with a wildcard, a nested group or an unterminated group yields
+ * `undefined`, meaning "could be anything". Callers treat that as a match, so
+ * an unknown pattern keeps the pre-existing drop behavior.
+ *
+ * @param fragment - The glob fragment to expand.
+ * @returns Every literal string the fragment can produce, or `undefined` when
+ *   the fragment is not a closed set of literals.
+ */
+function expandGlobAlternatives(fragment: string): Array<string> | undefined {
+	if (GLOB_WILDCARD.test(fragment)) {
+		return undefined;
+	}
+
+	let results = [""];
+	for (const part of fragment.split(GLOB_GROUP_SPLIT)) {
+		const alternatives = groupAlternatives(part);
+		if (alternatives === undefined) {
+			return undefined;
+		}
+
+		results = results.flatMap((prefix) => {
+			return alternatives.map((alternative) => prefix + alternative);
+		});
+	}
+
+	return results;
+}
+
+/**
+ * The index of the extension dot in a glob's last path segment, or `-1` when it
+ * has none. Dots inside a brace or bracket group are masked out first: they
+ * belong to an alternative, not to the extension boundary.
+ *
+ * @param segment - The last path segment of a `files` pattern.
+ * @returns The index of the extension dot, or `-1`.
+ */
+function extensionDotIndex(segment: string): number {
+	const masked = segment.replaceAll(GLOB_GROUP, (group) => "\0".repeat(group.length));
+	return masked.lastIndexOf(".");
+}
+
+/**
+ * Whether a single `files` pattern can match a file oxlint reads.
+ *
+ * Oxlint parses only the JS/TS family, so a pattern whose extension is a closed
+ * set of non-JS/TS extensions (`**\/*.y{,a}ml`, `**\/*.json{,5,c}`) describes
+ * files oxlint never sees. A pattern whose last segment has no extension, or
+ * whose extension is not a closed set, matches conservatively.
+ *
+ * @param pattern - The `files` pattern to classify.
+ * @returns Whether oxlint can lint something the pattern matches.
+ */
+function patternTargetsJsOrTs(pattern: string): boolean {
+	const segment = pattern.slice(pattern.lastIndexOf("/") + 1);
+	const dot = extensionDotIndex(segment);
+	if (dot === -1) {
+		return true;
+	}
+
+	const extensions = expandGlobAlternatives(segment.slice(dot + 1));
+	if (extensions === undefined) {
+		return true;
+	}
+
+	return extensions.some((extension) => JS_TS_EXTENSIONS.has(extension));
+}
+
+/**
+ * Whether a config's `files` reach any file oxlint can lint.
+ *
+ * Hybrid mode only hands a rule to oxlint for the files oxlint actually parses.
+ * A config scoped to YAML, JSON, CSS or GraphQL is invisible to oxlint, so its
+ * rules must stay in ESLint or they run in neither engine — the case that
+ * silently dropped `oxfmt/oxfmt` from every non-JS formatting config.
+ *
+ * @param files - The config's `files` patterns; nested arrays are AND-combined,
+ *   so they only reach JS/TS when every member does.
+ * @returns Whether oxlint can lint something the config targets.
+ */
+function targetsJsOrTs(files: TypedFlatConfigItem["files"]): boolean {
+	if (files === undefined || files.length === 0) {
+		return true;
+	}
+
+	return files.some((entry) => {
+		if (typeof entry === "string") {
+			return patternTargetsJsOrTs(entry);
+		}
+
+		return entry.every((pattern) => patternTargetsJsOrTs(pattern));
+	});
+}
+
 function findDeadMappedRules(
 	configs: Array<TypedFlatConfigItem>,
 	mode: OxlintHybridMode,
@@ -185,7 +334,12 @@ function findDeadMappedRules(
 	const references: Array<DeadRuleReference> = [];
 
 	for (const config of configs) {
-		if (config.rules === undefined || isPresetConfig(config) || targetsMarkdown(config.files)) {
+		if (
+			config.rules === undefined ||
+			isPresetConfig(config) ||
+			targetsMarkdown(config.files) ||
+			!targetsJsOrTs(config.files)
+		) {
 			continue;
 		}
 

--- a/test/oxlint-formatter-coverage.spec.ts
+++ b/test/oxlint-formatter-coverage.spec.ts
@@ -1,0 +1,145 @@
+import { ESLint } from "eslint";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import type { OptionsConfig, TypedFlatConfigItem } from "../src/eslint/types.ts";
+import { isentinel } from "../src/index.ts";
+
+const PROJECT_ROOT = path.resolve(import.meta.dirname, "..");
+
+const DEAD_HEADER = "oxlint owns in hybrid mode";
+
+const baseOptions = {
+	formatters: true,
+	gitignore: false,
+	isAgent: false,
+	isInEditor: false,
+	pnpm: false,
+	roblox: false,
+	spellCheck: false,
+} as const;
+
+/**
+ * Every oxfmt config scoped to a language oxlint cannot parse. Oxlint reads
+ * only the JS/TS family, so these must keep formatting in ESLint even in
+ * hybrid mode.
+ */
+const NON_JS_FORMATTER_CONFIGS = [
+	"isentinel/oxfmt/css",
+	"isentinel/oxfmt/scss",
+	"isentinel/oxfmt/less",
+	"isentinel/oxfmt/html",
+	"isentinel/oxfmt/markdown",
+	"isentinel/oxfmt/graphql",
+	"isentinel/oxfmt/json",
+	"isentinel/oxfmt/yaml",
+] as const;
+
+type FactoryOptions = OptionsConfig & TypedFlatConfigItem & { namedConfigs?: false };
+
+async function resolveConfigs(
+	options: Record<string, unknown>,
+	...userConfigs: Array<TypedFlatConfigItem>
+): Promise<Array<TypedFlatConfigItem>> {
+	const composer = await isentinel(options as FactoryOptions, ...userConfigs);
+	return [...composer];
+}
+
+/**
+ * The `name` of every config, with unnamed ones collapsed to an empty string.
+ *
+ * @param configs - The resolved flat config items.
+ * @returns One entry per config, in resolution order.
+ */
+function configNames(configs: Array<TypedFlatConfigItem>): Array<string> {
+	return configs.map((config) => config.name ?? "");
+}
+
+/**
+ * The names of the configs that enable `oxfmt/oxfmt`, in resolution order.
+ *
+ * @param configs - The resolved flat config items.
+ * @returns The names of the configs that format.
+ */
+function formattingConfigNames(configs: Array<TypedFlatConfigItem>): Array<string> {
+	return configNames(configs.filter((config) => config.rules?.["oxfmt/oxfmt"] !== undefined));
+}
+
+describe("oxlint hybrid formatter coverage", () => {
+	it("should keep oxfmt in ESLint for languages oxlint cannot parse", async () => {
+		expect.assertions(1);
+
+		const configs = await resolveConfigs({ ...baseOptions, oxlint: true });
+		const formatting = new Set(formattingConfigNames(configs));
+
+		expect([...NON_JS_FORMATTER_CONFIGS].filter((name) => !formatting.has(name))).toStrictEqual(
+			[],
+		);
+	});
+
+	it("should not create unreachable Markdown siblings for those configs", async () => {
+		expect.assertions(1);
+
+		const configs = await resolveConfigs({ ...baseOptions, oxlint: true });
+		const names = new Set(configNames(configs));
+
+		expect(
+			NON_JS_FORMATTER_CONFIGS.map((name) => `${name}/markdown-code`).filter((name) => {
+				return names.has(name);
+			}),
+		).toStrictEqual([]);
+	});
+
+	it("should still hand JS/TS formatting to oxlint", async () => {
+		expect.assertions(1);
+
+		const configs = await resolveConfigs({ ...baseOptions, oxlint: true });
+
+		expect(formattingConfigNames(configs)).toStrictEqual([
+			"isentinel/oxfmt/markdown-code",
+			...NON_JS_FORMATTER_CONFIGS,
+		]);
+	});
+
+	it("should report formatting on a YAML file in hybrid mode", async () => {
+		expect.assertions(1);
+
+		const configs = await resolveConfigs({ ...baseOptions, ignores: [], oxlint: true });
+		const eslint = new ESLint({
+			cwd: PROJECT_ROOT,
+			overrideConfig: configs,
+			overrideConfigFile: true,
+		});
+
+		const results = await eslint.lintText("a:    1\nb:      [1,    2]\n", {
+			filePath: path.join(PROJECT_ROOT, "hybrid-formatter-coverage.yaml"),
+		});
+
+		expect(
+			results.flatMap((result) => result.messages.map((message) => message.ruleId)),
+		).toContain("oxfmt/oxfmt");
+	});
+
+	it("should not warn that oxfmt is dead in a non-JS user config", async () => {
+		expect.assertions(1);
+
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		let messages: Array<string> = [];
+		try {
+			await resolveConfigs(
+				{ ...baseOptions, oxlint: true },
+				{
+					name: "user/yaml-format",
+					files: ["**/*.y{,a}ml"],
+					rules: { "oxfmt/oxfmt": "error" },
+				},
+			);
+			messages = warn.mock.calls.map((call) => String(call[0]));
+		} finally {
+			warn.mockRestore();
+		}
+
+		expect(messages.filter((message) => message.includes(DEAD_HEADER))).toStrictEqual([]);
+	});
+});


### PR DESCRIPTION
## Problem

With `oxlint: true` (full hybrid mode), `oxfmt/oxfmt` was dropped from every
non-JS formatting config and picked up by no engine. YAML, JSON, CSS, SCSS,
LESS, HTML and GraphQL went unformatted, and `formatters.yaml: true` (and its
siblings) had no effect.

`dropOxlintCoveredRules` decided rule ownership by rule name alone, ignoring the
config's `files` glob. `oxfmt/oxfmt` is a jsPlugin rule, so it was treated as
oxlint-covered for every file type — but oxlint parses only JS/TS:

```
$ pnpm exec oxlint --disable-nested-config pnpm-workspace.yaml
No files found to lint.
```

The dropped rule was re-added in a `*/markdown-code` sibling, but
`markdownVirtualFiles` AND-combines each pattern with the JS/TS code-block glob.
For the YAML config that yields `[["**/*.md/**/*.{,c,m}[jt]s{,x}", "**/*.y{,a}ml"]]`
— a file would have to be both a `.ts` code block and a `.yaml`. It matched
nothing.

Measured on `6.0.0-beta.44`:

| config | `oxlint: true` | `oxlint: false` |
|---|---|---|
| `isentinel/oxfmt/{css,scss,less,html,graphql,json,yaml}` | no rule | has rule |

End-to-end, on a deliberately misformatted file:

```
oxlint=true   probe.yaml -> yaml/key-spacing                 (no oxfmt)
oxlint=false  probe.yaml -> yaml/key-spacing, oxfmt/oxfmt
```

`oxlint: "native"` was never affected — it already keeps jsPlugin rules in
ESLint. That is why this repo's own config did not show the bug.

## Fix

Add `targetsJsOrTs` beside the existing `targetsMarkdown` exemption: skip a
preset config when its `files` patterns reach no extension oxlint can read.

The predicate takes each pattern's last path segment, finds the extension dot
outside any brace or bracket group, expands the extension fragment
(`{,c,m}ts` -> `ts`, `cts`, `mts`) and tests the result against
`GLOB_SRC_EXTENSIONS`. Patterns it cannot expand — a wildcard extension, a
nested group, no extension at all — match conservatively, so unknown patterns
keep the previous drop behaviour. Nested `files` arrays are AND-combined, so
they reach JS/TS only when every member does.

The same guard goes into `findDeadMappedRules`, so a YAML-scoped user config
no longer gets a spurious "oxlint owns this rule" warning.

JS/TS formatting still hands off to oxlint exactly as before, and the seven
unreachable `*/markdown-code` siblings are no longer created.

## Tests

`test/oxlint-formatter-coverage.spec.ts` — five cases: non-JS configs keep
`oxfmt/oxfmt`; no unreachable Markdown siblings; JS/TS still hands off to oxlint
(exact ordered list, so a regression in either direction fails); an end-to-end
ESLint run on a misformatted YAML reports `oxfmt/oxfmt`; no dead-rule warning for
a YAML-scoped user config.

Verified the tests bite: with the guard reverted, four of the five fail. The
fifth passes both ways by design — it is the guard rail against over-correcting.

## Verification

- `vitest run` — 41 files, 596 tests pass, no type errors
- `tsc --noEmit` — clean
- `isentinel-lint` — clean (oxlint + ESLint)
- `pnpm gen` — no generated drift
- `pnpm build` — clean, publint OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hybrid formatting so non-JavaScript and non-TypeScript files, including CSS, HTML, Markdown, GraphQL, JSON, and YAML, continue using ESLint formatting.
  * Prevented unreachable configuration warnings for supported non-JavaScript file types.
  * Continued routing JavaScript and TypeScript formatting to oxlint in hybrid mode.
  * Corrected formatter reporting for YAML files in hybrid mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->