### PR TITLE
fix(lint-cli): resolve the local bin the way Node resolves it

### DIFF
--- a/src/lint-cli/lib/exec/eslint-install.ts
+++ b/src/lint-cli/lib/exec/eslint-install.ts
@@ -11,12 +11,7 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 
-/**
- * A synthetic basename for `createRequire`, which resolves relative to a file
- * rather than a directory. Spelled so it can never collide with a real consumer
- * module.
- */
-const RESOLVE_ANCHOR = "__isentinel-lint__.js";
+import { RESOLVE_ANCHOR } from "./resolve.ts";
 
 /** A resolved ESLint installation. */
 export interface EslintInstall {

--- a/src/lint-cli/lib/exec/resolve.ts
+++ b/src/lint-cli/lib/exec/resolve.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { isRecord } from "../../../guards.ts";
 import { CliError } from "../cli/types.ts";
+import { readFileIfPresent } from "../state.ts";
 
 /** Memoised {@link resolveLocalBin} results, keyed by `cwd\0name`. */
 const localBinCache = new Map<string, string>();
@@ -98,7 +99,12 @@ export function resolveIgnoredHelper(): string {
  * @returns The declared relative path, or undefined when there is none.
  */
 function readBinEntry(manifestPath: string, name: string): string | undefined {
-	const parsed: unknown = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+	const raw = readFileIfPresent(manifestPath);
+	if (raw === undefined) {
+		return undefined;
+	}
+
+	const parsed: unknown = JSON.parse(raw);
 	if (!isRecord(parsed)) {
 		return undefined;
 	}

--- a/src/lint-cli/lib/exec/resolve.ts
+++ b/src/lint-cli/lib/exec/resolve.ts
@@ -7,6 +7,13 @@ import { isRecord } from "../../../guards.ts";
 import { CliError } from "../cli/types.ts";
 import { readFileIfPresent } from "../state.ts";
 
+/**
+ * A synthetic basename for `createRequire`, which resolves relative to a file
+ * rather than a directory. Spelled so it can never collide with a real consumer
+ * module.
+ */
+export const RESOLVE_ANCHOR = "__isentinel-lint__.js";
+
 /** Memoised {@link resolveLocalBin} results, keyed by `cwd\0name`. */
 const localBinCache = new Map<string, string>();
 
@@ -104,7 +111,13 @@ function readBinEntry(manifestPath: string, name: string): string | undefined {
 		return undefined;
 	}
 
-	const parsed: unknown = JSON.parse(raw);
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+
 	if (!isRecord(parsed)) {
 		return undefined;
 	}
@@ -121,9 +134,9 @@ function readBinEntry(manifestPath: string, name: string): string | undefined {
 /**
  * Locate a package's manifest exactly as a `require` call from `cwd` would.
  *
- * `createRequire` resolves relative to the *file* it is handed, so `cwd` is
- * joined with a sentinel filename that never has to exist — passing the bare
- * directory would start the walk one level too high.
+ * Reads the manifest as a subpath, so a package whose `exports` map hides
+ * `./package.json` counts as unresolvable. Both packages this serves publish
+ * it, and one that does not could not be spawned from its `bin` field anyway.
  *
  * @param name - The package name to resolve.
  * @param cwd - The directory to resolve from.
@@ -131,7 +144,7 @@ function readBinEntry(manifestPath: string, name: string): string | undefined {
  *   the package is not installed.
  */
 function resolveManifest(name: string, cwd: string): string | undefined {
-	const require = createRequire(path.join(cwd, "resolve-local-bin.js"));
+	const require = createRequire(path.join(cwd, RESOLVE_ANCHOR));
 	try {
 		return require.resolve(`${name}/package.json`);
 	} catch {

--- a/src/lint-cli/lib/exec/resolve.ts
+++ b/src/lint-cli/lib/exec/resolve.ts
@@ -1,8 +1,9 @@
-import { getPackageInfoSync } from "local-pkg";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { isRecord } from "../../../guards.ts";
 import { CliError } from "../cli/types.ts";
 
 /** Memoised {@link resolveLocalBin} results, keyed by `cwd\0name`. */
@@ -15,6 +16,10 @@ const localBinCache = new Map<string, string>();
  * Windows `.cmd`/`.ps1` quoting hazards. Memoised so the two ESLint passes
  * resolve the same bin once.
  *
+ * The walk is Node's own rather than a hand-rolled one: inside a worktree
+ * nested in its own checkout the two disagree, and taking the ancestor's copy
+ * silently runs a different version of the linter than every other tool sees.
+ *
  * @param name - The package name to resolve (for example `eslint`).
  * @param cwd - The directory to resolve from.
  * @returns The absolute path to the package's JavaScript entry.
@@ -26,20 +31,19 @@ export function resolveLocalBin(name: string, cwd: string): string {
 		return cached;
 	}
 
-	const info = getPackageInfoSync(name, { paths: [cwd] });
-	if (info === undefined) {
+	const manifestPath = resolveManifest(name, cwd);
+	if (manifestPath === undefined) {
 		throw new CliError(
 			`Could not find "${name}". Install it in this project to run isentinel-lint.`,
 		);
 	}
 
-	const { bin } = info.packageJson;
-	const relative = typeof bin === "string" ? bin : bin?.[name];
+	const relative = readBinEntry(manifestPath, name);
 	if (relative === undefined) {
 		throw new CliError(`Package "${name}" does not declare a "${name}" bin entry.`);
 	}
 
-	const resolved = path.resolve(info.rootPath, relative);
+	const resolved = path.resolve(path.dirname(manifestPath), relative);
 	localBinCache.set(cacheKey, resolved);
 	return resolved;
 }
@@ -82,4 +86,49 @@ export function resolveIgnoredHelper(): string {
 	return fs.existsSync(built)
 		? built
 		: fileURLToPath(new URL("../../ignored-child.ts", import.meta.url));
+}
+
+/**
+ * The path a package's manifest declares as the bin of the package's own name,
+ * relative to the package root. Both the shorthand string form and the map form
+ * count.
+ *
+ * @param manifestPath - The absolute path to the package's `package.json`.
+ * @param name - The bin name to look for.
+ * @returns The declared relative path, or undefined when there is none.
+ */
+function readBinEntry(manifestPath: string, name: string): string | undefined {
+	const parsed: unknown = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+	if (!isRecord(parsed)) {
+		return undefined;
+	}
+
+	const { bin } = parsed;
+	if (typeof bin === "string") {
+		return bin;
+	}
+
+	const entry = isRecord(bin) ? bin[name] : undefined;
+	return typeof entry === "string" ? entry : undefined;
+}
+
+/**
+ * Locate a package's manifest exactly as a `require` call from `cwd` would.
+ *
+ * `createRequire` resolves relative to the *file* it is handed, so `cwd` is
+ * joined with a sentinel filename that never has to exist — passing the bare
+ * directory would start the walk one level too high.
+ *
+ * @param name - The package name to resolve.
+ * @param cwd - The directory to resolve from.
+ * @returns The absolute path to the package's `package.json`, or undefined when
+ *   the package is not installed.
+ */
+function resolveManifest(name: string, cwd: string): string | undefined {
+	const require = createRequire(path.join(cwd, "resolve-local-bin.js"));
+	try {
+		return require.resolve(`${name}/package.json`);
+	} catch {
+		return undefined;
+	}
 }

--- a/test/lint-cli-resolve.spec.ts
+++ b/test/lint-cli-resolve.spec.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, onTestFinished } from "vitest";
+
+import { CliError } from "../src/lint-cli/lib/cli/types.ts";
+import { resolveLocalBin } from "../src/lint-cli/lib/exec/resolve.ts";
+
+function temporaryDirectory(): string {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), "lint-cli-resolve-"));
+
+	onTestFinished(() => {
+		fs.rmSync(directory, { force: true, recursive: true });
+	});
+
+	return fs.realpathSync(directory);
+}
+
+function installPackage(root: string, name: string, packageJson: object): string {
+	const directory = path.join(root, "node_modules", name);
+	fs.mkdirSync(path.join(directory, "bin"), { recursive: true });
+	fs.writeFileSync(path.join(directory, "package.json"), JSON.stringify(packageJson));
+	fs.writeFileSync(path.join(directory, "bin", `${name}.js`), "");
+	return directory;
+}
+
+function installEslint(root: string, version: string): string {
+	return installPackage(root, "eslint", {
+		name: "eslint",
+		bin: { eslint: "./bin/eslint.js" },
+		version,
+	});
+}
+
+function nestedDirectory(root: string): string {
+	const nested = path.join(root, "nested");
+	fs.mkdirSync(nested);
+	return nested;
+}
+
+describe("resolveLocalBin", () => {
+	it("prefers the nearest node_modules over an ancestor's", () => {
+		expect.assertions(1);
+
+		const root = temporaryDirectory();
+		const nested = nestedDirectory(root);
+		installEslint(root, "10.8.1");
+		const near = installEslint(nested, "10.10.0");
+
+		expect(resolveLocalBin("eslint", nested)).toBe(path.join(near, "bin", "eslint.js"));
+	});
+
+	it("falls back to an ancestor's node_modules", () => {
+		expect.assertions(1);
+
+		const root = temporaryDirectory();
+		const nested = nestedDirectory(root);
+		const far = installEslint(root, "10.8.1");
+
+		expect(resolveLocalBin("eslint", nested)).toBe(path.join(far, "bin", "eslint.js"));
+	});
+
+	it("resolves a string bin against the package root", () => {
+		expect.assertions(1);
+
+		const root = temporaryDirectory();
+		const installed = installPackage(root, "oxlint", {
+			name: "oxlint",
+			bin: "bin/oxlint.js",
+			version: "1.0.0",
+		});
+
+		expect(resolveLocalBin("oxlint", root)).toBe(path.join(installed, "bin", "oxlint.js"));
+	});
+
+	it("reports a package it cannot find", () => {
+		expect.assertions(1);
+
+		const root = temporaryDirectory();
+
+		expect(() => resolveLocalBin("eslint", root)).toThrow(CliError);
+	});
+
+	it("reports a package that declares no matching bin entry", () => {
+		expect.assertions(1);
+
+		const root = temporaryDirectory();
+		installPackage(root, "eslint", { name: "eslint", version: "10.10.0" });
+
+		expect(() => resolveLocalBin("eslint", root)).toThrow(/does not declare/u);
+	});
+});

--- a/test/lint-cli-resolve.spec.ts
+++ b/test/lint-cli-resolve.spec.ts
@@ -81,4 +81,14 @@ describe("resolveLocalBin", () => {
 
 		expect(() => resolveLocalBin("eslint", root)).toThrow(/does not declare/u);
 	});
+
+	it("reports a manifest it cannot parse rather than throwing a parse error", () => {
+		expect.assertions(1);
+
+		const root = temporaryDirectory();
+		const installed = installPackage(root, "eslint", { name: "eslint" });
+		fs.writeFileSync(path.join(installed, "package.json"), "{ truncated");
+
+		expect(() => resolveLocalBin("eslint", root)).toThrow(CliError);
+	});
 });

--- a/test/lint-cli-resolve.spec.ts
+++ b/test/lint-cli-resolve.spec.ts
@@ -24,12 +24,8 @@ function installPackage(root: string, name: string, packageJson: object): string
 	return directory;
 }
 
-function installEslint(root: string, version: string): string {
-	return installPackage(root, "eslint", {
-		name: "eslint",
-		bin: { eslint: "./bin/eslint.js" },
-		version,
-	});
+function installEslint(root: string): string {
+	return installPackage(root, "eslint", { name: "eslint", bin: { eslint: "./bin/eslint.js" } });
 }
 
 function nestedDirectory(root: string): string {
@@ -44,8 +40,8 @@ describe("resolveLocalBin", () => {
 
 		const root = temporaryDirectory();
 		const nested = nestedDirectory(root);
-		installEslint(root, "10.8.1");
-		const near = installEslint(nested, "10.10.0");
+		installEslint(root);
+		const near = installEslint(nested);
 
 		expect(resolveLocalBin("eslint", nested)).toBe(path.join(near, "bin", "eslint.js"));
 	});
@@ -55,7 +51,7 @@ describe("resolveLocalBin", () => {
 
 		const root = temporaryDirectory();
 		const nested = nestedDirectory(root);
-		const far = installEslint(root, "10.8.1");
+		const far = installEslint(root);
 
 		expect(resolveLocalBin("eslint", nested)).toBe(path.join(far, "bin", "eslint.js"));
 	});
@@ -64,11 +60,7 @@ describe("resolveLocalBin", () => {
 		expect.assertions(1);
 
 		const root = temporaryDirectory();
-		const installed = installPackage(root, "oxlint", {
-			name: "oxlint",
-			bin: "bin/oxlint.js",
-			version: "1.0.0",
-		});
+		const installed = installPackage(root, "oxlint", { name: "oxlint", bin: "bin/oxlint.js" });
 
 		expect(resolveLocalBin("oxlint", root)).toBe(path.join(installed, "bin", "oxlint.js"));
 	});
@@ -85,7 +77,7 @@ describe("resolveLocalBin", () => {
 		expect.assertions(1);
 
 		const root = temporaryDirectory();
-		installPackage(root, "eslint", { name: "eslint", version: "10.10.0" });
+		installPackage(root, "eslint", { name: "eslint" });
 
 		expect(() => resolveLocalBin("eslint", root)).toThrow(/does not declare/u);
 	});


### PR DESCRIPTION
## Summary

`resolveLocalBin` located the local eslint/oxlint binary with `local-pkg`'s `getPackageInfoSync`, whose own upward filesystem walk can disagree with Node's module resolution. For a cwd nested inside another checkout — a git worktree under `.claude/worktrees/` — it returned the **ancestor's** eslint, so `pnpm lint` and hk silently spawned a different version of the linter than every other tool in the repo resolved. Resolution now goes through `createRequire(<cwd>/<anchor>).resolve("<name>/package.json")`, which is Node's own walk.

Everything the function guaranteed is intact: it still returns the package's JavaScript entry from the `bin` field (so callers spawn it with `process.execPath` and no shell, avoiding the Windows `.cmd`/`.ps1` quoting hazard), still memoises on `cwd\0name`, and still raises both `CliError`s. `local-pkg` stays a dependency — `isPackageExists` is used in four other modules.

The sentinel basename `createRequire` needs is now one exported `RESOLVE_ANCHOR` shared with `resolveEslintInstall`, which had grown its own copy, and the manifest read goes through `readFileIfPresent` so a manifest that vanishes or parses as garbage reports a missing bin entry instead of escaping as `ENOENT` or `SyntaxError`.

`test/lint-cli-resolve.spec.ts` builds the nesting case as a fixture — one `node_modules` at the cwd, another at its parent — and asserts the nearer one wins.

## Notes

Independent of #679: no shared files, no shared branch point. That branch is where the wrong-version bin does visible damage (its `--fix` reads its verdict from the ESLint cache, whose payload moved between 10.8.1 and 10.10.0, so a stale binary silently fixes nothing), but this fix stands alone and can merge in either order.

Follow-up worth its own issue: `isPackageExists` in `src/lint-cli/lib/run.ts`, `src/eslint/factory.ts`, `src/oxlint/factory.ts` and `src/utils.ts` bottoms out in the same `local-pkg` resolver, so the same class of disagreement survives there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)